### PR TITLE
Integrate with Opal master

### DIFF
--- a/npm/builder.js
+++ b/npm/builder.js
@@ -350,7 +350,7 @@ Builder.prototype.replaceUnsupportedFeatures = function (callback) {
   var path = 'build/asciidoctor-lib.js';
   var data = fs.readFileSync(path, 'utf8');
   log.debug('Replace (g)sub! with (g)sub');
-  data = data.replace(/(\(\$\w+ = \(\$\w+ = (\w+)\))\['(\$g?sub)!'\]/g, '$2 = $1[\'$3\']');
+  data = data.replace(/\$send\(([^,]+), '(g?sub)!'/g, '$1 = $send\($1, \'$2\'');
   fs.writeFileSync(path, data, 'utf8');
   callback();
 };
@@ -367,7 +367,7 @@ Builder.prototype.replaceDefaultStylesheetPath = function (callback) {
     '  stylesheetsPath = "css";\n' +
     '}\n' +
     'return ((($a = self.primary_stylesheet_data) !== false && $a !== nil && $a != null) ? $a : self.primary_stylesheet_data = Opal.get("IO").$read(Opal.get("File").$join(stylesheetsPath, "asciidoctor.css")).$chomp());';
-  data = data.replace(/(ːprimary_stylesheet_data\(\)\ {\n)(?:[^}]*)(\n\s+}.*)/g, '$1' + primaryStylesheetDataImpl + '$2');
+  data = data.replace(/(function \$\$primary_stylesheet_data\(\)\ {\n)(?:[^}]*)(\n\s+}.*)/g, '$1' + primaryStylesheetDataImpl + '$2');
   fs.writeFileSync(path, data, 'utf8');
   callback();
 };

--- a/npm/test/jasmine-browser-min.js
+++ b/npm/test/jasmine-browser-min.js
@@ -22,7 +22,6 @@ jasmine.loadConfig({
 
 // This code is necessary to fake a browser for Opal
 //--------------------------------------------------
-window = {};
 process.browser = true;
 
 if (typeof XMLHttpRequest === 'undefined') {

--- a/npm/test/jasmine-browser.js
+++ b/npm/test/jasmine-browser.js
@@ -18,7 +18,6 @@ jasmine.loadConfig({
 
 // This code is necessary to fake a browser for Opal
 //--------------------------------------------------
-window = {};
 process.browser = true;
 
 if (typeof XMLHttpRequest === 'undefined') {

--- a/npm/test/jasmine-webpack.js
+++ b/npm/test/jasmine-webpack.js
@@ -28,7 +28,7 @@ webpack(config, function () {
 
   // This code is necessary to fake a browser for Opal
   //--------------------------------------------------
-  window = {};
+  window = global;
 
   if (typeof XMLHttpRequest === 'undefined') {
     XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "asciidoctor.js",
-  "version": "1.5.5-4",
+  "version": "1.5.5-integration1",
   "description": "A JavaScript AsciiDoc processor, cross-compiled from the Ruby-based AsciiDoc implementation, Asciidoctor, using Opal",
   "main": "dist/asciidoctor.js",
   "engines": {
-    "node": ">=0.12",
+    "node": ">=4",
     "npm": ">=3.0.0"
   },
   "files": [
@@ -47,19 +47,19 @@
   },
   "homepage": "https://github.com/asciidoctor/asciidoctor.js",
   "dependencies": {
-    "opal-runtime": "0.10.2",
+    "opal-runtime": "0.11.0-integration6",
     "xmlhttprequest": "~1.7.0"
   },
   "devDependencies": {
-    "asciidoctor-docbook.js": "1.5.5-4",
+    "asciidoctor-docbook.js": "1.5.5-integration2",
     "asciidoctor-reveal.js": "1.0.1",
-    "asciidoctor-template.js": "1.5.5-4",
+    "asciidoctor-template.js": "1.5.5-integration1",
     "async": "^1.5.0",
     "bestikk-download": "^0.1.0",
     "bestikk-fs": "^0.1.0",
     "bestikk-jdk-ea": "0.1.1",
     "bestikk-log": "0.1.0",
-    "bestikk-opal-compiler": "0.2.0",
+    "bestikk-opal-compiler": "0.3.0-integration5",
     "bestikk-uglify": "0.1.1",
     "bower": "^1.5.3",
     "browserify": "^13.0.0",

--- a/spec/browser/asciidoctor.spec.js
+++ b/spec/browser/asciidoctor.spec.js
@@ -5,7 +5,7 @@ var testOptions = {
   baseDir: 'file://' + path.join(__dirname, '..')
 };
 
-var asciidoctor = require('./asciidoctor.js')();
+var asciidoctor = require('./asciidoctor.js')({runtime: {platform: 'browser'}});
 require('asciidoctor-docbook.js');
 
 commonSpec(testOptions, asciidoctor);

--- a/spec/requireJS/main.js
+++ b/spec/requireJS/main.js
@@ -21,7 +21,9 @@ require.config({
 
   config: {
     'asciidoctor': {
-      'ioModule': 'phantomjs'
+      'runtime': {
+        'ioModule': 'xmlhttprequest'
+      }
     }
   },
 

--- a/spec/webpack/spec.js
+++ b/spec/webpack/spec.js
@@ -1,5 +1,5 @@
 var commonSpec = require('../share/common-spec.js');
-var asciidoctor = require('../../build/asciidoctor.js')();
+var asciidoctor = require('../../build/asciidoctor.js')({runtime: {platform: 'browser'}});
 require('asciidoctor-docbook.js');
 
 commonSpec(testOptions, asciidoctor);

--- a/src/template-asciidoctor.js
+++ b/src/template-asciidoctor.js
@@ -4,6 +4,7 @@ if (typeof Opal === 'undefined' && typeof module === 'object' && module.exports)
 
 if (typeof Opal === 'undefined') {
 //#{opalCode}
+  Opal.require('opal');
 }
 
 // UMD Module


### PR DESCRIPTION
RequireJS is failing, otherwise all good!

I don't understand why but RequireJS does not resolve `asciidoctor` but does resolve `asciidoctor/docbook`. @anthonny @hsablonniere any idea ?

`asciidoctor` object is equal to: 

```javascript
function c(c, j, k) {
  var n = [];
  j = 1 == j ? {entropy: !0} : j || {};
  var s = g(f(j.entropy ? [c, i(a)] : null == c ? h() : c, 3), n), t = new d(n), u = function () {
    for (var a = t.g(m), b = p, c = 0; a < q;)a = (a + c) * l, b *= l, c = t.g(1);
    for (; a >= r;)a /= 2, b /= 2, c >>>= 1;
    return (a + c) / b
  };
  return u.int32 = function () {
    return 0 | t.g(4)
  }, u.quick = function () {
    return t.g(4) / 4294967296
  }, u.double = u, g(i(t.S), a), (j.pass || k || function (a, c, d, f) {
    return f && (f.S && e(f, t), a.state = function () {
      return e(t, {})
    }), d ? (b[o] = a, c) : a
  })(u, s, "global" in j ? j.global : this == b, j.state);
}
```

entropy is high!!! :rofl: 

https://github.com/asciidoctor/asciidoctor.js/blob/0866d3335699f728f0a9197f8f01c51ce92525cc/spec/requireJS/asciidoctor.spec.js#L8