### PR TITLE
drop duplicate require statement

### DIFF
--- a/lib/asciidoctor/js/postscript.rb
+++ b/lib/asciidoctor/js/postscript.rb
@@ -1,4 +1,3 @@
-require 'asciidoctor/converter'
 require 'asciidoctor/converter/composite'
 require 'asciidoctor/converter/html5'
 require 'asciidoctor/extensions'

--- a/lib/asciidoctor/opal_ext.rb
+++ b/lib/asciidoctor/opal_ext.rb
@@ -1,3 +1,4 @@
 # For backward compatibility with Asciidoctor <= 1.5.5
 require 'asciidoctor/js'
+require 'asciidoctor/converter'
 require 'asciidoctor/js/postscript'


### PR DESCRIPTION
Core already requires "asciidoctor/converter" (and always has), so there's no reason to require it in the Asciidoctor.js build.