### PR TITLE
Resolves #152, Upgrade to Opal 0.9.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -35,7 +35,7 @@
     "dist/css/asciidoctor.css"
   ],
   "dependencies": {
-    "opal": "0.9.0.beta2"
+    "opal": "0.9.2"
   },
   "ignore": [
     "**/.*",

--- a/manual.adoc
+++ b/manual.adoc
@@ -8,13 +8,13 @@ You can set document attributes after loading AsciiDoc content.
 
 [source,javascript]
 ----
-var content= "== Title";
-var document= Opal.Asciidoctor.$load(content);
-console.log(document.$attr("data-uri")); // prints nil
-console.log(document.$attr("data-uri",false)); // prints false
+var content = '== Title';
+var doc = Opal.Asciidoctor.$load(content);
+console.log(doc.$attr('data-uri')); // prints nil
+console.log(doc.$attr('data-uri', 'false')); // prints 'false'
 
-document.$set_attribute("data-uri",true);
-console.log(document.$attr("data-uri")); // prints true
+doc.$set_attribute('data-uri', 'true');
+console.log(doc.$attr('data-uri')); // prints 'true'
 ----
 
 === How to unset/delete document attribute
@@ -23,12 +23,12 @@ You can unset document attributes after loading AsciiDoc content.
 
 [source,javascript]
 ----
-var content= "== Title";
-var document= Opal.Asciidoctor.$load(content);
-document.$set_attribute("data-uri",true);
-console.log(document.$attr("data-uri")); // prints true
+var content = '== Title';
+var doc = Opal.Asciidoctor.$load(content);
+doc.$set_attribute('data-uri', 'true');
+console.log(doc.$attr('data-uri')); // prints 'true'
 
-doc.attributes.$delete("data-uri");
-doc.attribute_overrides.$delete("data-uri");
-console.log(document.$attr("data-uri")); // prints nil
+doc.attributes.$delete('data-uri');
+doc.attribute_overrides.$delete('data-uri');
+console.log(doc.$attr('data-uri')); // prints nil
 ----

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "homepage": "https://github.com/asciidoctor/asciidoctor.js",
   "dependencies": {
-    "opal-npm-wrapper": "0.9.0-beta2",
+    "opal-npm-wrapper": "0.9.2",
     "xmlhttprequest": "~1.7.0"
   },
   "devDependencies": {

--- a/spec/share/common-specs.js
+++ b/spec/share/common-specs.js
@@ -56,6 +56,18 @@ var commonSpec = function(Opal, Asciidoctor) {
       expect(doc.$attr('authorinitials_2')).toBe('AN');
       expect(doc.$attr('authors')).toBe('Guillaume Grossetie, Anders Nawroth');
     });
+
+    it('should modify document attributes', function() {
+      var content = '== Title';
+      var doc = Opal.Asciidoctor.$load(content);
+      doc.$set_attribute('data-uri', 'true');
+      expect(doc.$attr('data-uri')).toBe('true');
+      doc.attributes.$delete('data-uri');
+      doc.attribute_overrides.$delete('data-uri');
+      expect(doc.$attr('data-uri')).toBe(Opal.nil);
+      doc.$set_attribute('data-uri', 'false');
+      expect(doc.$attr('data-uri')).toBe('false');
+    });
   });
 
   describe('Modifying', function() {

--- a/spec/share/common-specs.js
+++ b/spec/share/common-specs.js
@@ -15,7 +15,7 @@ var commonSpec = function(Opal, Asciidoctor) {
     it('should load document with inline attributes @', function() {
       var options = Opal.hash({'attributes': 'icons=font@'});
       var doc = Asciidoctor.$load('== Test', options);
-      expect(doc.attributes.smap['icons']).toBe('font');
+      expect(doc.$attr('icons')).toBe('font');
       expect(doc.attributes['$[]']('icons')).toBe('font');
       expect(doc.attributes.$fetch('icons')).toBe('font');
     });
@@ -23,7 +23,7 @@ var commonSpec = function(Opal, Asciidoctor) {
     it('should load document with inline attributes !', function() {
       var options = Opal.hash({'attributes': 'icons=font@ data-uri!'});
       var doc = Asciidoctor.$load('== Test', options);
-      expect(doc.attributes.smap['icons']).toBe('font');
+      expect(doc.$attr('icons')).toBe('font');
     });
 
     it('should load document attributes', function() {
@@ -35,26 +35,26 @@ var commonSpec = function(Opal, Asciidoctor) {
     it('should load document with array attributes !', function() {
       var options = Opal.hash({'attributes': ['icons=font@', 'data-uri!']});
       var doc = Asciidoctor.$load('== Test', options);
-      expect(doc.attributes.smap['icons']).toBe('font');
-      expect(doc.attributes.smap['data-uri']).toBeUndefined();
+      expect(doc.$attr('icons')).toBe('font');
+      expect(doc.$attr('data-uri')).toBe(Opal.nil);
     });
 
     it('should load document with boolean attributes', function() {
       var options = Opal.hash({'attributes': ['sectnums=true']});
       var doc = Asciidoctor.$load('== Test', options);
-      expect(doc.attributes.smap['sectnums']).toBe('true');
+      expect(doc.$attr('sectnums')).toBe('true');
     });
 
     it('should load document authors', function() {
       var doc = Asciidoctor.$load('= Authors\nGuillaume Grossetie;Anders Nawroth\n');
-      expect(doc.attributes.smap['author']).toBe('Guillaume Grossetie');
-      expect(doc.attributes.smap['author_1']).toBe('Guillaume Grossetie');
-      expect(doc.attributes.smap['author_2']).toBe('Anders Nawroth');
-      expect(doc.attributes.smap['authorcount']).toBe(2);
-      expect(doc.attributes.smap['authorinitials']).toBe('GG');
-      expect(doc.attributes.smap['authorinitials_1']).toBe('GG');
-      expect(doc.attributes.smap['authorinitials_2']).toBe('AN');
-      expect(doc.attributes.smap['authors']).toBe('Guillaume Grossetie, Anders Nawroth');
+      expect(doc.$attr('author')).toBe('Guillaume Grossetie');
+      expect(doc.$attr('author_1')).toBe('Guillaume Grossetie');
+      expect(doc.$attr('author_2')).toBe('Anders Nawroth');
+      expect(doc.$attr('authorcount')).toBe(2);
+      expect(doc.$attr('authorinitials')).toBe('GG');
+      expect(doc.$attr('authorinitials_1')).toBe('GG');
+      expect(doc.$attr('authorinitials_2')).toBe('AN');
+      expect(doc.$attr('authors')).toBe('Guillaume Grossetie, Anders Nawroth');
     });
   });
 


### PR DESCRIPTION
Version 0.9.2 is slightly faster than 0.9.0.beta2:

**Node.js**
Run 1 is 8,53% faster
Run 2 is 5,57% faster
Run 3 is 3,89% faster
Run 4 is 6,09% faster

Average time to render in Opal 0.9.2: 0,63805s (was 0,67835s in Opal 0.9.0.beta2)

**PhantomJS**

Run 1 is 9,91% faster
Run 2 is 9,07% faster
Run 3 is 8,99% faster
Run 4 is 8,75% faster

Average time to render in Opal 0.9.2: 0,75665s (was 0,8261s in Opal 0.9.0.beta2)

Resolves #152



