### PR TITLE
The "user manual" is now published on Netlify

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -8,7 +8,7 @@ Dan Allen <https://github.com/mojavelinux[@mojavelinux]>; Guillaume Grossetie <h
 :uri-freesoftware: https://www.gnu.org/philosophy/free-sw.html
 ifndef::uri-rel-file-base[:uri-rel-file-base: link:]
 :uri-contribute: {uri-rel-file-base}CONTRIBUTING.adoc
-:uri-user-manual: {uri-rel-file-base}/docs/manual.adoc
+:uri-user-manual: https://asciidoctor-docs.netlify.com/asciidoctor.js/
 :license: {uri-repo}/blob/master/LICENSE
 :experimental:
 :endash:


### PR DESCRIPTION
The documentation available on Netlify is now more complete than the file `docs/manual.adoc`