### PR TITLE
Mutable String methods are not supported in Opal

### DIFF
--- a/npm/builder.js
+++ b/npm/builder.js
@@ -91,6 +91,7 @@ Builder.prototype.build = function(callback) {
     function(callback) { builder.clean(callback); }, // clean
     function(callback) { builder.downloadDependencies(callback); }, // download dependencies
     function(callback) { builder.compile(callback); }, // compile
+    function(callback) { builder.replaceUnsupportedFeatures(callback); }, // replace unsupported features
     function(callback) { builder.concatJavaScripts(callback); }, // concat
     function(callback) { builder.uglify(callback); } // uglify (optional)
   ], function() {
@@ -519,6 +520,16 @@ Builder.prototype.compile = function(callback) {
   var asciidoctorPath = 'build/asciidoctor';
   var asciidoctorCSSFile = asciidoctorPath + '/data/stylesheets/asciidoctor-default.css';
   fs.createReadStream(asciidoctorCSSFile).pipe(fs.createWriteStream('build/asciidoctor.css'));
+  callback();
+};
+
+Builder.prototype.replaceUnsupportedFeatures = function(callback) {
+  log.title('Replace unsupported features');
+  var path = 'build/asciidoctor-core.js';
+  var data = fs.readFileSync(path, 'utf8');
+  log.debug('Replace (g)sub! with (g)sub');
+  data = data.replace(/(\(\$\w+ = \(\$\w+ = (\w+)\))\['(\$g?sub)!'\]/g, "$2 = $1['$3']");
+  fs.writeFileSync(path, data, 'utf8');
   callback();
 };
 

--- a/npm/test/unsupported-features.js
+++ b/npm/test/unsupported-features.js
@@ -1,0 +1,11 @@
+var fs = require('fs');
+var Log = require('../log.js');
+var log = new Log();
+
+log.title('Check unsupported features');
+var data = fs.readFileSync('build/asciidoctor-core.js', 'utf8');
+var mutableStringPattern = /\['\$(g)?sub!'\]/;
+if (mutableStringPattern.test(data)) {
+  log.error("Mutable String methods are not supported in Opal, please replace sub! and gsub! methods");
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "README.adoc"
   ],
   "scripts": {
-    "test": "node npm/test/jasmine-bower.js && node npm/test/jasmine-bower-min.js && node npm/test/jasmine-npm.js && node npm/test/jasmine-bower-latex.js && karma start",
+    "test": "node npm/test/unsupported-features.js && node npm/test/jasmine-bower.js && node npm/test/jasmine-bower-min.js && node npm/test/jasmine-npm.js && node npm/test/jasmine-bower-latex.js && karma start",
     "build": "node npm/build.js && npm run test",
     "package": "cross-env MINIFY=1 node npm/build.js && cross-env MINIFY=1 npm run test",
     "examples": "node npm/examples.js",

--- a/spec/share/common-specs.js
+++ b/spec/share/common-specs.js
@@ -84,23 +84,28 @@ var commonSpec = function(testOptions, Opal, Asciidoctor) {
     });
 
     describe('Parsing', function() {
-      it('== Test should contains <h2 id="_test">Test</h2>', function() {
+      it('should convert a simple document with a title 2', function() {
         var html = Asciidoctor.$convert('== Test', null);
         expect(html).toContain('<h2 id="_test">Test</h2>');
       });
 
-      it('=== Test should contains <h3 id="_test">Test</h3>', function() {
+      it('should convert a simple document with a title 3', function() {
         var html = Asciidoctor.$convert('=== Test', null);
         expect(html).toContain('<h3 id="_test">Test</h3>');
       });
 
-      it('=== Test should embed assets', function() {
+      it('should convert a document with tabsize', function() {
+        var html = Asciidoctor.$convert('= Learn Go\n:tabsize: 2\n\n[source]\n----\npackage main\nimport "fmt"\n\nfunc main() {\n\tfmt.Println("Hello, playground")\n}', null);
+        expect(html).toContain('<div class="listingblock">\n<div class="content">\n<pre class="highlight"><code>package main\nimport "fmt"\n\nfunc main() {\n  fmt.Println("Hello, playground")\n}</code></pre>\n</div>\n</div>');
+      });
+
+      it('should embed assets', function() {
         var options = Opal.hash({doctype: 'article', safe: 'unsafe', header_footer: true, attributes: ['showtitle', 'stylesheet=asciidoctor.css', 'stylesdir='+testOptions.baseDir+'/build']});
         var html = Asciidoctor.$convert('=== Test', options);
         expect(html).toContain('Asciidoctor default stylesheet');
       });
 
-      it('backend=docbook45 should produce a docbook45 document', function() {
+      it('should produce a docbook45 document when backend=docbook45', function() {
         var options = Opal.hash({'attributes': ['backend=docbook45', 'doctype=book'],'header_footer':true});
         var html = Asciidoctor.$convert(':doctitle: DocTitle\n:docdate: 2014-01-01\n== Test', options);
         expect(html).toContain('<?xml version="1.0" encoding="UTF-8"?>\n\
@@ -119,7 +124,7 @@ var commonSpec = function(testOptions, Opal, Asciidoctor) {
 </book>');
             });
 
-      it('backend=docbook5 should produce a docbook5 document', function() {
+      it('should produce a docbook5 document when backend=docbook5', function() {
         var options = Opal.hash({'attributes': ['backend=docbook5', 'doctype=book'],'header_footer':true});
         var html = Asciidoctor.$convert(':doctitle: DocTitle\n:docdate: 2014-01-01\n== Test', options);
         expect(html).toContain('<?xml version="1.0" encoding="UTF-8"?>\n\
@@ -146,13 +151,13 @@ var commonSpec = function(testOptions, Opal, Asciidoctor) {
     });
 
     describe('Include', function() {
-      it('Should include file', function() {
+      it('should include file', function() {
         var opts = Opal.hash({base_dir: testOptions.baseDir, 'safe': 'safe'});
         var html = Asciidoctor.$convert('include::spec/share/include.adoc[]', opts);
         expect(html).toContain('include content');
       });
 
-      it('Should include csv file in table', function() {
+      it('should include csv file in table', function() {
         var opts = Opal.hash({base_dir: testOptions.baseDir, 'safe': 'safe'});
         var html = Asciidoctor.$convert(',===\ninclude::spec/share/sample.csv[]\n,===', opts);
         expect(html).toContain('March');


### PR DESCRIPTION
Replaces unsupported methods in asciidoctor-core.js during the build phase.
Adds tests to check that asciidoctor-core.js does *not* contains unsupported features in Opal.

Resolves #173