### PR TITLE
Automatically load Opal's nodejs and pathname module

### DIFF
--- a/lib/asciidoctor/opal_ext.rb
+++ b/lib/asciidoctor/opal_ext.rb
@@ -16,6 +16,8 @@
     } else {
       value = 'node';
     }
+    Opal.load("nodejs");
+    Opal.load("pathname");
   }
   else if (isNashorn) {
     value = 'java-nashorn';


### PR DESCRIPTION
Avoid the necessity to manually load those modules when running on Node.js.
Currently when an user want to use the `convert_file` method, it's mandatory to load `nodejs` module:

The following code will throw an exception `mtime: undefined method 'mtime' for #<File:0x1b6>`:
```javascript
var asciidoctor = require('asciidoctor.js')();

var opal = asciidoctor.Opal;
var processor = asciidoctor.Asciidoctor();

//opal.load('nodejs');

var doc = processor.$convert_file('test.adoc');
console.log(doc.$doctitle());
```

