### PR TITLE
add a build:quick task

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:karmaRequirejs": "karma start karma-requirejs.conf.js",
     "test": "node npm/test/builder.js && node npm/test/unsupported-features.js && node npm/test/jasmine-browser.js && node npm/test/jasmine-browser-min.js && node npm/test/jasmine-node.js && node npm/test/jasmine-webpack.js && npm run test:karmaBrowserify && npm run test:karmaRequirejs && node npm/test/nashorn.js",
     "build": "npm run lint && node npm/build.js && npm run test",
+    "build:quick": "npm run code:lint && node npm/build.js && node npm/test/jasmine-node.js",
     "clean": "node npm/clean.js",
     "dist": "cross-env MINIFY=1 node npm/dist.js",
     "lint": "npm run code:lint && npm run docs:lint",


### PR DESCRIPTION
This task is for rapid turnaround when you're working on the API. It does the bare minimum to get some tests running. Good for wip tests (rename it to fit).