### PR TITLE
Update to Opal 0.11.1.dev@ceda559

### DIFF
--- a/lib/asciidoctor/js/opal_ext/uri.rb
+++ b/lib/asciidoctor/js/opal_ext/uri.rb
@@ -2,4 +2,8 @@ module URI
   def self.parse str
     str.extend URI
   end
+
+  def path
+    self
+  end
 end

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "homepage": "https://github.com/asciidoctor/asciidoctor.js",
   "dependencies": {
-    "opal-runtime": "1.0.2"
+    "opal-runtime": "1.0.3"
   },
   "devDependencies": {
     "asciidoctor-docbook.js": "1.5.6-preview.2",
@@ -85,7 +85,7 @@
     "karma-chrome-launcher": "2.2.0",
     "karma-jasmine": "1.1.1",
     "karma-requirejs": "1.1.0",
-    "opal-compiler": "1.0.2",
+    "opal-compiler": "1.0.3",
     "puppeteer": "1.0.0",
     "requirejs": "2.3.5",
     "sinon": "4.2.2",

--- a/spec/share/asciidoctor-include-file.spec.js
+++ b/spec/share/asciidoctor-include-file.spec.js
@@ -8,6 +8,28 @@ var includeFileSpec = function (testOptions, asciidoctor) {
       var html = asciidoctor.convert('include::' + testOptions.baseDir + '/README.adoc[]', opts);
       expect(html).toContain('Asciidoctor.js');
     });
+
+    it('should partially include file with an absolute file URI (using tag)', function () {
+      var opts = {
+        safe: 'safe'
+      };
+      var html = asciidoctor.convert('include::' + testOptions.baseDir + '/spec/share/include-tag.adoc[tag=a]', opts);
+      expect(html).toContain('tag-a');
+      html = asciidoctor.convert('include::' + testOptions.baseDir + '/spec/share/include-tag.adoc[tag=b]', opts);
+      expect(html).toContain('tag-b');
+    });
+
+    it('should partially include file with an absolute file URI (using lines)', function () {
+      var opts = {
+        safe: 'safe'
+      };
+      var html = asciidoctor.convert('include::' + testOptions.baseDir + '/spec/share/include-lines.adoc[lines=1..2]', opts);
+      expect(html).toContain('First line');
+      expect(html).toContain('Second line');
+      html = asciidoctor.convert('include::' + testOptions.baseDir + '/spec/share/include-lines.adoc[lines=3..4]', opts);
+      expect(html).toContain('Third line');
+      expect(html).toContain('Fourth line');
+    });
   });
 };
 

--- a/spec/share/asciidoctor-include-https.spec.js
+++ b/spec/share/asciidoctor-include-https.spec.js
@@ -10,6 +10,32 @@ var includeHttpsSpec = function (testOptions, asciidoctor) {
       expect(html).toContain('Asciidoctor.js');
     });
 
+    it('should partially include file with an absolute https URI (using tag)', function () {
+      var opts = {
+        safe: 'safe',
+        attributes: {'allow-uri-read': true}
+      };
+      // FIXME: Replace by https://raw.githubusercontent.com/asciidoctor/asciidoctor.js/master/spec/share/include-tag.adoc
+      var html = asciidoctor.convert('include::https://gist.githubusercontent.com/Mogztter/abbda92399727ebfb480a93223f0f901/raw/2ab345ec99066bdebc404285fef92a2af01fd2c6/include-tag.adoc[tag=a]', opts);
+      expect(html).toContain('tag-a');
+      html = asciidoctor.convert('include::https://gist.githubusercontent.com/Mogztter/abbda92399727ebfb480a93223f0f901/raw/2ab345ec99066bdebc404285fef92a2af01fd2c6/include-tag.adoc[tag=b]', opts);
+      expect(html).toContain('tag-b');
+    });
+
+    it('should partially include file with an absolute https URI (using lines)', function () {
+      var opts = {
+        safe: 'safe',
+        attributes: {'allow-uri-read': true}
+      };
+      // FIXME: Replace by https://raw.githubusercontent.com/asciidoctor/asciidoctor.js/master/spec/share/include-lines.adoc
+      var html = asciidoctor.convert('include::https://gist.githubusercontent.com/Mogztter/b939a2a8078ec7dd7b5f422898891278/raw/2124d99a15b1b6ac4a23109c6cbc216d87704d81/include-lines.adoc[lines=1..2]', opts);
+      expect(html).toContain('First line');
+      expect(html).toContain('Second line');
+      html = asciidoctor.convert('include::https://gist.githubusercontent.com/Mogztter/b939a2a8078ec7dd7b5f422898891278/raw/2124d99a15b1b6ac4a23109c6cbc216d87704d81/include-lines.adoc[lines=3..4]', opts);
+      expect(html).toContain('Third line');
+      expect(html).toContain('Fourth line');
+    });
+
     it('should include file with an absolute https URI (base_dir is not defined)', function () {
       var opts = {safe: 'safe', attributes: {'allow-uri-read': true}};
       var html = asciidoctor.convert('include::https://raw.githubusercontent.com/HubPress/dev.hubpress.io/gh-pages/README.adoc[]', opts);

--- a/spec/share/include-lines.adoc
+++ b/spec/share/include-lines.adoc
@@ -1,0 +1,4 @@
+First line
+Second line
+Third line
+Fourth line

--- a/spec/share/include-tag.adoc
+++ b/spec/share/include-tag.adoc
@@ -1,0 +1,6 @@
+// tag::a[]
+tag-a
+// end::a[]
+// tag::b[]
+tag-b
+// end::b[]

--- a/yarn.lock
+++ b/yarn.lock
@@ -4761,11 +4761,11 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
-opal-compiler@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/opal-compiler/-/opal-compiler-1.0.2.tgz#b3b91dc538ef1016e755f20d031e5e336c5ee86a"
+opal-compiler@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/opal-compiler/-/opal-compiler-1.0.3.tgz#0fd4af2dc34ca5b5c24918a5e6305da106472350"
   dependencies:
-    opal-runtime "1.0.2+opal.fc20415"
+    opal-runtime "1.0.3"
 
 opal-runtime@0.11.0-integration8:
   version "0.11.0-integration8"
@@ -4773,9 +4773,9 @@ opal-runtime@0.11.0-integration8:
   dependencies:
     glob "6.0.4"
 
-opal-runtime@1.0.2, opal-runtime@1.0.2+opal.fc20415:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/opal-runtime/-/opal-runtime-1.0.2.tgz#dae7669f23943b3f3fbba77b718a7e4977f4af73"
+opal-runtime@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/opal-runtime/-/opal-runtime-1.0.3.tgz#e81e5c2a2568bbb0b05743b427d035dd901485b7"
   dependencies:
     glob "6.0.4"
     xmlhttprequest "1.8.0"


### PR DESCRIPTION
Include directive should now work on `http` and `https` URI (including partial include with tags or lines) in a Node.js environment.

Note: you will need to define the `allow-uri-read` attribute.