### PR TITLE
Map AbstractNode#getNodeName in the API

### DIFF
--- a/spec/node/asciidoctor.spec.js
+++ b/spec/node/asciidoctor.spec.js
@@ -369,6 +369,7 @@ intro
       expect(blocks[1].getContext()).to.equal('section');
       expect(blocks[1].getBlocks().length).to.equal(5);
 
+      expect(blocks[1].getBlocks()[1].getNodeName()).to.equal('quote');
       expect(blocks[1].getBlocks()[1].hasTitle()).to.be.true;
       expect(blocks[1].getBlocks()[1].getId()).to.equal('blockid');
       expect(blocks[1].getBlocks()[1].getStyle()).to.equal('quote');
@@ -376,6 +377,7 @@ intro
       expect(blocks[1].getBlocks()[1].getSourceLines()).to.have.members(['This is a quote.', 'It has a title, id, and attribution.']);
       expect(blocks[1].getBlocks()[1].getSource()).to.equal('This is a quote.\nIt has a title, id, and attribution.');
 
+      expect(blocks[1].getBlocks()[2].getNodeName()).to.equal('ulist');
       expect(blocks[1].getBlocks()[2].hasTitle()).to.be.false;
       expect(blocks[1].getBlocks()[2].getContext()).to.equal('ulist');
       expect(blocks[1].getBlocks()[2].getRole()).to.equal('feature-list');
@@ -387,6 +389,7 @@ intro
       expect(blocks[2].getTitle()).to.equal('Second Section');
       expect(blocks[2].getBlocks().length).to.equal(3);
 
+      expect(blocks[2].getBlocks()[0].getNodeName()).to.equal('image');
       expect(blocks[2].getBlocks()[0].hasTitle()).to.be.false;
       expect(blocks[2].getBlocks()[0].getContext()).to.equal('image');
       expect(blocks[2].getBlocks()[0].getTitle()).to.be.undefined;

--- a/spec/share/asciidoctor-spec.js
+++ b/spec/share/asciidoctor-spec.js
@@ -386,6 +386,7 @@ const shareSpec = function (testOptions, asciidoctor, expect) {
       it('should assign sectname, caption, and numeral to appendix section by default', function () {
         const doc = asciidoctor.load('[appendix]\n== Attribute Options\n\nDetails');
         const appendix = doc.getBlocks()[0];
+        expect(appendix.getNodeName()).to.equal('section');
         expect(appendix.getSectionName()).to.equal('appendix');
         expect(appendix.getCaption()).to.equal('Appendix A: ');
         expect(appendix.getCaptionedTitle()).to.equal('Appendix A: Attribute Options');
@@ -431,6 +432,7 @@ const shareSpec = function (testOptions, asciidoctor, expect) {
         expect(doc.hasSections()).to.equal(true);
         expect(doc.getSections().length).to.equal(4);
         const firstSection = doc.getSections()[0];
+        expect(firstSection.getNodeName()).to.equal('section');
         expect(firstSection.getIndex()).to.equal(0);
         expect(firstSection.getName()).to.equal('First section');
         expect(firstSection.getTitle()).to.equal('First section');

--- a/src/asciidoctor-core-api.js
+++ b/src/asciidoctor-core-api.js
@@ -628,6 +628,13 @@ var AbstractNode = Opal.Asciidoctor.AbstractNode;
 /**
  * @memberof AbstractNode
  */
+AbstractNode.prototype.getNodeName = function () {
+  return this.node_name;
+};
+
+/**
+ * @memberof AbstractNode
+ */
 AbstractNode.prototype.getAttributes = function () {
   return fromHash(this.attributes);
 };


### PR DESCRIPTION
//cc @oncletom I've noticed that you are using `getParent().node_name` in https://github.com/oncletom/asciidoctor-converter-opendocument