### PR TITLE
README no longer has images

### DIFF
--- a/npm/builder.js
+++ b/npm/builder.js
@@ -463,11 +463,6 @@ Builder.prototype.copyExamplesResources = function(callback) {
   this.copyToExamplesBuildDir('examples/asciidoctor.css');
   this.copyToExamplesBuildDir('README.adoc');
 
-  log.title('copy images to ' + this.examplesImagesBuildDir + '/');
-  this.mkdirSync(this.examplesBuildDir + '/images');
-  this.copyToExamplesImagesBuildDir('error-in-chrome-console.png');
-  this.copyToExamplesImagesBuildDir('error-in-javascript-debugger.png');
-
   log.title('download sample data from AsciiDoc repository');
   async.series([
     function(callback) {


### PR DESCRIPTION
So it's unnecessary to copy images for the examples.