### PR TITLE
map public properties consistently

### DIFF
--- a/src/asciidoctor-core-api.js
+++ b/src/asciidoctor-core-api.js
@@ -317,7 +317,7 @@ Block.$$proto.getSource = function () {
  * @returns {Array} - returns the String {Array} of source lines for this block.
  */
 Block.$$proto.getSourceLines = function () {
-  return this.$lines();
+  return this.lines;
 };
 
 // AbstractNode API
@@ -386,7 +386,7 @@ AbstractNode.$$proto.removeAttribute = function (name) {
  * @returns {Document} - returns the {@link Document} object to which this node belongs.
  */
 AbstractNode.$$proto.getDocument = function () {
-  return this.$document();
+  return this.document;
 };
 
 /**
@@ -660,14 +660,14 @@ Document.$$proto.hasExtensions = function () {
  * @memberof Document
  */
 Document.$$proto.getDoctype = function () {
-  return this.$doctype();
+  return this.doctype;
 };
 
 /**
  * @memberof Document
  */
 Document.$$proto.getBackend = function () {
-  return this.$backend();
+  return this.backend;
 };
 
 /**
@@ -717,6 +717,11 @@ Document.$$proto.getDoctitle = Document.$$proto.getDocumentTitle;
 Document.$$proto.getCatalog = function () {
   return fromHash(this.catalog);
 };
+
+/**
+ * @memberof Document
+ */
+Document.$$proto.getReferences = Document.$$proto.getCatalog;
 
 /**
  * Get the document revision date from document header (document attribute <code>revdate</code>).
@@ -895,42 +900,35 @@ Document.$$proto.counter = function (name, seed) {
  * @memberof Document
  */
 Document.$$proto.getSafe = function () {
-  return this.$safe;
+  return this.safe;
 };
 
 /**
  * @memberof Document
  */
 Document.$$proto.getCompatMode = function () {
-  return this.$compat_mode;
+  return this.compat_mode;
 };
 
 /**
  * @memberof Document
  */
 Document.$$proto.getSourcemap = function () {
-  return this.$sourcemap;
-};
-
-/**
- * @memberof Document
- */
-Document.$$proto.getReferences = function () {
-  return this.$references;
+  return this.sourcemap;
 };
 
 /**
  * @memberof Document
  */
 Document.$$proto.getCounters = function () {
-  return this.$counters;
+  return this.counters;
 };
 
 /**
  * @memberof Document
  */
 Document.$$proto.getCallouts = function () {
-  return this.$callouts;
+  return this.$callouts();
 };
 
 /**
@@ -944,21 +942,21 @@ Document.$$proto.getBaseDir = function () {
  * @memberof Document
  */
 Document.$$proto.getOptions = function () {
-  return this.$options;
+  return this.options;
 };
 
 /**
  * @memberof Document
  */
 Document.$$proto.getOutfilesuffix = function () {
-  return this.$outfilesuffix;
+  return this.outfilesuffix;
 };
 
 /**
  * @memberof Document
  */
 Document.$$proto.getParentDocument = function () {
-  return this.$parent_document;
+  return this.parent_document;
 };
 
 /**
@@ -972,14 +970,14 @@ Document.$$proto.getReader = function () {
  * @memberof Document
  */
 Document.$$proto.getConverter = function () {
-  return this.$converter;
+  return this.converter;
 };
 
 /**
  * @memberof Document
  */
 Document.$$proto.getExtensions = function () {
-  return this.$extensions;
+  return this.extensions;
 };
 
 // Document.Title API

--- a/src/asciidoctor-core-api.js
+++ b/src/asciidoctor-core-api.js
@@ -921,7 +921,7 @@ Document.$$proto.getSourcemap = function () {
  * @memberof Document
  */
 Document.$$proto.getCounters = function () {
-  return this.counters;
+  return fromHash(this.counters);
 };
 
 /**
@@ -942,7 +942,7 @@ Document.$$proto.getBaseDir = function () {
  * @memberof Document
  */
 Document.$$proto.getOptions = function () {
-  return this.options;
+  return fromHash(this.options);
 };
 
 /**


### PR DESCRIPTION
- remove $ prefix or unnecessary method call