### PR TITLE
Opal.const_get_qualified does not resolve ThreadSafe.Cache

### DIFF
--- a/lib/asciidoctor/js/opal_ext/thread_safe.rb
+++ b/lib/asciidoctor/js/opal_ext/thread_safe.rb
@@ -1,5 +1,4 @@
 module ThreadSafe
-end
-
-class Cache < ::Hash
+  class Cache < ::Hash
+  end
 end


### PR DESCRIPTION
Resolves https://github.com/asciidoctor/asciidoctor-template.js/issues/12

I don't really know the difference between:

```ruby
module ThreadSafe
end

class Cache < ::Hash
end
```

and:
```ruby
module ThreadSafe
  class Cache < ::Hash
  end
end
```

But Opal cannot resolve `ThreadSafe.Cache` with the first code sample.

*Ruby code*
```ruby
require 'thread_safe'
::ThreadSafe::Cache.new
```

*Compiled JavaScript code*
```js
Opal.const_get_qualified(Opal.const_get_qualified('::', 'ThreadSafe'), 'Cache');
```

*Error thrown with the first code sample*
```js
{ Cache: uninitialized constant ThreadSafe::Cache
  name: 'Cache',
  message: 'uninitialized constant ThreadSafe::Cache' }
```

@mojavelinux @iliabylich Any glue ? Is this a bug ? Is this intended ?