### PR TITLE
Release on npm for each tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ sudo: false
 before_deploy:
 - npm run build
 - npm run dist
-- npm config set git-tag-version false
-- if [[ "$TRAVIS_BRANCH" == master ]]; then npm version "$(npm view . version)+git.$(git log -n1 --pretty=format:%h)"; fi
+- if [[ "$TRAVIS_BRANCH" == master ]]; then npm --no-git-tag-version version "$(npm view . version)+git.$(git log -n1 --pretty=format:%h)"; fi
 - if [[ "$TRAVIS_BRANCH" == master ]]; then npm config set tag dev; fi
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,4 @@ deploy:
     tags: true
     repo: asciidoctor/asciidoctor.js
     node: node
+    condition: "$ASCIIDOCTOR_CORE_VERSION -ne 'master'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,47 @@
 language: node_js
 env:
-  - ASCIIDOCTOR_CORE_VERSION=v1.5.5
-  - ASCIIDOCTOR_CORE_VERSION=master
+- ASCIIDOCTOR_CORE_VERSION=v1.5.5
+- ASCIIDOCTOR_CORE_VERSION=master
 node_js:
-  - "4"
-  - "6"
-  - "node"
-
+- '4'
+- '6'
+- node
 jdk:
-  - oraclejdk8
-
+- oraclejdk8
 before_script:
-  - npm install
-
+- npm install
 script:
- - npm run lint
- - npm run package
- - npm run docs
- - SKIP_BUILD=1 npm run examples
-
+- npm run lint
+- npm run package
+- npm run docs
+- SKIP_BUILD=1 npm run examples
 sudo: false
+
+before_deploy:
+- npm run build
+- npm run dist
+- npm config set git-tag-version false
+- if [[ "$TRAVIS_BRANCH" == master ]]; then npm version "$(npm view . version)+git.$(git log -n1 --pretty=format:%h)"; fi
+- if [[ "$TRAVIS_BRANCH" == master ]]; then npm config set tag dev; fi
+
+deploy:
+- provider: npm
+  skip_cleanup: true
+  email: ascii@doctor.org
+  api_key:
+    secure: OOM/FNDuhWGeZgD5EKzn/Kuv3Nf/uU1rVLoYyJ5/SKo8UeJ95acZyDisG2Y9ZOF1VeFEpmXXfgMxAs5ZKO7GwrGhah9Mvnbex5UQZBiR6Mw2Emq+Zgo+J4qFsTevU280ShQFACw6j5AQM9pFBeg+EcqrD5Q4iloJxG5g0qkUsZQ=
+  on:
+    tags: true
+    repo: asciidoctor/asciidoctor.js
+    condition: "$ASCIIDOCTOR_CORE_VERSION = 'v1.5.5'"
+    node: node
+- provider: npm
+  skip_cleanup: true
+  email: ascii@doctor.org
+  api_key:
+    secure: OOM/FNDuhWGeZgD5EKzn/Kuv3Nf/uU1rVLoYyJ5/SKo8UeJ95acZyDisG2Y9ZOF1VeFEpmXXfgMxAs5ZKO7GwrGhah9Mvnbex5UQZBiR6Mw2Emq+Zgo+J4qFsTevU280ShQFACw6j5AQM9pFBeg+EcqrD5Q4iloJxG5g0qkUsZQ=
+  on:
+    branch: master
+    repo: asciidoctor/asciidoctor.js
+    condition: "$ASCIIDOCTOR_CORE_VERSION = 'v1.5.5'"
+    node: node

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,8 @@ before_deploy:
 deploy:
 - provider: npm
   skip_cleanup: true
