### PR TITLE
Upgrade build versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: node_js
 node_js:
-  - "0.12"
+  - "4.4.7"
 
 jdk:
   - oraclejdk8
 
 before_script:
-  - rvm install 1.9.3-p194
-  - rvm use 1.9.3-p194
+  - rvm install 2.3.1
+  - rvm use 2.3.1
   - npm install
   - bower install
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 
 gem 'opal', '0.9.0.beta2'
 #gem 'opal', :github => 'opal'
+gem 'rack', '1.6.4' # Opal compiler is *not* compatible with Rack 2.x
 gem 'asciidoctor', '1.5.4'
 #gem 'asciidoctor', :github => 'asciidoctor', :ref => 'master'
 #gem 'asciidoctor', :path => 'asciidoctor'

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.5.5-1",
   "description": "A JavaScript AsciiDoc processor, cross-compiled from the Ruby-based AsciiDoc implementation, Asciidoctor, using Opal",
   "main": "dist/npm/asciidoctor-core.min.js",
+  "engines" : { "node" : ">=0.12" },
   "files": [
     "dist/npm/asciidoctor-core.js",
     "dist/npm/asciidoctor-core.min.js",


### PR DESCRIPTION
Ruby 1.9.3 is no longer maintained and Node 4.4.7 is the current LTS.