### PR TITLE
map Reader#getString() method in public API

### DIFF
--- a/spec/share/asciidoctor.spec.js
+++ b/spec/share/asciidoctor.spec.js
@@ -135,6 +135,16 @@ var shareSpec = function (testOptions, asciidoctor) {
         expect(doc.getSourceLines()).toEqual([ '== Test', 'This is the first paragraph.', '', 'This is a second paragraph.' ]);
       });
 
+      it('should get reader lines', function () {
+        var doc = asciidoctor.load('line one\nline two\nline three', { parse: false });
+        expect(doc.getReader().getLines()).toEqual(['line one', 'line two', 'line three']);
+      });
+
+      it('should get reader string', function () {
+        var doc = asciidoctor.load('line one\nline two\nline three', { parse: false });
+        expect(doc.getReader().getString()).toBe('line one\nline two\nline three');
+      });
+
       it('should not be nested', function () {
         var doc = asciidoctor.load('== Test');
         expect(doc.isNested()).toBe(false);

--- a/src/asciidoctor-core-api.js
+++ b/src/asciidoctor-core-api.js
@@ -986,7 +986,7 @@ Document.$$proto.getParentDocument = function () {
  * @memberof Document
  */
 Document.$$proto.getReader = function () {
-  return this.$reader;
+  return this.reader;
 };
 
 /**
@@ -1163,4 +1163,14 @@ Reader.$$proto.getCursor = function () {
  */
 Reader.$$proto.getLines = function () {
   return this.$lines();
+};
+
+/**
+ * Get the remaining lines managed by this Reader as a String.
+ *
+ * @memberof Reader
+ * @returns {string} - returns The remaining lines managed by this Reader as a String (joined by linefeed characters).
+ */
+Reader.$$proto.getString = function () {
+  return this.$string();
 };


### PR DESCRIPTION
- map Reader#getString() method in public API
- fix mapping for Document#getReader()
- add test for getReader().getLines() and getReader().getString()