### PR TITLE
Adds code coverage

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -152,7 +152,14 @@ module.exports = function(grunt) {
     jasmine: {
       options: {
         specs: 'spec/bower/bower.spec.js',
-        vendor: ['spec/share/common-specs.js']
+        vendor: ['spec/share/common-specs.js'],
+        template: require('grunt-template-jasmine-istanbul'),
+        templateOptions: {
+          coverage: 'coverage.json',
+          report: {
+            type: 'lcovonly'
+          }
+        }
       },
       allStandard: {
         src: ['dist/asciidoctor-all.js', 'dist/asciidoctor-docbook.js']
@@ -177,7 +184,13 @@ module.exports = function(grunt) {
         }
       },
       all: ['spec/npm']
-    }
+    },
+
+    coveralls: {
+      all: {
+        src: 'lcov.info'
+      }
+    },
   });
 
   grunt.loadNpmTasks('grunt-contrib-clean');
@@ -188,6 +201,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-compress');
   grunt.loadNpmTasks('grunt-contrib-jasmine');
   grunt.loadNpmTasks('grunt-jasmine-node');
+  grunt.loadNpmTasks('grunt-coveralls');
 
   grunt.registerTask('default', ['dist']);
   grunt.registerTask('dist', ['clean', 'rake', 'npm', 'bower', 'uglify', 'copy', 'compress', 'test']);

--- a/package.json
+++ b/package.json
@@ -55,8 +55,10 @@
     "grunt-contrib-copy": "^0.5.0",
     "grunt-contrib-jasmine": "^0.6.4",
     "grunt-contrib-uglify": "^0.4.0",
+    "grunt-coveralls": "^1.0.0",
     "grunt-jasmine-node": "^0.2.1",
     "grunt-shell": "^0.7.0",
-    "grunt-string-replace": "^0.2.7"
+    "grunt-string-replace": "^0.2.7",
+    "grunt-template-jasmine-istanbul": "^0.3.0"
   }
 }


### PR DESCRIPTION
Nearly working, the `coveralls` task is throwing an error. After `grunt test`, type `grunt coveralls`:

``` sh
$ grunt coveralls
Running "coveralls:all" (coveralls) task
>> Failed to submit 'lcov.info' to coveralls: Bad response: 422 {"message":"Couldn't find a repository matching this job.","error":true}
>> Failed to submit coverage results to coveralls
Warning: Task "coveralls:all" failed. Use --force to continue.

Aborted due to warnings.
```

If someone knows how to setup coveralls in an Grunt.js environment... ?
