### PR TITLE
Add the project name, version and license in the browser file

### DIFF
--- a/packages/core/tasks/module/builder.js
+++ b/packages/core/tasks/module/builder.js
@@ -96,7 +96,18 @@ const generateFlavors = (asciidoctorCoreTarget, environments) => {
     }
     templateModel['//{{asciidoctorCode}}'] = asciidoctorData
     const content = parseTemplateFile(templateFile, templateModel)
-    fs.writeFileSync(target, content, 'utf8')
+    if (environment === 'browser') {
+      const header = `/**
+ * @license Asciidoctor.js ${packageJson.version} | MIT | https://github.com/asciidoctor/asciidoctor.js
+ */
+`
+      const buffers = []
+      buffers.push(Buffer.from(header, 'utf8'))
+      buffers.push(Buffer.from(content, 'utf8'))
+      fs.writeFileSync(target, Buffer.concat(buffers), 'utf8')
+    } else {
+      fs.writeFileSync(target, content, 'utf8')
+    }
   })
 }
 


### PR DESCRIPTION
As suggested by @ainslec.
Google Clojure compiler preserves the `@license` tag, so the unminifed file will contain:

```
/**
 * @license Asciidoctor.js 2.0.0 | MIT - https://github.com/asciidoctor/asciidoctor.js/blob/master/LICENSE
 */
```

And the minified file will contain:

```
/*
 Asciidoctor.js 2.0.0 | MIT - https://github.com/asciidoctor/asciidoctor.js/blob/master/LICENSE
*/
```

I think it's important to add the project name and version. Wdyt ?