### PR TITLE
Map Converter.Factory#register in the API

### DIFF
--- a/spec/node/asciidoctor.spec.js
+++ b/spec/node/asciidoctor.spec.js
@@ -1137,11 +1137,7 @@ header_attribute::foo[bar]`;
 
     it('should register a custom converter', () => {
       class DummyConverter {
-        constructor (backend, opts) {
-          this.basebackend = 'xml';
-          this.outfilesuffix = '.dummy';
-          this.filetype = 'xml';
-          this.htmlsyntax = 'xml';
+        constructor () {
           this.transforms = {
             document: ({node}) => {
               return `<dummy>${node.getContent()}</dummy>`;
@@ -1152,11 +1148,11 @@ header_attribute::foo[bar]`;
           };
         }
 
-        $convert (node, transform = null, opts = {}) {
+        convert (node, transform = null, opts = {}) {
           return this.transforms[node.node_name]({node});
         }
       }
-      asciidoctor.ConverterFactory.$register(new DummyConverter('dummy'), ['dummy']);
+      asciidoctor.ConverterFactory.register(new DummyConverter(), ['dummy']);
       const options = { safe: 'safe', backend: 'dummy' };
       const result = asciidoctor.convert('content', options);
       expect(result).to.contain('<dummy>content</dummy>');

--- a/src/asciidoctor-extensions-api.js
+++ b/src/asciidoctor-extensions-api.js
@@ -754,6 +754,21 @@ var ConverterFactory = Opal.Asciidoctor.Converter.Factory;
 // Alias
 Opal.Asciidoctor.ConverterFactory = ConverterFactory;
 
+/**
+ * Register a custom converter in the global converter factory to handle conversion to the specified backends.
+ * If the backend value is an asterisk, the converter is used to handle any backend that does not have an explicit converter.
+ *
+ * @param converter - The Converter instance to register
+ * @param backends {Array} - A {string} {Array} of backend names that this converter should be registered to handle (optional, default: ['*'])
+ * @return {*} - Returns nothing
+ * @memberof Converter/Factory
+ */
+ConverterFactory.register = function (converter, backends) {
+  if (typeof converter === 'object' && typeof converter.$convert === 'undefined' && typeof converter.convert === 'function') {
+    Opal.def(converter, '$convert', converter.convert);
+  }
+  return this.$register(converter, backends);
+};
 
 /**
  * Retrieves the singleton instance of the converter factory.


### PR DESCRIPTION
@oncletom You should be able to remove the `$` prefix in https://github.com/oncletom/asciidoctor-converter-opendocument/blob/master/index.js

Also I think that you can (for now) safely remove the constructor arguments and assignments. I need to find a solution to pass these arguments. Currently I believe that they are ignored.