### PR TITLE
Add an example for slide backends

### DIFF
--- a/examples/slide.html
+++ b/examples/slide.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <title>Asciidoctor in JavaScript powered by Opal</title>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+  <link rel="stylesheet" href="../asciidoctor.css">
+  <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/1.8.3/jquery.js"></script>
+  <style>
+    .left {
+      width: 50%;
+      float: left
+    }
+
+    .right {
+      width: 50%;
+      float: right
+    }
+
+    iframe, textarea {
+      width: 99%;
+      height: 500px;
+    }
+  </style>
+</head>
+<body>
+<div class="left">
+  <textarea id="editor" cols="30" rows="10">
+= Title
+:backend: revealjs
+// depending on your npm version, you might have to try the other 'revealjsdir' value.
+//:revealjsdir: ../../node_modules/asciidoctor-reveal.js/node_modules/reveal.js
+:revealjsdir: ../../node_modules/reveal.js
+
+== Slide 1
+
+Content 1
+
+== Slide 2
+
+Content 2
+
+  </textarea>
+</div>
+<div class="right">
+  <iframe id="output"></iframe>
+</div>
+<button id="convertBtn">Convert</button>
+<script src="../../node_modules/jade/jade.js"></script>
+<script src="../../bower_components/opal/opal/current/opal.js"></script>
+<script src="../asciidoctor-core.js"></script>
+<script src="../../node_modules/asciidoctor-template.js/dist/main.js"></script>
+<script>
+  var options = Opal.hash({
+    safe: 'safe',
+    header_footer: true,
+    template_dir: '../../node_modules/asciidoctor-reveal.js/templates'
+  });
+  function convertSlide() {
+    var content = $("#editor").val();
+    var doc = Opal.Asciidoctor.$load(content, options);
+    var rendered = doc.$convert();
+    var iframe = document.querySelector("iframe");
+    iframe.contentWindow.document.open();
+    iframe.contentWindow.document.write(rendered);
+    iframe.contentWindow.document.close();
+  }
+  $("#convertBtn").click(function () {
+    convertSlide();
+  });
+  convertSlide();
+</script>
+</body>
+</html>

--- a/lib/asciidoctor/opal_ext.rb
+++ b/lib/asciidoctor/opal_ext.rb
@@ -36,6 +36,9 @@ require 'asciidoctor/opal_ext/file'
 require 'asciidoctor/opal_ext/match_data'
 require 'asciidoctor/opal_ext/kernel'
 require 'asciidoctor/opal_ext/thread_safe'
+require 'asciidoctor/converter'
+require 'asciidoctor/converter/composite'
+require 'asciidoctor/converter/html5'
 
 case JAVASCRIPT_PLATFORM
   when 'java-nashorn'

--- a/npm/builder.js
+++ b/npm/builder.js
@@ -327,7 +327,13 @@ Builder.prototype.examples = function(callback) {
       builder.copyExamplesResources(callback); // Step 3: Copy examples resources
     }
   ], function() {
-    log.success('You can now open build/examples/asciidoctor_example.html and build/examples/userguide_test.html');
+    log.info('');
+    log.info('In order to visualize the result, a local HTTP server must be started within the root of this project otherwise you will have cross-origin issues.');
+    log.info('For this purpose, you can run the following command to start a HTTP server locally: npm run server');
+    log.success('You can now open:'
+      + '\n - build/examples/asciidoctor_example.html'
+      + '\n - build/examples/userguide_test.html'
+      + '\n - build/examples/slide.html');
     typeof callback === 'function' && callback();
   });
 };
@@ -370,6 +376,7 @@ Builder.prototype.copyExamplesResources = function(callback) {
   this.copyToExamplesBuildDir('examples/asciidoctor_example.html');
   this.copyToExamplesBuildDir('examples/userguide_test.html');
   this.copyToExamplesBuildDir('examples/asciidoctor.css');
+  this.copyToExamplesBuildDir('examples/slide.html');
   this.copyToExamplesBuildDir('README.adoc');
 
   log.task('download sample data from AsciiDoc repository');

--- a/npm/server.js
+++ b/npm/server.js
@@ -1,0 +1,25 @@
+var httpServer = require('http-server');
+var portfinder = require('portfinder');
+var log = require('bestikk-log');
+
+var args = process.argv.slice(2);
+var port = args[0];
+
+var server = httpServer.createServer({});
+
+var listen = function(port) {
+  server.listen(port, function(){
+    // Callback triggered when server is successfully listening. Hurray!
+    log.info('Server listening on: http://localhost:' + port);
+  });
+}
+
+if (!port) {
+  portfinder.basePort = 8080;
+  portfinder.getPort(function (err, port) {
+    if (err) { throw err; }
+    listen(port);
+  });
+} else {
+  listen(port);
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A JavaScript AsciiDoc processor, cross-compiled from the Ruby-based AsciiDoc implementation, Asciidoctor, using Opal",
   "main": "dist/npm/asciidoctor-core.min.js",
   "engines": {
-    "node": ">=0.12"
+    "node": ">=0.12",
+    "npm": ">=3.0.0"
   },
   "files": [
     "dist/npm/asciidoctor-core.js",
@@ -23,6 +24,7 @@
     "lint": "eslint src spec",
     "package": "cross-env MINIFY=1 node npm/build.js && cross-env MINIFY=1 npm run test",
     "examples": "node npm/examples.js",
+    "server": "node npm/server.js",
     "benchmark": "node npm/benchmark.js",
     "release": "cross-env MINIFY=1 node npm/release.js"
   },
@@ -52,6 +54,8 @@
     "xmlhttprequest": "~1.7.0"
   },
   "devDependencies": {
+    "asciidoctor-reveal.js": "1.5.5-2",
+    "asciidoctor-template.js": "1.5.5-3",
     "async": "^1.5.0",
     "bestikk-fs": "^0.1.0",
     "bestikk-jdk-ea": "^0.1.0",
@@ -61,6 +65,7 @@
     "browserify": "^13.0.0",
     "cross-env": "^1.0.8",
     "eslint": "^2.11.0",
+    "http-server": "^0.9.0",
     "jasmine": "^2.4.1",
     "jasmine-core": "^2.4.1",
     "karma": "^0.13.22",

--- a/spec/npm/asciidoctor-all.spec.js
+++ b/spec/npm/asciidoctor-all.spec.js
@@ -2,6 +2,7 @@ var path = require('path');
 var fs = require('fs');
 var commonSpec = require('../share/common-specs.js');
 var asciidoctor = require('../../build/npm/asciidoctor-core.js')();
+
 var testOptions = {
   platform: 'Node.js',
   baseDir: path.join(__dirname, '..', '..')
@@ -11,6 +12,8 @@ var Opal = asciidoctor.Opal;
 
 Opal.load('nodejs');
 Opal.load('pathname');
+
+require('asciidoctor-template.js');
 
 commonSpec(testOptions, Opal, Asciidoctor);
 
@@ -67,10 +70,10 @@ describe('Node.js', function () {
       expect(blocks[1].getBlocks()[1].getAttribute('attribution')).toBe('Abraham Lincoln');
 
       expect(blocks[1].getBlocks()[2].getRole()).toBe('feature-list');
-      
+
       expect(blocks[2].getTitle()).toBe('Second Section');
       expect(blocks[2].getBlocks().length).toBe(2);
-     
+
       expect(blocks[2].getBlocks()[0].getContext()).toBe('image');
       expect(blocks[2].getBlocks()[1].getContext()).toBe('image');
     });
@@ -144,6 +147,20 @@ describe('Node.js', function () {
       } finally {
         removeFile(expectFilePath);
       }
+    });
+
+    it('should be able to use a custom backend', function () {
+      var options = Opal.hash({'safe': 'safe', 'header_footer': true});
+      var content = '= Title\n' +
+                    ':backend: revealjs\n\n' +
+                    '== Slide 1\n\n' +
+                    'Content 1\n\n' +
+                    '== Slide 2\n\n' +
+                    'Content 2';
+      var result = Asciidoctor.$convert(content, options);
+      expect(result).toContain('<section id="_slide_1"');
+      expect(result).toContain('<section id="_slide_2"');
+      expect(result).toContain('<script src="reveal.js/js/reveal.js"></script>');
     });
   });
 });


### PR DESCRIPTION
Cancels and replaces #119 

```sh
 $ npm run examples
 $ http-server -a localhost # or python -m SimpleHTTPServer 8080
```

http://localhost:8080/build/examples/slide.html