### PR TITLE
Print a more friendly error message when the extensions-lab directory is missing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -42,9 +42,14 @@ task :dist do
   env['asciidoctor/converter/docbook45'].write_to "build/asciidoctor-docbook45.js#{compress ? '.gz' : nil}"
   env['asciidoctor/converter/docbook5'].write_to "build/asciidoctor-docbook5.js#{compress ? '.gz' : nil}"
 
-  env.append_path 'extensions-lab/lib'
-  endorsed_extensions = ['chrome-inline-macro', 'man-inline-macro', 'emoji-inline-macro']
-  endorsed_extensions.each { |extension| env[extension].write_to "build/asciidoctor-#{extension}.js#{compress ? '.gz' : nil}" }
+  if File.directory? 'extensions-lab/lib'
+    env.append_path 'extensions-lab/lib'
+    endorsed_extensions = ['chrome-inline-macro', 'man-inline-macro', 'emoji-inline-macro']
+    endorsed_extensions.each { |extension| env[extension].write_to "build/asciidoctor-#{extension}.js#{compress ? '.gz' : nil}" }
+  else
+    puts "Unable to cross-compile extensions because git submodule 'extensions-lab' is not initialized."
+    puts "To initialize the submodule use the following command `git submodule init` and `git submodule update`."
+  end
 
   asciidoctor_spec = Gem::Specification.find_by_name 'asciidoctor'
   css_file = File.join asciidoctor_spec.full_gem_path, 'data/stylesheets/asciidoctor-default.css'


### PR DESCRIPTION
If `extensions-lab` directory is missing (probably because the git submodule is not initialized) you get the following error:
```
rake aborted!
NoMethodError: undefined method `write_to' for nil:NilClass
/workspace/asciidoctor.js/Rakefile:47:in `block (2 levels) in <top (required)>'
/workspace/asciidoctor.js/Rakefile:47:in `each'
/workspace/asciidoctor.js/Rakefile:47:in `block in <top (required)>'
Tasks: TOP => default => dist
(See full trace by running task with --trace)
```

The error message is unclear and the current documentation doesn't tell you to initialize git submodule so there's a high chance that user will see this error message. See https://github.com/asciidoctor/asciidoctor.js/issues/86

I now check that the directory exists and if not prints the following message:
```
Unable to cross-compile extensions because git submodule 'extensions-lab' is not initialized.
To initialize the submodule use the following command `git submodule init` and `git submodule update`.
``` 