### PR TITLE
fix(commonJs): change the test to check the JS platform

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,35 @@
+'use strict';
+
+module.exports = function(karma) {
+  karma.set({
+    frameworks: [ 'jasmine', 'browserify' ],
+
+    files: [
+      {pattern: 'spec/share/include.adoc', watched: false, included: false, served: true},
+      {pattern: 'spec/share/sample.csv', watched: false, included: false, served: true},
+      {pattern: 'build/asciidoctor.css', watched: false, included: false, served: true},
+      'spec/commonJs/asciidoctor-all.spec.js'
+    ],
+
+    reporters: [ 'dots' ],
+
+    preprocessors: {
+      'spec/commonJs/asciidoctor-all.spec.js': [ 'browserify' ]
+    },
+
+    browsers: [ 'PhantomJS' ],
+
+    logLevel: 'LOG_DEBUG',
+
+    singleRun: true,
+    autoWatch: false,
+    // force the port to use
+    port: 9876,
+
+    // browserify configuration
+    browserify: {
+      debug: true,
+      transform: [ ]
+    }
+  });
+};

--- a/lib/asciidoctor/opal_ext.rb
+++ b/lib/asciidoctor/opal_ext.rb
@@ -1,23 +1,36 @@
 %x(
-  var value;
-  if (typeof module !== 'undefined' && module.exports) {
+  var isNode = typeof module !== 'undefined' && module.exports,
+      isBrowser = typeof window !== 'undefined',
+      isNashorn = typeof Java !== 'undefined' && Java.type,
+      isRhino = typeof java !== 'undefined',
+      value;
+
+
+  // With browserify we can use module and XMLHttpRequest, so for node
+  // we must test that we have not XMLHttpRequest
+  if (isNode && !isBrowser) {
     value = 'node';
   }
-  else if (typeof XMLHttpRequest !== 'undefined') {
+  else if (isBrowser) {
   // or we can check for document
   //else if (typeof document !== 'undefined' && document.nodeType) {
     value = 'browser';
   }
-  else if (typeof Java !== 'undefined' && Java.type) {
+  else if (isNashorn) {
     value = 'java-nashorn';
   }
-  else if (typeof java !== 'undefined') {
+  else if (isRhino) {
     value = 'java-rhino';
   }
   else {
     // standalone is likely SpiderMonkey
     value = 'standalone';
   }
+  // Extra lines to debug tests
+  // console.log('====== opal_ext.rb - Comment this block of logs, it\'s just for debug');
+  // console.log('====== JAVASCRIPT_PLATFORM ========== ', value);
+  // console.log('====== Value of isBrowser ', !!isBrowser);
+  // console.log('====== Value of isNode ', !!isNode);
 )
 JAVASCRIPT_PLATFORM = %x(value)
 require 'strscan'

--- a/lib/asciidoctor/opal_ext/file.rb
+++ b/lib/asciidoctor/opal_ext/file.rb
@@ -46,7 +46,7 @@ class File
       lines = File.read(@path)
       %x(
         self.eof = false;
-        self.lineno = 0; 
+        self.lineno = 0;
         var chomped  = #{lines.chomp},
             trailing = lines.length != chomped.length,
             splitted = chomped.split(separator);
@@ -94,7 +94,7 @@ class File
   def self.file?(path)
     true
   end
-  
+
   def self.readable?(path)
     true
   end

--- a/npm/test/jasmine-bower-min.js
+++ b/npm/test/jasmine-bower-min.js
@@ -12,7 +12,7 @@ concat([
   'build/asciidoctor-all.min.js',
   'build/asciidoctor-docbook.min.js',
   'spec/share/common-specs.js',
-  'spec/bower/bower.spec.js',
+  'spec/bower/bower.spec.js'
 ], 'build/bower.spec.all.min.js');
 
 var jasmine = new Jasmine();
@@ -22,4 +22,16 @@ jasmine.loadConfig({
     'bower.spec.all.min.js',
   ]
 });
+
+// This code is necessary to fake a browser for Opal
+//--------------------------------------------------
+window = {};
+
+if (typeof XMLHttpRequest === 'undefined') {
+  XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;
+  // Define overrideMimeType, not define by default in wrapper
+  XMLHttpRequest.prototype.overrideMimeType = function() {};
+}
+//--------------------------------------------------
+
 jasmine.execute();

--- a/npm/test/jasmine-bower.js
+++ b/npm/test/jasmine-bower.js
@@ -8,14 +8,26 @@ concat([
   'build/asciidoctor-all.js',
   'build/asciidoctor-docbook.js',
   'spec/share/common-specs.js',
-  'spec/bower/bower.spec.js',
+  'spec/bower/bower.spec.js'
 ], 'build/bower.spec.all.js');
 
 var jasmine = new Jasmine();
 jasmine.loadConfig({
   spec_dir: 'build',
   spec_files: [
-    'bower.spec.all.js',
+    'bower.spec.all.js'
   ]
 });
+
+// This code is necessary to fake a browser for Opal
+//--------------------------------------------------
+window = {};
+
+if (typeof XMLHttpRequest === 'undefined') {
+  XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;
+  // Define overrideMimeType, not define by default in wrapper
+  XMLHttpRequest.prototype.overrideMimeType = function() {};
+}
+//--------------------------------------------------
+
 jasmine.execute();

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "README.adoc"
   ],
   "scripts": {
-    "test": "node npm/test/jasmine-bower.js && node npm/test/jasmine-bower-min.js && node npm/test/jasmine-npm.js",
+    "test": "node npm/test/jasmine-bower.js && node npm/test/jasmine-bower-min.js && node npm/test/jasmine-npm.js && karma start",
     "build": "node npm/build.js && npm run test",
     "package": "MINIFY=1 node npm/build.js && MINIFY=1 npm run test",
     "examples": "node npm/examples.js",
@@ -48,10 +48,17 @@
     "xmlhttprequest": "~1.7.0"
   },
   "devDependencies": {
-    "bower": "^1.5.3",
-    "jasmine": "^2.4.1",
-    "colors": "1.1.2",
     "async": "^1.5.0",
-    "tar-fs": "1.11.1"
+    "bower": "^1.5.3",
+    "browserify": "^13.0.0",
+    "colors": "1.1.2",
+    "jasmine": "^2.4.1",
+    "karma": "^0.13.22",
+    "karma-browserify": "^5.0.3",
+    "karma-jasmine": "^0.3.8",
+    "karma-phantomjs-launcher": "^1.0.0",
+    "phantomjs-prebuilt": "^2.1.7",
+    "tar-fs": "1.11.1",
+    "watchify": "^3.7.0"
   }
 }

--- a/spec/bower/bower.spec.js
+++ b/spec/bower/bower.spec.js
@@ -1,1 +1,7 @@
-commonSpec(Opal, Opal.Asciidoctor);
+var path = require('path');
+var testOptions = {
+  platform: 'Bower',
+  baseDir: 'file://' + path.join(__dirname, '..')
+};
+
+commonSpec(testOptions, Opal, Opal.Asciidoctor);

--- a/spec/commonJs/asciidoctor-all.spec.js
+++ b/spec/commonJs/asciidoctor-all.spec.js
@@ -1,0 +1,33 @@
+var path = require('path');
+var commonSpec = require('../share/common-specs.js');
+var asciidoctor = require('../../build/npm/asciidoctor-core.js')(false, XMLHttpRequest)  ;
+console.log(__dirname);
+var testOptions = {
+  platform: 'CommonJs',
+  baseDir: 'http://localhost:9876/base'
+};
+commonSpec(testOptions, asciidoctor.Opal, asciidoctor.Asciidoctor(true));
+
+
+var Opal = asciidoctor.Opal;
+var Asciidoctor = asciidoctor.Asciidoctor(true);
+
+describe('Include', function() {
+  it('Should include file', function() {
+    var opts = Opal.hash({'safe': 'safe'});
+    var html = Asciidoctor.$convert('include::https://raw.githubusercontent.com/HubPress/dev.hubpress.io/gh-pages/README.adoc[]', opts);
+
+    expect(html).toContain('Gratipay');
+  });
+
+  it('Should include file', function() {
+    var opts = Opal.hash({'safe': 'safe'});
+    var html = Asciidoctor.$convert('= Title\n\
+\n\
+include::https://raw.githubusercontent.com/HubPress/dev.hubpress.io/gh-pages/README.adoc[]', opts);
+
+    // FIXME This test fail because this error occures
+    // asciidoctor: ERROR: https://raw.githubusercontent.com/HubPress/dev.hubpress.io/gh-pages/README.adoc: line 5: only book doctypes can contain level 0 sections
+    expect(html).toContain('Gratipay');
+  });
+});

--- a/spec/npm/asciidoctor-all.spec.js
+++ b/spec/npm/asciidoctor-all.spec.js
@@ -1,3 +1,8 @@
+var path = require('path');
 var commonSpec = require('../share/common-specs.js');
 var asciidoctor = require('../../build/npm/asciidoctor-core.js')()  ;
-commonSpec(asciidoctor.Opal, asciidoctor.Asciidoctor(true));
+var testOptions = {
+  platform: 'Node',
+  baseDir: path.join(__dirname, '..', '..')
+};
+commonSpec(testOptions, asciidoctor.Opal, asciidoctor.Asciidoctor(true));

--- a/spec/share/common-specs.js
+++ b/spec/share/common-specs.js
@@ -1,107 +1,109 @@
-var commonSpec = function(Opal, Asciidoctor) {
+var commonSpec = function(testOptions, Opal, Asciidoctor) {
 
-  describe('When loaded', function() {
-    it('Opal should not be null', function() {
-      expect(Opal).not.toBe(null);
+  describe(testOptions.platform, function () {
+
+    describe('When loaded', function() {
+      it('Opal should not be null', function() {
+        expect(Opal).not.toBe(null);
+      });
+
+      it('Asciidoctor should not be null', function() {
+        expect(Asciidoctor).not.toBe(null);
+      });
     });
 
-    it('Asciidoctor should not be null', function() {
-      expect(Asciidoctor).not.toBe(null);
-    });
-  });
 
+    describe('Loading', function() {
+      it('should load document with inline attributes @', function() {
+        var options = Opal.hash({'attributes': 'icons=font@'});
+        var doc = Asciidoctor.$load('== Test', options);
+        expect(doc.$attr('icons')).toBe('font');
+        expect(doc.attributes['$[]']('icons')).toBe('font');
+        expect(doc.attributes.$fetch('icons')).toBe('font');
+      });
 
-  describe('Loading', function() {
-    it('should load document with inline attributes @', function() {
-      var options = Opal.hash({'attributes': 'icons=font@'});
-      var doc = Asciidoctor.$load('== Test', options);
-      expect(doc.$attr('icons')).toBe('font');
-      expect(doc.attributes['$[]']('icons')).toBe('font');
-      expect(doc.attributes.$fetch('icons')).toBe('font');
-    });
+      it('should load document with inline attributes !', function() {
+        var options = Opal.hash({'attributes': 'icons=font@ data-uri!'});
+        var doc = Asciidoctor.$load('== Test', options);
+        expect(doc.$attr('icons')).toBe('font');
+      });
 
-    it('should load document with inline attributes !', function() {
-      var options = Opal.hash({'attributes': 'icons=font@ data-uri!'});
-      var doc = Asciidoctor.$load('== Test', options);
-      expect(doc.$attr('icons')).toBe('font');
-    });
+      it('should load document attributes', function() {
+        var options = Opal.hash({'attributes': 'icons=font@ data-uri!'});
+        var doc = Asciidoctor.$load('= Document Title\n:attribute-key: attribute-value\n\ncontent', options);
+        expect(doc.$attr('attribute-key')).toBe('attribute-value');
+      });
 
-    it('should load document attributes', function() {
-      var options = Opal.hash({'attributes': 'icons=font@ data-uri!'});
-      var doc = Asciidoctor.$load('= Document Title\n:attribute-key: attribute-value\n\ncontent', options);
-      expect(doc.$attr('attribute-key')).toBe('attribute-value');
-    });
+      it('should load document with array attributes !', function() {
+        var options = Opal.hash({'attributes': ['icons=font@', 'data-uri!']});
+        var doc = Asciidoctor.$load('== Test', options);
+        expect(doc.$attr('icons')).toBe('font');
+        expect(doc.$attr('data-uri')).toBe(Opal.nil);
+      });
 
-    it('should load document with array attributes !', function() {
-      var options = Opal.hash({'attributes': ['icons=font@', 'data-uri!']});
-      var doc = Asciidoctor.$load('== Test', options);
-      expect(doc.$attr('icons')).toBe('font');
-      expect(doc.$attr('data-uri')).toBe(Opal.nil);
-    });
+      it('should load document with boolean attributes', function() {
+        var options = Opal.hash({'attributes': ['sectnums=true']});
+        var doc = Asciidoctor.$load('== Test', options);
+        expect(doc.$attr('sectnums')).toBe('true');
+      });
 
-    it('should load document with boolean attributes', function() {
-      var options = Opal.hash({'attributes': ['sectnums=true']});
-      var doc = Asciidoctor.$load('== Test', options);
-      expect(doc.$attr('sectnums')).toBe('true');
-    });
+      it('should load document authors', function() {
+        var doc = Asciidoctor.$load('= Authors\nGuillaume Grossetie;Anders Nawroth\n');
+        expect(doc.$attr('author')).toBe('Guillaume Grossetie');
+        expect(doc.$attr('author_1')).toBe('Guillaume Grossetie');
+        expect(doc.$attr('author_2')).toBe('Anders Nawroth');
+        expect(doc.$attr('authorcount')).toBe(2);
+        expect(doc.$attr('authorinitials')).toBe('GG');
+        expect(doc.$attr('authorinitials_1')).toBe('GG');
+        expect(doc.$attr('authorinitials_2')).toBe('AN');
+        expect(doc.$attr('authors')).toBe('Guillaume Grossetie, Anders Nawroth');
+      });
 
-    it('should load document authors', function() {
-      var doc = Asciidoctor.$load('= Authors\nGuillaume Grossetie;Anders Nawroth\n');
-      expect(doc.$attr('author')).toBe('Guillaume Grossetie');
-      expect(doc.$attr('author_1')).toBe('Guillaume Grossetie');
-      expect(doc.$attr('author_2')).toBe('Anders Nawroth');
-      expect(doc.$attr('authorcount')).toBe(2);
-      expect(doc.$attr('authorinitials')).toBe('GG');
-      expect(doc.$attr('authorinitials_1')).toBe('GG');
-      expect(doc.$attr('authorinitials_2')).toBe('AN');
-      expect(doc.$attr('authors')).toBe('Guillaume Grossetie, Anders Nawroth');
-    });
-
-    it('should modify document attributes', function() {
-      var content = '== Title';
-      var doc = Opal.Asciidoctor.$load(content);
-      doc.$set_attribute('data-uri', 'true');
-      expect(doc.$attr('data-uri')).toBe('true');
-      doc.attributes.$delete('data-uri');
-      doc.attribute_overrides.$delete('data-uri');
-      expect(doc.$attr('data-uri')).toBe(Opal.nil);
-      doc.$set_attribute('data-uri', 'false');
-      expect(doc.$attr('data-uri')).toBe('false');
-    });
-  });
-
-  describe('Modifying', function() {
-    it('should allow document-level attributes to be modified', function() {
-      var doc = Asciidoctor.$load('= Document Title\n:lang: fr\n\ncontent is in {lang}');
-      expect(doc.$attr('lang')).toBe('fr');
-      doc.$set_attribute('lang', 'us');
-      expect(doc.$attr('lang')).toBe('us');
-      var html = doc.$convert();
-      expect(html).toContain('content is in us');
-    });
-  });
-
-  describe('Parsing', function() {
-    it('== Test should contains <h2 id="_test">Test</h2>', function() {
-      var html = Asciidoctor.$convert('== Test', null);
-      expect(html).toContain('<h2 id="_test">Test</h2>');
+      it('should modify document attributes', function() {
+        var content = '== Title';
+        var doc = Opal.Asciidoctor.$load(content);
+        doc.$set_attribute('data-uri', 'true');
+        expect(doc.$attr('data-uri')).toBe('true');
+        doc.attributes.$delete('data-uri');
+        doc.attribute_overrides.$delete('data-uri');
+        expect(doc.$attr('data-uri')).toBe(Opal.nil);
+        doc.$set_attribute('data-uri', 'false');
+        expect(doc.$attr('data-uri')).toBe('false');
+      });
     });
 
-    it('=== Test should contains <h3 id="_test">Test</h3>', function() {
-      var html = Asciidoctor.$convert('=== Test', null);
-      expect(html).toContain('<h3 id="_test">Test</h3>');
+    describe('Modifying', function() {
+      it('should allow document-level attributes to be modified', function() {
+        var doc = Asciidoctor.$load('= Document Title\n:lang: fr\n\ncontent is in {lang}');
+        expect(doc.$attr('lang')).toBe('fr');
+        doc.$set_attribute('lang', 'us');
+        expect(doc.$attr('lang')).toBe('us');
+        var html = doc.$convert();
+        expect(html).toContain('content is in us');
+      });
     });
 
-   it('=== Test should embed assets', function() {
-     var options = Opal.hash({doctype: 'article', safe: 'unsafe', header_footer: true, attributes: ['showtitle', 'stylesheet=asciidoctor.css', 'stylesdir=../../build']});
-     var html = Asciidoctor.$convert('=== Test', options);
-     expect(html).toContain('Asciidoctor default stylesheet');
-    });
+    describe('Parsing', function() {
+      it('== Test should contains <h2 id="_test">Test</h2>', function() {
+        var html = Asciidoctor.$convert('== Test', null);
+        expect(html).toContain('<h2 id="_test">Test</h2>');
+      });
 
-    it('backend=docbook45 should produce a docbook45 document', function() {
-      var options = Opal.hash({'attributes': ['backend=docbook45', 'doctype=book'],'header_footer':true});
-      var html = Asciidoctor.$convert(':doctitle: DocTitle\n:docdate: 2014-01-01\n== Test', options);
-      expect(html).toContain('<?xml version="1.0" encoding="UTF-8"?>\n\
+      it('=== Test should contains <h3 id="_test">Test</h3>', function() {
+        var html = Asciidoctor.$convert('=== Test', null);
+        expect(html).toContain('<h3 id="_test">Test</h3>');
+      });
+
+      it('=== Test should embed assets', function() {
+        var options = Opal.hash({doctype: 'article', safe: 'unsafe', header_footer: true, attributes: ['showtitle', 'stylesheet=asciidoctor.css', 'stylesdir='+testOptions.baseDir+'/build']});
+        var html = Asciidoctor.$convert('=== Test', options);
+        expect(html).toContain('Asciidoctor default stylesheet');
+      });
+
+      it('backend=docbook45 should produce a docbook45 document', function() {
+        var options = Opal.hash({'attributes': ['backend=docbook45', 'doctype=book'],'header_footer':true});
+        var html = Asciidoctor.$convert(':doctitle: DocTitle\n:docdate: 2014-01-01\n== Test', options);
+        expect(html).toContain('<?xml version="1.0" encoding="UTF-8"?>\n\
 <!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.5//EN" "http://www.oasis-open.org/docbook/xml/4.5/docbookx.dtd">\n\
 <?asciidoc-toc?>\n\
 <?asciidoc-numbered?>\n\
@@ -115,12 +117,12 @@ var commonSpec = function(Opal, Asciidoctor) {
 \n\
 </chapter>\n\
 </book>');
-    });
+            });
 
-    it('backend=docbook5 should produce a docbook5 document', function() {
-      var options = Opal.hash({'attributes': ['backend=docbook5', 'doctype=book'],'header_footer':true});
-      var html = Asciidoctor.$convert(':doctitle: DocTitle\n:docdate: 2014-01-01\n== Test', options);
-      expect(html).toContain('<?xml version="1.0" encoding="UTF-8"?>\n\
+      it('backend=docbook5 should produce a docbook5 document', function() {
+        var options = Opal.hash({'attributes': ['backend=docbook5', 'doctype=book'],'header_footer':true});
+        var html = Asciidoctor.$convert(':doctitle: DocTitle\n:docdate: 2014-01-01\n== Test', options);
+        expect(html).toContain('<?xml version="1.0" encoding="UTF-8"?>\n\
 <?asciidoc-toc?>\n\
 <?asciidoc-numbered?>\n\
 <book xmlns="http://docbook.org/ns/docbook" xmlns:xl="http://www.w3.org/1999/xlink" version="5.0" xml:lang="en">\n\
@@ -133,32 +135,31 @@ var commonSpec = function(Opal, Asciidoctor) {
 \n\
 </chapter>\n\
 </book>');
+        });
+
+      it('should produce a html5 document with font icons', function() {
+        var options = Opal.hash({'attributes': 'icons=font@'});
+        var html = Asciidoctor.$convert('= Document\n\nThis is a simple document.\n\n== Section\n\nCAUTION: This is important!', options);
+        expect(html).toContain('<i class="fa icon-caution" title="Caution"></i>');
+      });
+
     });
 
-    it('should produce a html5 document with font icons', function() {
-      var options = Opal.hash({'attributes': 'icons=font@'});
-      var html = Asciidoctor.$convert('= Document\n\nThis is a simple document.\n\n== Section\n\nCAUTION: This is important!', options);
-      expect(html).toContain('<i class="fa icon-caution" title="Caution"></i>');
-    });
+    describe('Include', function() {
+      it('Should include file', function() {
+        var opts = Opal.hash({base_dir: testOptions.baseDir, 'safe': 'safe'});
+        var html = Asciidoctor.$convert('include::spec/share/include.adoc[]', opts);
+        expect(html).toContain('include content');
+      });
 
+      it('Should include csv file in table', function() {
+        var opts = Opal.hash({base_dir: testOptions.baseDir, 'safe': 'safe'});
+        var html = Asciidoctor.$convert(',===\ninclude::spec/share/sample.csv[]\n,===', opts);
+        expect(html).toContain('March');
+      });
+    });
   });
-  
-  describe('Include', function() {
-    it('Should include file', function() {
-      var opts = Opal.hash({'safe': 'safe'});
-      var html = Asciidoctor.$convert('include::spec/share/include.adoc[]', opts);
-      expect(html).toContain('include content');
-    });
-
-    it('Should include csv file in table', function() {
-      var opts = Opal.hash({'safe': 'safe'});
-      var html = Asciidoctor.$convert(',===\ninclude::spec/share/sample.csv[]\n,===', opts);
-      expect(html).toContain('March');
-    });
-  });
-
 }
-
 
 // Export commonSpec for node test
 if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
To know if the script is use in a browser, it now check the typeof window instead of XMLHttpRequest
Tests for bower have some code to fake browser and XMLHttpRequest
I have added Karma with PhantomJS to run the CommonJS tests run in a real browser context
The CommonJS tests use browserify

The CommonJS tests contain a test that generate an error because of a typo in Opal, it must pass after an fix in the Opal dependencies.

The problem is here https://github.com/anthonny/opal-npm-wrapper/blob/master/index.js#L18320 and 18321:
`typeof(process) === 'object'`

The test should be:
`typeof(process) === 'object' && !process.browser`

Tested and approuved after some tests on HubPress