### PR TITLE
Return an empty string instead of Opal.nil

### DIFF
--- a/spec/share/common-spec.js
+++ b/spec/share/common-spec.js
@@ -206,6 +206,18 @@ var commonSpec = function (testOptions, Opal, Asciidoctor) {
         expect(html).toContain('<h2 id="_test">Test</h2>');
       });
 
+      it('should return an empty string when there\'s no candidate for inline conversion', function () {
+        // Converting a document with inline document type should produce an empty string
+        // Read more: http://asciidoctor.org/docs/user-manual/#document-types
+        var options = {doctype: 'inline'};
+        var content = '= Document Title\n\n== Introduction\n\nA simple paragraph.';
+        var html = Asciidoctor.convert(content, options);
+        expect(html).toBe('');
+        var doc = Asciidoctor.load(content, options);
+        html = doc.convert();
+        expect(html).toBe('');
+      });
+
       it('should convert a simple document with a title 3', function () {
         var html = Asciidoctor.convert('=== Test', null);
         expect(html).toContain('<h3 id="_test">Test</h3>');

--- a/src/asciidoctor-core-api.js
+++ b/src/asciidoctor-core-api.js
@@ -8,7 +8,11 @@ var toHash = function (object) {
 // Asciidoctor API
 
 Opal.Asciidoctor['$$class'].$$proto.convert = function (input, options) {
-  return this.$convert(input, toHash(options));
+  var result = this.$convert(input, toHash(options));
+  if (result === Opal.nil) {
+    return '';
+  }
+  return result;
 };
 
 Opal.Asciidoctor['$$class'].$$proto.convertFile = function (filename, options) {
@@ -207,7 +211,11 @@ Opal.Asciidoctor.Document.$$proto.removeAttribute = function (name) {
 };
 
 Opal.Asciidoctor.Document.$$proto.convert = function (options) {
-  return this.$convert(toHash(options));
+  var result = this.$convert(toHash(options));
+  if (result === Opal.nil) {
+    return '';
+  }
+  return result;
 };
 
 Opal.Asciidoctor.Document.$$proto.write = function (output, target) {


### PR DESCRIPTION
`console.log(Opal.nil)` produces the following output :

```
NilClass_alloc { '$$id': 4, apply: [Function], call: [Function] }
```

This output can be confusing and is not consistent with Asciidoctor (Ruby).
We now return an empty string.

Ref #201