### PR TITLE
Resolves #137, remove backreference substitution hack for Opal

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -44,6 +44,9 @@ task :dist do
   
   # NOTE hack to make version compliant with semver
   asciidoctor_src = asciidoctor_src.sub(/'VERSION', "(\d+\.\d+.\d+)\.(.*)"/, '\'VERSION\', "\1-\2"')
+  # NOTE hack to remove backreference substitution for Opal
+  # Keep this hack until Asciidoctor 1.5.4 is released (fix in core https://github.com/asciidoctor/asciidoctor/commit/df49f227bab51f2b1197862e7ac95f2a0b844f2b)
+  asciidoctor_src = asciidoctor_src.sub(/capture_1\ =\ \(function\(\).*/, 'capture_1 = (function() {if (false) {')
   asciidoctor.instance_variable_set :@source, asciidoctor_src
   
   # NOTE hack to manually resolve the constant in the scope (workaround an issue in Opal)

--- a/spec/share/common-specs.js
+++ b/spec/share/common-specs.js
@@ -18,14 +18,17 @@ var commonSpec = function(Opal, Asciidoctor) {
       expect(doc.attributes.smap['icons']).toBe('font');
     });
 
-    // Regression with Opal 0.8.0
-    /*
     it('should load document with inline attributes !', function() {
       var options = Opal.hash({'attributes': 'icons=font@ data-uri!'});
       var doc = Asciidoctor.$load('== Test', options);
       expect(doc.attributes.smap['icons']).toBe('font');
     });
-    */
+
+    it('should load document attributes', function() {
+      var options = Opal.hash({'attributes': 'icons=font@ data-uri!'});
+      var doc = Asciidoctor.$load('= Document Title\n:attribute-key: attribute-value\n\ncontent', options);
+      expect(doc.$attr('attribute-key')).toBe('attribute-value');
+    });
 
     it('should load document with array attributes !', function() {
       var options = Opal.hash({'attributes': ['icons=font@', 'data-uri!']});


### PR DESCRIPTION
This should resolved #137 and #96