### PR TITLE
return undefined if block title is not set

### DIFF
--- a/spec/node/asciidoctor.spec.js
+++ b/spec/node/asciidoctor.spec.js
@@ -161,7 +161,7 @@ describe('Node.js', () => {
       expect(blocks[2].getBlocks().length).toBe(3);
 
       expect(blocks[2].getBlocks()[0].getContext()).toBe('image');
-      expect(blocks[2].getBlocks()[0].getTitle()).toBe('');
+      expect(blocks[2].getBlocks()[0].getTitle()).toBe(undefined);
       expect(blocks[2].getBlocks()[1].getContext()).toBe('image');
 
       expect(blocks[3].getTitle()).toBe('Got <span class="icon">[file pdf o]</span>?');

--- a/src/asciidoctor-core-api.js
+++ b/src/asciidoctor-core-api.js
@@ -166,17 +166,14 @@ var AbstractBlock = Opal.Asciidoctor.AbstractBlock;
  * <code>specialcharacters</code>, <code>quotes</code>, <code>replacements</code>, <code>macros</code>, <code>attributes</code> and <code>post_replacements</code>
  *
  * @memberof AbstractBlock
- * @returns {string} - returns the converted String title for this Block, or an empty string if the assigned title is falsy
+ * @returns {string} - returns the converted String title for this Block, or undefined if the title is not set.
  * @example
  * block.title // "Foo 3^ # {two-colons} Bar(1)"
  * block.getTitle(); // "Foo 3^ # :: Bar(1)"
  */
 AbstractBlock.$$proto.getTitle = function () {
   var result = this.$title();
-  if (result === Opal.nil) {
-    return '';
-  }
-  return result;
+  return result === Opal.nil ? undefined : result;
 };
 
 /**


### PR DESCRIPTION
It's not clear to me why getTitle() on a Block behaves differently than on Document. I've aligned their behavior.