### PR TITLE
Use the original hash key when mapping non-string keys to JSON

### DIFF
--- a/spec/share/asciidoctor.spec.js
+++ b/spec/share/asciidoctor.spec.js
@@ -357,6 +357,13 @@ var shareSpec = function (testOptions, asciidoctor) {
         expect(paragraphBlock.getAttribute('bold-statement')).toBe('off');
       });
 
+      it('should hide positional attributes in getAttributes', function () {
+        var doc = asciidoctor.load('[positional1,positional2,attr=value]\ntext');
+        var block = doc.getBlocks()[0];
+        var attributes = block.getAttributes();
+        expect(Object.getOwnPropertyNames(attributes).sort()).toEqual(['attr', 'style'].sort());
+      });
+
       it('should assign sectname, caption, and numeral to appendix section by default', function () {
         var doc = asciidoctor.load('[appendix]\n== Attribute Options\n\nDetails');
         var appendix = doc.getBlocks()[0];

--- a/src/asciidoctor-core-api.js
+++ b/src/asciidoctor-core-api.js
@@ -14,12 +14,7 @@ var fromHash = function (hash) {
   var object = {};
   for (var i = 0, keys = hash.$$keys, data = hash.$$smap, len = keys.length; i < len; i++) {
     var key = keys[i];
-    if ((typeof key === 'object') && ('key' in key)) {
-      object[key.key] = key.value;
-    }
-    else {
-      object[key] = data[key];
-    }
+    object[key] = data[key];
   }
   return object;
 };
@@ -363,7 +358,9 @@ var AbstractNode = Opal.Asciidoctor.AbstractNode;
  * @memberof AbstractNode
  */
 AbstractNode.$$proto.getAttributes = function () {
-  return fromHash(this.attributes);
+  // Do not use fromHash here since we want to keep only entries
+  // whose key is a string. By definition this *is* $$smap
+  return Object.assign({}, this.attributes.$$smap);
 };
 
 /**

--- a/src/asciidoctor-core-api.js
+++ b/src/asciidoctor-core-api.js
@@ -14,7 +14,12 @@ var fromHash = function (hash) {
   var object = {};
   for (var i = 0, keys = hash.$$keys, data = hash.$$smap, len = keys.length; i < len; i++) {
     var key = keys[i];
-    object[key] = data[key];
+    if ((typeof key === 'object') && ('key' in key)) {
+      object[key.key] = key.value;
+    }
+    else {
+      object[key] = data[key];
+    }
   }
   return object;
 };


### PR DESCRIPTION
When a hash key is _not_ a string, the key and the value are stored in an embedded object inside the hash `$$key` array. when converting such hash to a JavaScript object ("JSON"), the original key should be used.

Related to https://github.com/s-leroux/asciidoctor.js-pug/pull/13#issuecomment-386918557

This is required especially when mapping numbers to values in a hash like when using positional arguments in a block attribute list:

```
    > ad = require("./build/asciidoctor.js")()
    > d = ad.load("[positional1, positional2,attr=value]\ntext")

    > d.blocks[0].attributes
    $Hash {
      '$$smap': { attr: 'value', style: 'positional1' },
      '$$map':
       { '3': { key: 1, key_hash: 3, value: 'positional1' },
         '5': { key: 2, key_hash: 5, value: 'positional2' } },
      '$$keys':
       [ { key: 1, key_hash: 3, value: 'positional1' },
         { key: 2, key_hash: 5, value: 'positional2' },
         'attr',
         'style' ],
      '$$none': undefined,
      '$$proc': undefined }

    > d.blocks[0].getAttributes()
    { '1': 'positional1',
      '2': 'positional2',
      attr: 'value',
      style: 'positional1' }
```