### PR TITLE
add Processor#createImageBlock method to public extension API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ addons:
   chrome: stable
 
 env:
-- ASCIIDOCTOR_CORE_VERSION=v1.5.6.1
+- ASCIIDOCTOR_CORE_VERSION=asciidoctor/asciidoctor#v1.5.6.x
 - ASCIIDOCTOR_CORE_VERSION=master
 
 cache:

--- a/spec/node/asciidoctor.spec.js
+++ b/spec/node/asciidoctor.spec.js
@@ -397,6 +397,21 @@ Content 2`;
       expect(result).toContain('we have liftoff.');
     });
 
+    it('should be able to create an image block from a processor extension', () => {
+      const registry = asciidoctor.Extensions.create(function () {
+        this.blockMacro(function () {
+          this.named('img');
+          this.process((parent, target) => {
+            return this.createImageBlock(parent, { target: target + '.png' });
+          });
+        });
+      });
+      const opts = {};
+      opts[asciidoctorVersionGreaterThan('1.5.5') ? 'extension_registry' : 'extensions_registry'] = registry;
+      const result = asciidoctor.convert('img::image-name[]', opts);
+      expect(result).toContain('<img src="image-name.png" alt="image name">');
+    });
+
     it('should be able to process emoji inline macro processor extension', () => {
       const registry = asciidoctor.Extensions.create();
       const opts = {};

--- a/src/asciidoctor-extensions-api.js
+++ b/src/asciidoctor-extensions-api.js
@@ -208,6 +208,13 @@ Processor.$$proto.createBlock = function (parent, context, source, attrs, opts) 
 /**
  * @memberof Extensions/Processor
  */
+Processor.$$proto.createImageBlock = function (parent, attrs, opts) {
+  return this.$create_image_block(parent, toHash(attrs), toHash(opts));
+};
+
+/**
+ * @memberof Extensions/Processor
+ */
 Processor.$$proto.createInline = function (parent, context, text, opts) {
   return this.$create_inline(parent, context, text, toHash(opts));
 };


### PR DESCRIPTION
This method is of particular importance, not only because it cuts down the number of method arguments needed to create an image block, but it enforces that the target attribute is set, automatically computes the alt text from the image name, and stores the generated alt text in the default-alt attribute. It's a lot of bang for the buck.

Resolves #364