### PR TITLE
Reduce statically-registered extensions scope in tests

### DIFF
--- a/spec/share/asciidoctor.spec.js.orig
+++ b/spec/share/asciidoctor.spec.js.orig
@@ -268,9 +268,15 @@ var shareSpec = function (testOptions, asciidoctor) {
         expect(appendix.sectname).toBe('appendix');
         expect(appendix.caption).toBe('Appendix A: ');
         expect(appendix.getCaption()).toBe('Appendix A: ');
+<<<<<<< HEAD
         expect(appendix.getCaptionedTitle()).toBe('Appendix A: Attribute Options');
+        var asciidoctorVersion = asciidoctor.getCoreVersion();
+        var asciidoctorVersionNumber = parseInt(asciidoctorVersion.replace(/(\.|dev)/g, ''));
+        if (asciidoctorVersion === '1.5.6' || asciidoctorVersionNumber > 156) {
+=======
         var asciidoctorVersionNumber = getCoreVersionNumber(asciidoctor);
         if (asciidoctorVersionNumber >= 156) {
+>>>>>>> Reduce statically-registered extensions scope in tests
           expect(appendix.number).toBe('A');
           expect(appendix.numbered).toBe(true);
         }

--- a/src/asciidoctor-extensions-api.js
+++ b/src/asciidoctor-extensions-api.js
@@ -80,6 +80,14 @@ Extensions.register = function (name, block) {
 };
 
 /**
+ * Unregister all statically-registered extension groups.
+ * @memberof Extensions
+ */
+Extensions.unregisterAll = function () {
+  this.$unregister_all();
+};
+
+/**
  * @namespace
  * @module Extensions/Registry
  */


### PR DESCRIPTION
Attempt to fix tests on master: https://github.com/asciidoctor/asciidoctor/commit/3759c0009df3111efb6a811179bdb5ded8db2426

The following declaration does not activate anymore (with https://github.com/asciidoctor/asciidoctor/commit/3759c0009df3111efb6a811179bdb5ded8db2426):
```js
// Extension declaration
module.exports = function (registry) {
  registry.treeProcessor(function () {
    var self = this;
    self.process(function (doc) {
      doc.getBlocks()[0] = self.createBlock(doc, 'paragraph', 'Made with icon:heart[]');
      return doc;
    });
  });
};

// Usage
var registry = asciidoctor.Extensions.create();
require('../share/extensions/love-tree-processor.js')(registry);
var opts = {};
opts[asciidoctorVersionGreaterThan('1.5.5') ? 'extension_registry' : 'extensions_registry'] = registry;

// tree processor is not activated!
var result = asciidoctor.convert(fs.readFileSync(path.resolve(__dirname + '/love-tree-processor-ex.adoc')), opts);
```

With the following declaration, the extension is activated:
```js
// Extension declaration
module.exports = function (asciidoctor) {
  return asciidoctor.Extensions.create(function () {
    this.treeProcessor(function () {
      var self = this;
      self.process(function (doc) {
        doc.getBlocks()[0] = self.createBlock(doc, 'paragraph', 'Made with icon:heart[]');
        return doc;
      });
    });
  });
};

// Usage
var registry = require('../share/extensions/love-tree-processor.js')(asciidoctor);
var opts = {};
opts[asciidoctorVersionGreaterThan('1.5.5') ? 'extension_registry' : 'extensions_registry'] = registry;

// tree processor is activated \o/
var result = asciidoctor.convert(fs.readFileSync(path.resolve(__dirname + '/love-tree-processor-ex.adoc')), opts);
```
commit: https://github.com/asciidoctor/asciidoctor.js/pull/372/commits/a20731275bb688e558df59b973316b19351e0d7f

@mojavelinux Is this intended ? I didn't find a test in Asciidoctor core with the first declaration but it should work right ? `Asciidoctor.Extensions.create()` (without function) should return a new `Registry` and we should be able to register an extension on this registry... ?