### PR TITLE
Build against master

### DIFF
--- a/lib/asciidoctor/opal_ext.rb
+++ b/lib/asciidoctor/opal_ext.rb
@@ -36,6 +36,7 @@ require 'asciidoctor/opal_ext/file'
 require 'asciidoctor/opal_ext/match_data'
 require 'asciidoctor/opal_ext/kernel'
 require 'asciidoctor/opal_ext/thread_safe'
+require 'asciidoctor/opal_ext/string'
 
 case JAVASCRIPT_PLATFORM
   when 'java-nashorn'

--- a/lib/asciidoctor/opal_ext/string.rb
+++ b/lib/asciidoctor/opal_ext/string.rb
@@ -1,0 +1,8 @@
+class String
+  # Safely truncate the string to the specified number of bytes.
+  def limit size
+    return self.to_s unless size < bytes.length
+    result = byteslice 0, size
+    result.to_s
+  end unless method_defined? :limit
+end

--- a/npm/builder.js
+++ b/npm/builder.js
@@ -27,7 +27,6 @@ function Builder() {
     'src/npm/prepend-core.js',
     'build/asciidoctor-core.js'
   ];
-  this.asciidoctorCoreVersion = '1.5.4';
   this.asciidoctorLatexVersion = '0.2';
   this.htmlEntitiesVersion = '4.3.3';
   this.benchmarkBuildDir = 'build' + path.sep + 'benchmark';
@@ -71,7 +70,7 @@ Builder.prototype.downloadDependencies = function(callback) {
 
   var builder = this;
   async.series([
-    function(callback) { builder.getContentFromURL('https://codeload.github.com/asciidoctor/asciidoctor/tar.gz/v' + builder.asciidoctorCoreVersion, 'build/asciidoctor.tar.gz', callback); },
+    function(callback) { builder.getContentFromURL('https://codeload.github.com/asciidoctor/asciidoctor/tar.gz/master', 'build/asciidoctor.tar.gz', callback); },
     function(callback) { builder.getContentFromURL('https://codeload.github.com/asciidoctor/asciidoctor-latex/tar.gz/' + builder.asciidoctorLatexVersion, 'build/asciidoctor-latex.tar.gz', callback); },
     function(callback) { builder.getContentFromURL('https://codeload.github.com/threedaymonk/htmlentities/tar.gz/v' + builder.htmlEntitiesVersion, 'build/htmlentities.tar.gz', callback); },
     function(callback) { bfs.untar('build/asciidoctor.tar.gz', 'asciidoctor', 'build', callback); },

--- a/spec/share/latex-specs.js
+++ b/spec/share/latex-specs.js
@@ -16,14 +16,16 @@ var commonSpec = function(testOptions, Opal, Asciidoctor) {
       it('should render asciidoctor-latex question/answer block', function() {
         var html = Asciidoctor.$convert('[env.question]\n--\nWhat is the speed of light?\n--\n\n[click.answer]\n--\n300,000 km/sec\n--', null);
         expect(html).toContain('<div class="openblock question">\n' +
-                               '<div class="title">Question 1.</div><div class="content">\n' + 
+                               '<div class="title">Question 1.</div>\n' +
+                               '<div class="content">\n' +
                                '<div class=\'click_oblique\'>\n' +
                                'What is the speed of light?\n' +
                                '</div>\n' +
                                '</div>\n' +
                                '</div>\n' +
                                '<div class="openblock click">\n' +
-                               '<div class="title">Answer</div><div class="content">\n' +
+                               '<div class="title">Answer</div>\n' +
+                               '<div class="content">\n' +
                                '<div class=\'click_oblique\'>\n' +
                                '300,000 km/sec\n' +
                                '</div>\n' +


### PR DESCRIPTION
@mojavelinux 

```
1) Bower Loading should load document attributes
  Message:
    bytes: undefined method `bytes' for #<Encoding:UTF-16LE>
  Stack:
    bytes: undefined method `bytes' for #<Encoding:UTF-16LE>
        at Opal.defs.TMP_1 [as $new] (/home/guillaume/workspace/opensource/asciidoctor.js/build/bower.spec.all.js:4853:15)
        at ːmethod_missing (/home/guillaume/workspace/opensource/asciidoctor.js/build/bower.spec.all.js:3410:54)
        at method_missing_stub [as $bytes] (/home/guillaume/workspace/opensource/asciidoctor.js/build/bower.spec.all.js:1006:35)
        at ːbytesize (/home/guillaume/workspace/opensource/asciidoctor.js/build/bower.spec.all.js:15983:19)
        at String.ːbytesize (/home/guillaume/workspace/opensource/asciidoctor.js/build/bower.spec.all.js:16020:28)
        at String.ːlimit (/home/guillaume/workspace/opensource/asciidoctor.js/build/bower.spec.all.js:20765:38)
        at $Document.ːset_attribute (/home/guillaume/workspace/opensource/asciidoctor.js/build/bower.spec.all.js:26435:72)
        at /home/guillaume/workspace/opensource/asciidoctor.js/build/bower.spec.all.js:28613:24
        at ːstore_attribute (/home/guillaume/workspace/opensource/asciidoctor.js/build/bower.spec.all.js:28616:28)
        at ːprocess_attribute_entry (/home/guillaume/workspace/opensource/asciidoctor.js/build/bower.spec.all.js:28578:16)
```
https://github.com/asciidoctor/asciidoctor/blob/93063e2500369612e923c04695fbf6e3054b31ba/lib/asciidoctor/core_ext/string/limit.rb#L5

I don't know why this error is thrown because Opal seems to implement these methods: 

 * https://github.com/opal/opal/blob/0cf1870a66c7ff338e33ede1a1941f70ff357828/opal/corelib/string/encoding.rb#L101-L116
 * https://github.com/opal/opal/blob/0cf1870a66c7ff338e33ede1a1941f70ff357828/opal/corelib/string/encoding.rb#L152-L154

Maybe since we are "patching" String class, Opal doesn't find `bytes` method anymore ?



