### PR TITLE
Resolves #653, provide an implementation for Kernel#sprintf

### DIFF
--- a/lib/asciidoctor/js/asciidoctor_ext.rb
+++ b/lib/asciidoctor/js/asciidoctor_ext.rb
@@ -1,4 +1,5 @@
 require 'asciidoctor/js/asciidoctor_ext/stylesheet'
+require 'asciidoctor/js/asciidoctor_ext/substitutors'
 
 %x(
 // Load specific runtime

--- a/lib/asciidoctor/js/asciidoctor_ext/substitutors.rb
+++ b/lib/asciidoctor/js/asciidoctor_ext/substitutors.rb
@@ -1,0 +1,8 @@
+module Asciidoctor
+module Substitutors
+  # Avoid using Kernel#sprintf for performance and bundle size reasons
+  def sub_placeholder format_string, replacement
+    `format_string.replace('%s', replacement)`
+  end
+end
+end


### PR DESCRIPTION
Allow to remove Kernel#sprintf (alias #format).