-  email: ascii@doctor.org
-  api_key:
-    secure: OOM/FNDuhWGeZgD5EKzn/Kuv3Nf/uU1rVLoYyJ5/SKo8UeJ95acZyDisG2Y9ZOF1VeFEpmXXfgMxAs5ZKO7GwrGhah9Mvnbex5UQZBiR6Mw2Emq+Zgo+J4qFsTevU280ShQFACw6j5AQM9pFBeg+EcqrD5Q4iloJxG5g0qkUsZQ=
+  email: $NPM_USER_EMAIL
+  api_key: $NPM_USER_API_KEY
   on:
     tags: true
     repo: asciidoctor/asciidoctor.js
@@ -34,9 +33,8 @@ deploy:
     node: node
 - provider: npm
   skip_cleanup: true
-  email: ascii@doctor.org
-  api_key:
-    secure: OOM/FNDuhWGeZgD5EKzn/Kuv3Nf/uU1rVLoYyJ5/SKo8UeJ95acZyDisG2Y9ZOF1VeFEpmXXfgMxAs5ZKO7GwrGhah9Mvnbex5UQZBiR6Mw2Emq+Zgo+J4qFsTevU280ShQFACw6j5AQM9pFBeg+EcqrD5Q4iloJxG5g0qkUsZQ=
+  email: $NPM_USER_EMAIL
+  api_key: $NPM_USER_API_KEY
   on:
     branch: master
     repo: asciidoctor/asciidoctor.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,3 @@ deploy:
     tags: true
     repo: asciidoctor/asciidoctor.js
     node: node
-    condition: "$ASCIIDOCTOR_CORE_VERSION -ne 'master'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ script:
 sudo: false
 
 before_deploy:
-- npm run build
 - npm run dist
 - if [[ "$TRAVIS_BRANCH" == master ]]; then npm --no-git-tag-version version "$(npm view . version)+git.$(git log -n1 --pretty=format:%h)"; fi
 - if [[ "$TRAVIS_BRANCH" == master ]]; then npm config set tag dev; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ sudo: false
 
 before_deploy:
 - npm run dist
-- if [[ "$TRAVIS_BRANCH" == master ]]; then npm --no-git-tag-version version "$(npm view . version)+git.$(git log -n1 --pretty=format:%h)"; fi
-- if [[ "$TRAVIS_BRANCH" == master ]]; then npm config set tag dev; fi
 
 deploy:
 - provider: npm
@@ -28,14 +26,4 @@ deploy:
   on:
     tags: true
     repo: asciidoctor/asciidoctor.js
-    condition: "$ASCIIDOCTOR_CORE_VERSION = 'v1.5.5'"
-    node: node
-- provider: npm
-  skip_cleanup: true
-  email: $NPM_USER_EMAIL
-  api_key: $NPM_USER_API_KEY
-  on:
-    branch: master
-    repo: asciidoctor/asciidoctor.js
-    condition: "$ASCIIDOCTOR_CORE_VERSION = 'v1.5.5'"
     node: node

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ node_js:
 - node
 jdk:
 - oraclejdk8
-before_script:
-- npm install
 script:
 - npm run lint
 - npm run package

--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "type": "git",
     "url": "https://github.com/asciidoctor/asciidoctor.js.git"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "keywords": [
     "asciidoc",
     "asciidoctor",


### PR DESCRIPTION
On a git tag push, a new version will be published on npm under the npm dist-tag `latest` (default behaviour).

On a git push on `master`, a new version will be published in npm as version `<package version>+git.<git-tag>` under the npm dist-tag `dev`.

----

Things to do in `.travis.yml` file:

- [x] make sure the `condition` value is correct (it is currently set to release if build is done with asciidoctor 1.5.5)
- [x] define `NPM_USER_EMAIL` variable in [Travis CI GUI][travis-gui] with the value of: `npm whoami`
- [x] define `NPM_USER_API_KEY` variable in [Travis CI GUI][travis-gui] with the value of:`cat ~/.npmrc | grep ':_authToken=' | awk -F'=' '{print $2}'`

fix #340

[travis-gui]: https://travis-ci.org/asciidoctor/asciidoctor.js/settings