### PR TITLE
Set max line length for uglify to 500

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -114,6 +114,9 @@ module.exports = function(grunt) {
     */
     uglify: {
       dist: {
+        options: {
+              maxLineLen: 500
+        },
         files: {
           'dist/npm/asciidoctor-core.min.js': ['build/npm/asciidoctor-core-min.js'],
           'dist/npm/asciidoctor-extensions.min.js': ['build/npm/asciidoctor-extensions.js'],


### PR DESCRIPTION
* Fixes usage in Safari, see https://github.com/asciidoctor/docgist/issues/27
* Makes debugging easier.
* The increase in file size is tiny.