### PR TITLE
Make Asciidoctor.js available to Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,11 +18,11 @@
   "license": "MIT",
   "ignore": [
     "**/.*",
-    "examples"
+    "examples",
     "templates",
     "Gemfile",
     "Rakefile",
-    "error-in-chrome-console.png"
+    "error-in-chrome-console.png",
     "error-in-javascript-debugger.png"
   ]
 }


### PR DESCRIPTION
I add a bower.json file.
It's important to use [Semver](http://semver.org/) Git tags (cf [Bower documentation](https://github.com/bower/bower#registering-packages)).

Tag **v1.5.0.preview.1** does not conform, it should be **v1.5.0-preview.1** : 

```
anthonny@N550JV ~/99-Projects/test $ bower info https://github.com/anthonny/asciidoctor.js.git
bower cached        https://github.com/anthonny/asciidoctor.js.git#0.1.2
bower validate      0.1.2 against https://github.com/anthonny/asciidoctor.js.git#*
{
  name: 'asciidoctor.js',
  homepage: 'https://github.com/anthonny/asciidoctor.js',
  version: '0.1.2'
}
Available versions:
  - 1.5.0-preview.1
  - 0.1.2
You can request info for a specific version with 'bower info 
https://github.com/anthonny/asciidoctor.js.git#<version>'
```

Tag v1.5.0.preview.1 is not listed by Bower, it would be great to create a new tag **v1.5.0-preview.1**.

To register in public Bower repository :

```
bower register asciidoctor.js git://github.com/asciidoctor/asciidoctor.js.git
```
