### PR TITLE
resolves #768 initialize backend traits

### DIFF
--- a/packages/core/spec/node/asciidoctor.spec.js
+++ b/packages/core/spec/node/asciidoctor.spec.js
@@ -1723,6 +1723,82 @@ header_attribute::foo[bar]`
       const result = asciidoctor.convert('content', options)
       expect(result).to.contain('<dummy>content</dummy>')
     })
+    it('should retrieve backend traits from a converter class', () => {
+      class TEIConverter {
+        constructor (backend, _) {
+          this.backend = backend
+          this.backendTraits = {
+            basebackend: 'xml',
+            outfilesuffix: '.xml',
+            filetype: 'xml',
+            htmlsyntax: 'xml'
+          }
+          this.transforms = {
+            embedded: (node) => {
+              return `<tei>${node.getContent()}</tei>`
+            }
+          }
+        }
+
+        convert (node, transform) {
+          const name = transform || node.node_name
+          if (name === 'paragraph') {
+            return this.convertParagraph(node)
+          }
+          return this.transforms[name](node)
+        }
+
+        convertParagraph (node) {
+          return node.getContent()
+        }
+      }
+
+      asciidoctor.ConverterFactory.register(TEIConverter, ['tei'])
+      const doc = asciidoctor.load('content', { safe: 'safe', backend: 'tei' })
+      expect(doc.getAttribute('basebackend')).to.equal('xml')
+      expect(doc.getAttribute('outfilesuffix')).to.equal('.xml')
+      expect(doc.getAttribute('filetype')).to.equal('xml')
+      expect(doc.getAttribute('htmlsyntax')).to.equal('xml')
+      const result = doc.convert()
+      expect(result).to.contain('<tei>content</tei>')
+    })
+    it('should retrieve backend traits from a converter instance', () => {
+      class TEIConverter {
+        constructor () {
+          this.backend = 'tei'
+          this.basebackend = 'xml'
+          this.outfilesuffix = '.xml'
+          this.filetype = 'xml'
+          this.htmlsyntax = 'xml'
+          this.transforms = {
+            embedded: (node) => {
+              return `<tei>${node.getContent()}</tei>`
+            }
+          }
+        }
+
+        convert (node, transform) {
+          const name = transform || node.node_name
+          if (name === 'paragraph') {
+            return this.convertParagraph(node)
+          }
+          return this.transforms[name](node)
+        }
+
+        convertParagraph (node) {
+          return node.getContent()
+        }
+      }
+
+      asciidoctor.ConverterFactory.register(new TEIConverter(), ['tei'])
+      const doc = asciidoctor.load('content', { safe: 'safe', backend: 'tei' })
+      expect(doc.getAttribute('basebackend')).to.equal('xml')
+      expect(doc.getAttribute('outfilesuffix')).to.equal('.xml')
+      expect(doc.getAttribute('filetype')).to.equal('xml')
+      expect(doc.getAttribute('htmlsyntax')).to.equal('xml')
+      const result = doc.convert()
+      expect(result).to.contain('<tei>content</tei>')
+    })
     it('should register a custom converter (fallback to the built-in HTML5 converter)', () => {
       class BlogConverter {
         constructor () {

--- a/packages/core/src/asciidoctor-extensions-api.js
+++ b/packages/core/src/asciidoctor-extensions-api.js
@@ -1015,8 +1015,15 @@ Converter.create = function (backend, opts) {
  */
 var ConverterFactory = Opal.Asciidoctor.Converter.Factory
 
+var ConverterBase = Opal.Asciidoctor.Converter.Base
+
 // Alias
 Opal.Asciidoctor.ConverterFactory = ConverterFactory
+
+var ConverterBackendTraits = Opal.Asciidoctor.Converter.BackendTraits
+
+// Alias
+Opal.Asciidoctor.ConverterBackendTraits = ConverterBackendTraits
 
 /**
  * Register a custom converter in the global converter factory to handle conversion to the specified backends.
@@ -1028,10 +1035,68 @@ Opal.Asciidoctor.ConverterFactory = ConverterFactory
  * @memberof Converter/Factory
  */
 ConverterFactory.register = function (converter, backends) {
-  if (typeof converter === 'object' && typeof converter.$convert === 'undefined' && typeof converter.convert === 'function') {
-    Opal.def(converter, '$convert', converter.convert)
+  var object
+  const buildBackendTraitsFromInstance = instance => ({
+    ...instance.basebackend && { basebackend: instance.basebackend },
+    ...instance.outfilesuffix && { outfilesuffix: instance.outfilesuffix },
+    ...instance.filetype && { filetype: instance.filetype },
+    ...instance.htmlsyntax && { htmlsyntax: instance.htmlsyntax },
+    ...instance.supports_templates && { supports_templates: instance.supports_templates }
+  })
+  if (typeof converter === 'function') {
+    // Class
+    object = initializeClass(ConverterBase, converter.constructor.name, {
+      'initialize': function (backend, opts) {
+        var self = this
+        var result = new converter(backend, opts) // eslint-disable-line
+        Object.assign(this, result)
+        if (result.backend_traits) {
+          self.backend_traits = toHash(result.backend_traits)
+        } else if (result.backendTraits) {
+          self.backend_traits = toHash(result.backendTraits)
+        } else if (result.basebackend || result.outfilesuffix || result.filetype || result.htmlsyntax || result.supports_templates) {
+          self.$init_backend_traits(toHash(buildBackendTraitsFromInstance(result)))
+        }
+        var propertyNames = Object.getOwnPropertyNames(converter.prototype)
+        for (var i = 0; i < propertyNames.length; i++) {
+          var propertyName = propertyNames[i]
+          if (propertyName !== 'constructor') {
+            self[propertyName] = result[propertyName]
+          }
+        }
+        if (typeof result.$convert === 'undefined' && typeof result.convert === 'function') {
+          self.$convert = result.convert
+        }
+        self.super(backend, opts)
+      }
+    })
+    object.$extend(ConverterBackendTraits)
+  } else if (typeof converter === 'object') {
+    // Instance
+    if (typeof converter.$convert === 'undefined' && typeof converter.convert === 'function') {
+      converter.$convert = converter.convert
+    }
+    if (converter.basebackend || converter.outfilesuffix || converter.filetype || converter.htmlsyntax || converter.supports_templates) {
+      // "extends" ConverterBackendTraits
+      converter.backend_traits = toHash(buildBackendTraitsFromInstance(converter))
+      var converterBackendTraitsFunctionNames = [
+        'basebackend',
+        'filetype',
+        'htmlsyntax',
+        'outfilesuffix',
+        'supports_templates',
+        'supports_templates?',
+        'init_backend_traits',
+        'backend_traits'
+      ]
+      for (var functionName of converterBackendTraitsFunctionNames) {
+        converter['$' + functionName] = ConverterBackendTraits.prototype['$' + functionName]
+      }
+      converter.$$meta = ConverterBackendTraits
+    }
+    object = converter
   }
-  var args = [converter].concat(backends)
+  var args = [object].concat(backends)
   return Converter.$register.apply(Converter, args)
 }
 


### PR DESCRIPTION
The goal is to bridge the Asciidoctor (Ruby) module named `BackendTraits` in a pure JavaScript class or instance.

The main benefit is that the user doesn't have to manipulate the `Opal` object in order to create a class but it has a few downsides.
Most notably, when using the `constructor` because the class is not yet bridged to the `Converter::Base` (Ruby) class.
So you can't use `super` or call the method `init_backend_traits`.


resolves #768