### PR TITLE
Asciidoctor.load_file method is now working in Node.js

### DIFF
--- a/lib/asciidoctor/opal_ext/file.rb
+++ b/lib/asciidoctor/opal_ext/file.rb
@@ -68,7 +68,7 @@ class File
     end
   end
 
-  def readlines()
+  def readlines
     File.readlines(@path)
   end
 

--- a/lib/asciidoctor/opal_ext/file.rb
+++ b/lib/asciidoctor/opal_ext/file.rb
@@ -68,6 +68,15 @@ class File
     end
   end
 
+  def readlines()
+    File.readlines(@path)
+  end
+
+  def self.readlines(path, separator = $/)
+    content = File.read(path)
+    content.split(separator)
+  end
+
   def self.expand_path(path)
     path
   end

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "homepage": "https://github.com/asciidoctor/asciidoctor.js",
   "dependencies": {
-    "opal-runtime": "0.10.1-integration1",
+    "opal-runtime": "0.10.1-integration2",
     "xmlhttprequest": "~1.7.0"
   },
   "devDependencies": {

--- a/spec/npm/asciidoctor-all.spec.js
+++ b/spec/npm/asciidoctor-all.spec.js
@@ -2,7 +2,24 @@ var path = require('path');
 var commonSpec = require('../share/common-specs.js');
 var asciidoctor = require('../../build/npm/asciidoctor-core.js')()  ;
 var testOptions = {
-  platform: 'Node',
+  platform: 'Node.js',
   baseDir: path.join(__dirname, '..', '..')
 };
-commonSpec(testOptions, asciidoctor.Opal, asciidoctor.Asciidoctor(true));
+var Asciidoctor = asciidoctor.Asciidoctor(true);
+var Opal = asciidoctor.Opal;
+
+Opal.load('nodejs');
+Opal.load('pathname');
+
+commonSpec(testOptions, Opal, Asciidoctor);
+
+describe('Node.js', function () {
+
+  describe('Loading file', function() {
+    it('should be able to load a file', function() {
+      var doc = Asciidoctor.$load_file(__dirname + '/test.adoc', null);
+      expect(doc.attributes.$fetch('docname')).toBe('test.adoc');
+    });
+  });
+});
+

--- a/spec/npm/test.adoc
+++ b/spec/npm/test.adoc
@@ -1,0 +1,5 @@
+= Document title
+
+== Title 1
+
+Hello world


### PR DESCRIPTION
`File.mtime` is available on Opal 0.10+ and `File.readlines` is implemented in `opal_ext`.

Note: Test is failing because I need to fix a small issue in Opal: https://github.com/opal/opal/issues/1550