### PR TITLE
drop name argument from method to register an include processor

### DIFF
--- a/src/asciidoctor-extensions-api.js
+++ b/src/asciidoctor-extensions-api.js
@@ -98,12 +98,8 @@ Registry.$$proto.inlineMacro = function (name, block) {
 /**
  * @memberof Extensions/Registry
  */
-Registry.$$proto.includeProcessor = function (name, block) {
-  if (typeof name === 'function' && typeof block === 'undefined') {
-    return Opal.send(this, 'include_processor', null, toBlock(name));
-  } else {
-    return Opal.send(this, 'include_processor', [name], toBlock(block));
-  }
+Registry.$$proto.includeProcessor = function (block) {
+  return Opal.send(this, 'include_processor', null, toBlock(block));
 };
 
 /**


### PR DESCRIPTION
Document processors don't take a name argument. They do take an options argument, but we haven't added support for that to any of the extension methods yet...and it's not really a documented feature.