### PR TITLE
👷 Resolves #405, skip the rebuild phase by default

### DIFF
--- a/npm/clean.js
+++ b/npm/clean.js
@@ -1,0 +1,4 @@
+const Builder = require('./builder.js');
+const builder = new Builder();
+
+builder.clean();

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:karmaRequirejs": "karma start karma-requirejs.conf.js",
     "test": "node npm/test/builder.js && node npm/test/unsupported-features.js && node npm/test/jasmine-browser.js && node npm/test/jasmine-browser-min.js && node npm/test/jasmine-node.js && node npm/test/jasmine-webpack.js && npm run test:karmaBrowserify && npm run test:karmaRequirejs && node npm/test/nashorn.js",
     "build": "node npm/build.js && npm run test",
+    "clean": "node npm/clean.js",
     "dist": "cross-env MINIFY=1 node npm/dist.js",
     "lint": "eslint src spec npm",
     "package": "cross-env MINIFY=1 node npm/build.js && cross-env MINIFY=1 npm run test",


### PR DESCRIPTION
The compilation from Asciidoctor core (rebuild) is skipped if, the file `build/asciidoctor-lib.js` already exists and the "rebuild" tag is absent. Otherwise, the rebuild task is run.

Also adds a clean task to clean the `build` directory.

Resolves #405