### PR TITLE
resolves #754 test multiple single-item menu macros in single line

### DIFF
--- a/packages/core/spec/share/asciidoctor-spec.js
+++ b/packages/core/spec/share/asciidoctor-spec.js
@@ -918,6 +918,11 @@ stem:normal[\\\\sqrt{{value}} = 2 \\]]`
         expect(html).to.include('<p>\\$\\\\sqrt{4} = 2 ]\\$</p>')
       })
 
+      it('should process multiple single-item menu macros in single line', function () {
+        const html = asciidoctor.convert('Click menu:File[] and menu:Edit[]', { doctype: 'inline', attributes: { experimental: '' } })
+        expect(html).to.include('Click <b class="menuref">File</b> and <b class="menuref">Edit</b>')
+      })
+
       if (getCoreVersionNumber(asciidoctor) >= '208') {
         it('should embed an SVG with a width (but no height)', function () {
           const options = { safe: 'safe', attributes: { 'allow-uri-read': true } }


### PR DESCRIPTION
The test should pass once https://github.com/asciidoctor/asciidoctor/pull/3435 is merged.
To test locally:

1. Go to `core` package directory:
```
$ cd packages/core
```

2. Make sure your working copy is clean:
```
$ npm run clean
```

3. Build and test:
```
$ ASCIIDOCTOR_CORE_VERSION=mojavelinux/asciidoctor#issue-3433-remove-errant-optional-flag-in-regexp npm run build && npm t
```

resolves #754