### PR TITLE
Resolves #298, API: get revision remark, number and info

### DIFF
--- a/spec/node/asciidoctor.spec.js
+++ b/spec/node/asciidoctor.spec.js
@@ -68,6 +68,23 @@ describe('Node.js', function () {
       expect(doc.getDoctitle()).toBe('Document title');
     });
 
+    it('should return empty revision info', function () {
+      var doc = asciidoctor.load('= Begin Again\n\n== First section');
+      expect(doc.getRevisionDate()).toBe(undefined);
+      expect(doc.getRevisionNumber()).toBe(undefined);
+      expect(doc.getRevisionRemark()).toBe(undefined);
+
+      expect(doc.hasRevisionInfo()).toBe(false);
+      var revisionInfo = doc.getRevisionInfo();
+      expect(revisionInfo.isEmpty()).toBe(true);
+      expect(revisionInfo.getDate()).toBe(undefined);
+      expect(revisionInfo.getNumber()).toBe(undefined);
+      expect(revisionInfo.getRemark()).toBe(undefined);
+      expect(revisionInfo.date).toBe(undefined);
+      expect(revisionInfo.number).toBe(undefined);
+      expect(revisionInfo.remark).toBe(undefined);
+    });
+
     it('should be able to retrieve structural content from file', function () {
       var doc = asciidoctor.loadFile(__dirname + '/documentblocks.adoc');
       var header = doc.getHeader();
@@ -76,6 +93,21 @@ describe('Node.js', function () {
       expect(header.getAttribute('revdate')).toBe('2013-05-20');
       expect(header.getAttribute('revnumber')).toBe('1.0');
       expect(header.getAttribute('revremark')).toBe('First draft');
+
+      expect(doc.getRevisionDate()).toBe('2013-05-20');
+      expect(doc.getRevisionNumber()).toBe('1.0');
+      expect(doc.getRevisionRemark()).toBe('First draft');
+
+      expect(doc.hasRevisionInfo()).toBe(true);
+      var revisionInfo = doc.getRevisionInfo();
+      expect(revisionInfo.isEmpty()).toBe(false);
+      expect(revisionInfo.getDate()).toBe('2013-05-20');
+      expect(revisionInfo.getNumber()).toBe('1.0');
+      expect(revisionInfo.getRemark()).toBe('First draft');
+      expect(revisionInfo.date).toBe('2013-05-20');
+      expect(revisionInfo.number).toBe('1.0');
+      expect(revisionInfo.remark).toBe('First draft');
+
       expect(header.getAttribute('tags')).toBe('[document, example]');
       expect(header.getAttribute('author')).toBe('Doc Writer');
       expect(header.getAttribute('email')).toBe('doc.writer@asciidoc.org');

--- a/src/asciidoctor-core-api.js
+++ b/src/asciidoctor-core-api.js
@@ -599,10 +599,11 @@ Document.$$proto.getDoctitle = function (options) {
 };
 
 /**
+ * Get the document revision date from document header (document attribute <code>revdate</code>).
  * @memberof Document
  */
 Document.$$proto.getRevisionDate = function () {
-  return this.$revdate();
+  return this.getAttribute('revdate');
 };
 
 /**
@@ -611,6 +612,86 @@ Document.$$proto.getRevisionDate = function () {
  */
 Document.$$proto.getRevdate = function () {
   return this.getRevisionDate();
+};
+
+/**
+ * Get the document revision number from document header (document attribute <code>revnumber</code>).
+ * @memberof Document
+ */
+Document.$$proto.getRevisionNumber = function () {
+  return this.getAttribute('revnumber');
+};
+
+/**
+ * Get the document revision remark from document header (document attribute <code>revremark</code>).
+ * @memberof Document
+ */
+Document.$$proto.getRevisionRemark = function () {
+  return this.getAttribute('revremark');
+};
+
+// private constructor
+Document.RevisionInfo = function (date, number, remark) {
+  this.date = date;
+  this.number = number;
+  this.remark = remark;
+};
+
+/**
+ * @class
+ * @namespace
+ * @module Document/RevisionInfo
+ */
+var RevisionInfo = Document.RevisionInfo;
+
+/**
+ * Get the document revision date from document header (document attribute <code>revdate</code>).
+ * @memberof Document/RevisionInfo
+ */
+RevisionInfo.prototype.getDate = function () {
+  return this.date;
+};
+
+/**
+ * Get the document revision number from document header (document attribute <code>revnumber</code>).
+ * @memberof Document/RevisionInfo
+ */
+RevisionInfo.prototype.getNumber = function () {
+  return this.number;
+};
+
+/**
+ * Get the document revision remark from document header (document attribute <code>revremark</code>).
+ * A short summary of changes in this document revision.
+ * @memberof Document/RevisionInfo
+ */
+RevisionInfo.prototype.getRemark = function () {
+  return this.remark;
+};
+
+/**
+ * @memberof Document/RevisionInfo
+ * @returns {Boolean} - returns true if the revision info is empty (ie. not defined), otherwise false
+ */
+RevisionInfo.prototype.isEmpty = function () {
+  return this.date === undefined && this.number === undefined && this.remark === undefined;
+};
+
+/**
+ * @memberof Document
+ * @returns {Document/RevisionInfo} - returns a {@link Document/RevisionInfo}
+ */
+Document.$$proto.getRevisionInfo = function () {
+  return new Document.RevisionInfo(this.getRevisionDate(), this.getRevisionNumber(), this.getRevisionRemark());
+};
+
+/**
+ * @memberof Document
+ * @returns {Boolean} - returns true if the document contains revision info, otherwise false
+ */
+Document.$$proto.hasRevisionInfo = function () {
+  var revisionInfo = this.getRevisionInfo();
+  return !revisionInfo.isEmpty();
 };
 
 /**

--- a/src/asciidoctor-core-api.js
+++ b/src/asciidoctor-core-api.js
@@ -671,7 +671,7 @@ RevisionInfo.prototype.getRemark = function () {
 
 /**
  * @memberof Document/RevisionInfo
- * @returns {Boolean} - returns true if the revision info is empty (ie. not defined), otherwise false
+ * @returns {boolean} - returns true if the revision info is empty (ie. not defined), otherwise false
  */
 RevisionInfo.prototype.isEmpty = function () {
   return this.date === undefined && this.number === undefined && this.remark === undefined;
@@ -687,7 +687,7 @@ Document.$$proto.getRevisionInfo = function () {
 
 /**
  * @memberof Document
- * @returns {Boolean} - returns true if the document contains revision info, otherwise false
+ * @returns {boolean} - returns true if the document contains revision info, otherwise false
  */
 Document.$$proto.hasRevisionInfo = function () {
   var revisionInfo = this.getRevisionInfo();


### PR DESCRIPTION
* Adds `Document.getRevisionInfo` function
* Adds `Document.getRevisionRemark` function
* Adds `Document.getRevisionNumber` function

Resolves #298