### PR TITLE
Provide a dedicated JavaScript file for each runtime

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -42,7 +42,7 @@ You can use Asciidoctor.js either for back-end development using {uri-nodejs}[No
 Once the package installed, you can add the following `script` tag to your HTML page:
 
 ```html
-<script src="node_modules/asciidoctor.js/dist/asciidoctor.min.js"></script>
+<script src="node_modules/asciidoctor.js/dist/browser/asciidoctor.js"></script>
 ```
 
 Here is a simple example that converts AsciiDoc to HTML5:

--- a/benchmark/nashorn.js
+++ b/benchmark/nashorn.js
@@ -30,7 +30,7 @@ if (typeof $ENV !== 'undefined') {
 }
 
 var start = currentTimeMillis();
-load('./build/asciidoctor.js');
+load('./build/asciidoctor-nashorn.js');
 console.log('Load scripts: ' + secondsSince(start));
 
 var asciidoctor = Asciidoctor();

--- a/benchmark/node.js
+++ b/benchmark/node.js
@@ -4,8 +4,8 @@ const verbose = process.env.VERBOSE;
 const include = process.env.INCLUDE;
 const runs = process.env.RUNS || 4;
 
-const start = new Date().getTime()
-const Asciidoctor = require('../asciidoctor.js');
+const start = new Date().getTime();
+const Asciidoctor = require('../asciidoctor-node.js');
 console.log(`Load scripts: ${((new Date().getTime() - start) / 1000.0)}s`);
 
 const baseDir = __dirname;
@@ -25,7 +25,7 @@ if (include) {
   content = fs.readFileSync(`${baseDir}/userguide.adoc`, 'utf-8');
 }
 let html;
-for (var i = 1; i <= runs; i++) {
+for (let i = 1; i <= runs; i++) {
   let start = new Date().getTime();
   html = asciidoctor.convert(content, options);
   let duration = new Date().getTime() - start;

--- a/lib/asciidoctor/js/opal_ext.rb
+++ b/lib/asciidoctor/js/opal_ext.rb
@@ -1,106 +1,3 @@
-%x(
-  var isNode = typeof process === 'object' && typeof process.versions === 'object' && process.browser != true,
-      isElectron = typeof navigator === 'object' && typeof navigator.userAgent === 'string' && typeof navigator.userAgent.indexOf('Electron') !== -1,
-      isBrowser = typeof window === 'object',
-      isNashorn = typeof Java === 'object' && Java.type,
-      isRhino = typeof java === 'object',
-      isPhantomJS = typeof window === 'object' && typeof window.phantom === 'object',
-      isWebWorker = typeof importScripts === 'function',
-      isSpiderMonkey = typeof JSRuntime === 'object',
-      platform,
-      engine,
-      framework,
-      ioModule;
-
-  // Load common modules
-  Opal.load("pathname");
-  Opal.load("base64");
-
-  if (typeof moduleConfig === 'object' && typeof moduleConfig.runtime === 'object') {
-    var runtime = moduleConfig.runtime;
-    platform = runtime.platform;
-    engine = runtime.engine;
-    framework = runtime.framework;
-    ioModule = runtime.ioModule;
-  }
-
-  if (typeof platform === 'undefined') {
-    // Try to automatically detect the JavaScript platform, engine and framework
-    if (isNode) {
-      platform = platform || 'node';
-      engine = engine || 'v8';
-      if (isElectron) {
-        framework = framework || 'electron';
-      }
-    }
-    else if (isNashorn) {
-      platform = platform || 'java';
-      engine = engine || 'nashorn';
-    }
-    else if (isRhino) {
-      platform = platform || 'java';
-      engine = engine || 'rhino';
-    }
-    else if (isSpiderMonkey) {
-      platform = platform || 'standalone';
-      framework = framework || 'spidermonkey';
-    }
-    else if (isBrowser) {
-      platform = platform || 'browser';
-      if (isPhantomJS) {
-        framework = framework || 'phantomjs';
-      }
-    }
-    // NOTE: WebWorker are not limited to browser
-    if (isWebWorker) {
-      framework = framework || 'webworker';
-    }
-  }
-
-  if (typeof platform === 'undefined') {
-    throw new Error('Unable to automatically detect the JavaScript platform, please configure Asciidoctor.js: `Asciidoctor({runtime: {platform: \'node\'}})`');
-  }
-
-  // Optional information
-  if (typeof framework === 'undefined') {
-    framework = '';
-  }
-  if (typeof engine === 'undefined') {
-    engine = '';
-  }
-
-  // IO Module
-  if (typeof ioModule !== 'undefined') {
-    if (ioModule != 'spidermonkey'
-         && ioModule != 'phantomjs'
-         && ioModule != 'node'
-         && ioModule != 'java_nio'
-         && ioModule != 'xmlhttprequest') {
-      throw new Error('Invalid IO module, `config.ioModule` must be one of: spidermonkey, phantomjs, node, java_nio or xmlhttprequest');
-    }
-  } else {
-    if (framework === 'spidermonkey') {
-      ioModule = 'spidermonkey';
-    } else if (framework === 'phantomjs') {
-      ioModule = 'phantomjs';
-    } else if (platform === 'node') {
-      ioModule = 'node';
-    } else if (engine === 'nashorn') {
-      ioModule = 'java_nio'
-    } else if (platform === 'browser' || typeof XmlHTTPRequest !== 'undefined') {
-      ioModule = 'xmlhttprequest'
-    } else {
-      throw new Error('Unable to automatically detect the IO module, please configure Asciidoctor.js: `Asciidoctor({runtime: {ioModule: \'node\'}})`');
-    }
-  }
-
-)
-
-JAVASCRIPT_IO_MODULE = %x(ioModule)
-JAVASCRIPT_PLATFORM = %x(platform)
-JAVASCRIPT_ENGINE = %x(engine)
-JAVASCRIPT_FRAMEWORK = %x(framework)
-
 require 'asciidoctor/js/opal_ext/file'
 require 'asciidoctor/js/opal_ext/match_data'
 require 'asciidoctor/js/opal_ext/kernel'
@@ -108,13 +5,11 @@ require 'asciidoctor/js/opal_ext/thread_safe'
 require 'asciidoctor/js/opal_ext/string'
 require 'asciidoctor/js/opal_ext/uri'
 
-if JAVASCRIPT_ENGINE == 'nashorn'
-  require 'asciidoctor/js/opal_ext/nashorn/io'
-  require 'asciidoctor/js/opal_ext/nashorn/dir'
-end
-if JAVASCRIPT_FRAMEWORK == 'electron'
-  require 'asciidoctor/js/opal_ext/electron/io'
-end
-if JAVASCRIPT_PLATFORM == 'node'
-  `Opal.load("nodejs")`
-end
+%x(
+// Load common modules
+Opal.load("pathname");
+Opal.load("base64");
+
+// Load specific implementation
+//{{asciidoctorRuntimeEnvironment}}
+)

--- a/lib/asciidoctor/js/opal_ext/browser.rb
+++ b/lib/asciidoctor/js/opal_ext/browser.rb
@@ -1,0 +1,22 @@
+%x(
+  var platform, engine, framework, ioModule;
+
+  if (typeof moduleConfig === 'object' && typeof moduleConfig.runtime === 'object') {
+    var runtime = moduleConfig.runtime;
+    platform = runtime.platform;
+    engine = runtime.engine;
+    framework = runtime.framework;
+    ioModule = runtime.ioModule;
+  }
+  ioModule = ioModule || 'xmlhttprequest';
+  platform = platform || 'browser';
+  engine = engine || '';
+  framework = framework || '';
+)
+
+JAVASCRIPT_IO_MODULE = %x(ioModule)
+JAVASCRIPT_PLATFORM = %x(platform)
+JAVASCRIPT_ENGINE = %x(engine)
+JAVASCRIPT_FRAMEWORK = %x(framework)
+
+require 'asciidoctor/js/opal_ext/browser/file'

--- a/lib/asciidoctor/js/opal_ext/browser/file.rb
+++ b/lib/asciidoctor/js/opal_ext/browser/file.rb
@@ -1,0 +1,31 @@
+class File
+
+  def self.read(path)
+    %x(
+      var data = '';
+      var status = -1;
+      try {
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', path, false);
+        xhr.addEventListener('load', function() {
+          status = this.status;
+          // status is 0 for local file mode (i.e., file://)
+          if (status === 0 || status === 200) {
+            data = this.responseText;
+          }
+        });
+        xhr.overrideMimeType('text/plain');
+        xhr.send();
+      }
+      catch (e) {
+        throw #{IOError.new `'Error reading file or directory: ' + path + '; reason: ' + e.message`};
+      }
+      // assume that no data in local file mode means it doesn't exist
+      if (status === 404 || (status === 0 && !data)) {
+        throw #{IOError.new `'No such file or directory: ' + path`};
+      }
+      return data;
+    )
+  end
+
+end

--- a/lib/asciidoctor/js/opal_ext/file.rb
+++ b/lib/asciidoctor/js/opal_ext/file.rb
@@ -91,49 +91,8 @@ class File
   end
 
   def self.read(path)
-    case JAVASCRIPT_IO_MODULE
-    when 'phantomjs'
-      %x(return require('fs').read(path);)
-    when 'java_nio'
-      %x(
-        var Paths = Java.type('java.nio.file.Paths');
-        var Files = Java.type('java.nio.file.Files');
-        var lines = Files.readAllLines(Paths.get(path), Java.type('java.nio.charset.StandardCharsets').UTF_8);
-        var data = [];
-        lines.forEach(function(line) { data.push(line); });
-        return data.join("\n");
-      )
-    when 'xmlhttprequest'
-      %x(
-        var data = '';
-        var status = -1;
-        try {
-          var xhr = new XMLHttpRequest();
-          xhr.open('GET', path, false);
-          xhr.addEventListener('load', function() {
-            status = this.status;
-            // status is 0 for local file mode (i.e., file://)
-            if (status == 0 || status == 200) {
-              data = this.responseText;
-            }
-          });
-          xhr.overrideMimeType('text/plain');
-          xhr.send();
-        }
-        catch (e) {
-          throw #{IOError.new `'Error reading file or directory: ' + path + '; reason: ' + e.message`};
-        }
-        // assume that no data in local file mode means it doesn't exist
-        if (status === 404 || (status === 0 && !data)) {
-          throw #{IOError.new `'No such file or directory: ' + path`};
-        }
-        return data;
-      )
-    when 'spidermonkey'
-      %x(return read(path);)
-    else
-      ''
-    end
+    # REMIND will be overriden by a specific implementation
+    ''
   end
 
 end

--- a/lib/asciidoctor/js/opal_ext/nashorn.rb
+++ b/lib/asciidoctor/js/opal_ext/nashorn.rb
@@ -1,0 +1,24 @@
+%x(
+  var platform, engine, framework, ioModule;
+
+  if (typeof moduleConfig === 'object' && typeof moduleConfig.runtime === 'object') {
+    var runtime = moduleConfig.runtime;
+    platform = runtime.platform;
+    engine = runtime.engine;
+    framework = runtime.framework;
+    ioModule = runtime.ioModule;
+  }
+  ioModule = ioModule || 'java_nio';
+  platform = platform || 'java';
+  engine = engine || 'nashorn';
+  framework = framework || '';
+)
+
+JAVASCRIPT_IO_MODULE = %x(ioModule)
+JAVASCRIPT_PLATFORM = %x(platform)
+JAVASCRIPT_ENGINE = %x(engine)
+JAVASCRIPT_FRAMEWORK = %x(framework)
+
+require 'asciidoctor/js/opal_ext/nashorn/io'
+require 'asciidoctor/js/opal_ext/nashorn/dir'
+require 'asciidoctor/js/opal_ext/nashorn/file'

--- a/lib/asciidoctor/js/opal_ext/nashorn/file.rb
+++ b/lib/asciidoctor/js/opal_ext/nashorn/file.rb
@@ -1,16 +1,13 @@
 class File
 
-  def self.file? path
+  def self.read(path)
     %x(
+      var Paths = Java.type('java.nio.file.Paths');
       var Files = Java.type('java.nio.file.Files');
-      return Files.exists(path) && Files.isRegularFile(path);
-    )
-  end
-
-  def self.readable? path
-    %x(
-      var Files = Java.type('java.nio.file.Files');
-      return Files.exists(path) && Files.isReadable(path);
+      var lines = Files.readAllLines(Paths.get(path), Java.type('java.nio.charset.StandardCharsets').UTF_8);
+      var data = [];
+      lines.forEach(function(line) { data.push(line); });
+      return data.join("\n");
     )
   end
 

--- a/lib/asciidoctor/js/opal_ext/node.rb
+++ b/lib/asciidoctor/js/opal_ext/node.rb
@@ -1,0 +1,35 @@
+%x(
+  var isElectron = typeof navigator === 'object' && typeof navigator.userAgent === 'string' && typeof navigator.userAgent.indexOf('Electron') !== -1,
+      platform,
+      engine,
+      framework,
+      ioModule;
+
+  if (typeof moduleConfig === 'object' && typeof moduleConfig.runtime === 'object') {
+    var runtime = moduleConfig.runtime;
+    platform = runtime.platform;
+    engine = runtime.engine;
+    framework = runtime.framework;
+    ioModule = runtime.ioModule;
+  }
+
+  ioModule = ioModule || 'node';
+  platform = platform || 'node';
+  engine = engine || 'v8';
+  if (isElectron) {
+    framework = framework || 'electron';
+  } else {
+    framework = framework || '';
+  }
+)
+
+JAVASCRIPT_IO_MODULE = %x(ioModule)
+JAVASCRIPT_PLATFORM = %x(platform)
+JAVASCRIPT_ENGINE = %x(engine)
+JAVASCRIPT_FRAMEWORK = %x(framework)
+
+if JAVASCRIPT_FRAMEWORK == 'electron'
+  require 'asciidoctor/js/opal_ext/electron/io'
+end
+
+`Opal.load("nodejs")`

--- a/lib/asciidoctor/js/opal_ext/phantomjs/file.rb
+++ b/lib/asciidoctor/js/opal_ext/phantomjs/file.rb
@@ -1,0 +1,7 @@
+class File
+
+  def self.read(path)
+    %x(return require('fs').read(path);)
+  end
+
+end

--- a/lib/asciidoctor/js/opal_ext/spidermonkey/file.rb
+++ b/lib/asciidoctor/js/opal_ext/spidermonkey/file.rb
@@ -1,0 +1,7 @@
+class File
+
+  def self.read(path)
+    %x(return read(path);)
+  end
+
+end

--- a/lib/asciidoctor/js/opal_ext/umd.rb
+++ b/lib/asciidoctor/js/opal_ext/umd.rb
@@ -1,0 +1,118 @@
+%x(
+  var isNode = typeof process === 'object' && typeof process.versions === 'object' && process.browser != true,
+      isElectron = typeof navigator === 'object' && typeof navigator.userAgent === 'string' && typeof navigator.userAgent.indexOf('Electron') !== -1,
+      isBrowser = typeof window === 'object',
+      isNashorn = typeof Java === 'object' && Java.type,
+      isRhino = typeof java === 'object',
+      isPhantomJS = typeof window === 'object' && typeof window.phantom === 'object',
+      isWebWorker = typeof importScripts === 'function',
+      isSpiderMonkey = typeof JSRuntime === 'object',
+      platform,
+      engine,
+      framework,
+      ioModule;
+
+  if (typeof moduleConfig === 'object' && typeof moduleConfig.runtime === 'object') {
+    var runtime = moduleConfig.runtime;
+    platform = runtime.platform;
+    engine = runtime.engine;
+    framework = runtime.framework;
+    ioModule = runtime.ioModule;
+  }
+
+  if (typeof platform === 'undefined') {
+    // Try to automatically detect the JavaScript platform, engine and framework
+    if (isNode) {
+      platform = platform || 'node';
+      engine = engine || 'v8';
+      if (isElectron) {
+        framework = framework || 'electron';
+      }
+    }
+    else if (isNashorn) {
+      platform = platform || 'java';
+      engine = engine || 'nashorn';
+    }
+    else if (isRhino) {
+      platform = platform || 'java';
+      engine = engine || 'rhino';
+    }
+    else if (isSpiderMonkey) {
+      platform = platform || 'standalone';
+      framework = framework || 'spidermonkey';
+    }
+    else if (isBrowser) {
+      platform = platform || 'browser';
+      if (isPhantomJS) {
+        framework = framework || 'phantomjs';
+      }
+    }
+    // NOTE: WebWorker are not limited to browser
+    if (isWebWorker) {
+      framework = framework || 'webworker';
+    }
+  }
+
+  if (typeof platform === 'undefined') {
+    throw new Error('Unable to automatically detect the JavaScript platform, please configure Asciidoctor.js: `Asciidoctor({runtime: {platform: \'node\'}})`');
+  }
+
+  // Optional information
+  if (typeof framework === 'undefined') {
+    framework = '';
+  }
+  if (typeof engine === 'undefined') {
+    engine = '';
+  }
+
+  // IO Module
+  if (typeof ioModule !== 'undefined') {
+    if (ioModule !== 'spidermonkey'
+         && ioModule !== 'phantomjs'
+         && ioModule !== 'node'
+         && ioModule !== 'java_nio'
+         && ioModule !== 'xmlhttprequest') {
+      throw new Error('Invalid IO module, `config.ioModule` must be one of: spidermonkey, phantomjs, node, java_nio or xmlhttprequest');
+    }
+  } else {
+    if (framework === 'spidermonkey') {
+      ioModule = 'spidermonkey';
+    } else if (framework === 'phantomjs') {
+      ioModule = 'phantomjs';
+    } else if (platform === 'node') {
+      ioModule = 'node';
+    } else if (engine === 'nashorn') {
+      ioModule = 'java_nio'
+    } else if (platform === 'browser' || typeof XmlHTTPRequest !== 'undefined') {
+      ioModule = 'xmlhttprequest'
+    } else {
+      throw new Error('Unable to automatically detect the IO module, please configure Asciidoctor.js: `Asciidoctor({runtime: {ioModule: \'node\'}})`');
+    }
+  }
+)
+
+JAVASCRIPT_IO_MODULE = %x(ioModule)
+JAVASCRIPT_PLATFORM = %x(platform)
+JAVASCRIPT_ENGINE = %x(engine)
+JAVASCRIPT_FRAMEWORK = %x(framework)
+
+if JAVASCRIPT_ENGINE == 'nashorn' || JAVASCRIPT_IO_MODULE == 'java_nio'
+  require 'asciidoctor/js/opal_ext/nashorn/dir'
+  require 'asciidoctor/js/opal_ext/nashorn/file'
+  require 'asciidoctor/js/opal_ext/nashorn/io'
+end
+if JAVASCRIPT_FRAMEWORK == 'electron'
+  require 'asciidoctor/js/opal_ext/electron/io'
+end
+if JAVASCRIPT_PLATFORM == 'node'
+  `Opal.load("nodejs")`
+end
+if JAVASCRIPT_IO_MODULE == 'phantomjs'
+  require 'asciidoctor/js/opal_ext/phantomjs/file'
+end
+if JAVASCRIPT_IO_MODULE == 'spidermonkey'
+  require 'asciidoctor/js/opal_ext/spidermonkey/file'
+end
+if JAVASCRIPT_IO_MODULE == 'xmlhttprequest'
+  require 'asciidoctor/js/opal_ext/browser/file'
+end

--- a/lib/asciidoctor/opal_ext.rb
+++ b/lib/asciidoctor/opal_ext.rb
@@ -1,4 +1,0 @@
-# For backward compatibility with Asciidoctor <= 1.5.5
-require 'asciidoctor/js'
-require 'asciidoctor/converter'
-require 'asciidoctor/js/postscript'

--- a/npm/.eslintrc
+++ b/npm/.eslintrc
@@ -1,0 +1,3 @@
+env:
+  node: true
+  es6: true

--- a/npm/.eslintrc.js
+++ b/npm/.eslintrc.js
@@ -1,6 +1,0 @@
-module.exports = {
-    "env": {
-        "node": true,
-        "es6": true
-    }
-};

--- a/package.json
+++ b/package.json
@@ -2,16 +2,15 @@
   "name": "asciidoctor.js",
   "version": "1.5.6-preview.5",
   "description": "A JavaScript AsciiDoc processor, cross-compiled from the Ruby-based AsciiDoc implementation, Asciidoctor, using Opal",
-  "main": "dist/asciidoctor.js",
+  "main": "dist/node/asciidoctor.js",
+  "browser": "dist/browser/asciidoctor.js",
   "engines": {
     "node": ">=6.12",
     "npm": ">=3.0.0",
     "yarn": ">=1.1.0"
   },
   "files": [
-    "dist/asciidoctor.js",
-    "dist/extensions",
-    "dist/css",
+    "dist",
     "LICENSE",
     "README.adoc"
   ],
@@ -71,7 +70,7 @@
     "bestikk-fs": "0.1.0",
     "bestikk-jdk-ea": "0.1.1",
     "bestikk-log": "0.1.0",
-    "bestikk-opal-compiler": "0.3.0-integration7",
+    "bestikk-opal-compiler": "0.3.1-integration7",
     "bestikk-uglify": "0.2.1",
     "browserify": "15.2.0",
     "cross-env": "5.1.3",

--- a/spec/nashorn/asciidoctor-convert.js
+++ b/spec/nashorn/asciidoctor-convert.js
@@ -1,4 +1,4 @@
-load('./build/asciidoctor.js');
+load('./build/asciidoctor-nashorn.js');
 var asciidoctor = Asciidoctor();
 
 var data = '= asciidoctor.js, AsciiDoc in JavaScript\n' +

--- a/spec/node/asciidoctor.spec.js
+++ b/spec/node/asciidoctor.spec.js
@@ -9,13 +9,13 @@ const config = {
     framework: 'lollipop'
   }
 };
-const asciidoctor = require('../../build/asciidoctor.js')(config);
+const asciidoctor = require('../../build/asciidoctor-node.js')(config);
 function asciidoctorVersionGreaterThan (version) {
   const currentVersion = asciidoctor.getCoreVersion();
   // ignore the fourth number, keep only major, minor and patch numbers
   const currentVersionNumeric = parseInt(currentVersion.replace('.dev', '').replace(/\./g, '').substring(0, 3));
   const versionNumeric = version.replace(/\./g, '');
-  return currentVersionNumeric > versionNumeric; 
+  return currentVersionNumeric > versionNumeric;
 }
 
 const Opal = require('opal-runtime').Opal; // for testing purpose only

--- a/src/template-asciidoctor-nashorn.js
+++ b/src/template-asciidoctor-nashorn.js
@@ -1,0 +1,26 @@
+//{{opalCode}}
+Opal.require('opal');
+
+// Nashorn Module
+(function (root, factory) {
+  // globals (root is window)
+  root.Asciidoctor = factory;
+// eslint-disable-next-line no-unused-vars
+}(this, function (moduleConfig) {
+//{{asciidoctorCode}}
+
+//{{asciidoctorAPI}}
+
+//{{asciidoctorVersion}}
+
+  /**
+   * Get Asciidoctor.js version number.
+   *
+   * @memberof Asciidoctor
+   * @returns {string} - returns the version number of Asciidoctor.js.
+   */
+  Asciidoctor.$$proto.getVersion = function () {
+    return ASCIIDOCTOR_JS_VERSION;
+  };
+  return Opal.Asciidoctor;
+}));

--- a/src/template-asciidoctor-node.js
+++ b/src/template-asciidoctor-node.js
@@ -1,0 +1,25 @@
+/* eslint-env node, es6 */
+const Opal = require('opal-runtime').Opal;
+
+// Node module
+(function (root, factory) {
+  module.exports = factory;
+// eslint-disable-next-line no-unused-vars
+}(this, function (moduleConfig) {
+//{{asciidoctorCode}}
+
+//{{asciidoctorAPI}}
+
+//{{asciidoctorVersion}}
+
+  /**
+   * Get Asciidoctor.js version number.
+   *
+   * @memberof Asciidoctor
+   * @returns {string} - returns the version number of Asciidoctor.js.
+   */
+  Asciidoctor.$$proto.getVersion = function () {
+    return ASCIIDOCTOR_JS_VERSION;
+  };
+  return Opal.Asciidoctor;
+}));

--- a/src/template-asciidoctor-umd.js
+++ b/src/template-asciidoctor-umd.js
@@ -3,7 +3,7 @@ if (typeof Opal === 'undefined' && typeof module === 'object' && module.exports)
 }
 
 if (typeof Opal === 'undefined') {
-//#{opalCode}
+//{{opalCode}}
   Opal.require('opal');
 }
 
@@ -25,11 +25,11 @@ if (typeof Opal === 'undefined') {
   }
 // eslint-disable-next-line no-unused-vars
 }(this, function (moduleConfig) {
-//#{asciidoctorCode}
+//{{asciidoctorCode}}
 
-//#{asciidoctorAPI}
+//{{asciidoctorAPI}}
 
-//#{asciidoctorVersion}
+//{{asciidoctorVersion}}
 
   /**
    * Get Asciidoctor.js version number.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1129,9 +1129,9 @@ bestikk-log@0.1.0, bestikk-log@^0.1.0:
   dependencies:
     colors "1.1.2"
 
-bestikk-opal-compiler@0.3.0-integration7:
-  version "0.3.0-integration7"
-  resolved "https://registry.yarnpkg.com/bestikk-opal-compiler/-/bestikk-opal-compiler-0.3.0-integration7.tgz#274698bc80a00c8854e6e93b768908f7986ce50e"
+bestikk-opal-compiler@0.3.1-integration7:
+  version "0.3.1-integration7"
+  resolved "https://registry.yarnpkg.com/bestikk-opal-compiler/-/bestikk-opal-compiler-0.3.1-integration7.tgz#4fcb76e8ff15bcd4f1213a5cb01d519a1ebe4d88"
   dependencies:
     bestikk-log "^0.1.0"
     opal-compiler "0.11.0-integration8"


### PR DESCRIPTION
Currently we provide a single UMD file with all the specific implementations.
In this pull request, we want to generate a dedicated JavaScript file for each runtime:

- node
- nashorn
- electron
- browser
- umd (for backward compatiblity)
- phantomjs (meh)
- spidermonkey (meh)

Each specific implementation has moved to a dedicated directory.

The idea is to compile a dedicated JavaScript file for each runtime in order to create a dedicated version of Asciidoctor.js. More specifically the browser version of Asciidoctor.js will not contain `require('fs')` and the Node version of Asciidoctor.js will not include `opal-runtime`.

Resolves #396 



