### PR TITLE
Resolves #361, Publish only once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,6 @@ before_deploy:
 - >
   if ! [ "$BEFORE_DEPLOY_RUN" ]; then
     export BEFORE_DEPLOY_RUN=1;
-    export ASCIIDOCTOR_CORE_VERSION="${ASCIIDOCTOR_CORE_VERSION_PUBLISH}";
     yarn run dist;
     mkdir bin
     cd dist/;
@@ -49,6 +48,7 @@ deploy:
   email: ${NPM_USER_EMAIL}
   api_key: ${NPM_USER_API_KEY}
   on:
+    condition: '$ASCIIDOCTOR_CORE_VERSION = $ASCIIDOCTOR_CORE_VERSION_PUBLISH'
     tags: true
     repo: asciidoctor/asciidoctor.js
     node: node
@@ -58,6 +58,7 @@ deploy:
   skip_cleanup: true
   file_glob: true
   on:
+    condition: '$ASCIIDOCTOR_CORE_VERSION = $ASCIIDOCTOR_CORE_VERSION_PUBLISH'
     repo: asciidoctor/asciidoctor.js
     tags: true
     node: node


### PR DESCRIPTION
The idea is to publish the release only once.
As you can see with the two links below, Travis tried to publish the release for `ASCIIDOCTOR_CORE_VERSION = 1.5.6` and `ASCIIDOCTOR_CORE_VERSION = master`:

* https://travis-ci.org/asciidoctor/asciidoctor.js/jobs/367669319 (1.5.6)
* https://travis-ci.org/asciidoctor/asciidoctor.js/jobs/367669323 (master)

(search for "Deploying application" in the logs)

Hopefully the environment variables are in the good order, so the first publish (1.5.6) worked and the second publish (master) was denied by `npm`:

```
npm ERR! publish Failed PUT 403
npm ERR! code E403
npm ERR! You cannot publish over the previously published versions: 1.5.6. : asciidoctor.js
```


I've added a condition to make sure that `deploy` only occurs when `ASCIIDOCTOR_CORE_VERSION_PUBLISH` equals `ASCIIDOCTOR_CORE_VERSION`.

@ldez I've added you as a reviewer for your expertise :wink: