### PR TITLE
Upgrade to Opal master (0.11.0.rc1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "homepage": "https://github.com/asciidoctor/asciidoctor.js",
   "dependencies": {
-    "opal-runtime": "0.11.0-integration7",
+    "opal-runtime": "0.11.0-integration8",
     "xmlhttprequest": "~1.7.0"
   },
   "devDependencies": {
@@ -68,7 +68,7 @@
     "bestikk-fs": "^0.1.0",
     "bestikk-jdk-ea": "0.1.1",
     "bestikk-log": "0.1.0",
-    "bestikk-opal-compiler": "0.3.0-integration6",
+    "bestikk-opal-compiler": "0.3.0-integration7",
     "bestikk-uglify": "0.1.1",
     "browserify": "^13.0.0",
     "cross-env": "^1.0.8",


### PR DESCRIPTION
https://github.com/opal/opal/commit/7d3ddfff23e486a106c5eae6175546587a2b621b

@mojavelinux 

-|pull request|	1.5.5-5|	1.5.6-preview.1
----|----|-----|-----
Run 1     |0,818	|0,920	|0,914
Run 2     |0,625	|0,687	|0,686
Run 3     |0,600	|0,653	|0,647
Run 4     |0,582	|0,630	|0,628
||	|12,49%	|11,73%
||	|9,89%	|9,73%
||	|8,80%	|7,76%
||	|8,21%	|7,94%

Version `1.5.5-5` and `1.5.6-preview.1` were about 10% slower
It should be noted that Opal 0.11 is now as fast as Opal 0.10:

_ | Opal 0.11 | Opal 0.10
------------| ------------- | -------------
Run 1     |      `0,942`|	`0,851`
Run 2     |      `0,716`|	`0,663`
Run 3     |      `0,67`  |	`0,614`
Run 4     |      `0,648`|	`0,588`
Average |	     `0,744`|	`0,679`
