### PR TITLE
Fix the Processor#resolvesAttributes function

### DIFF
--- a/packages/core/spec/node/asciidoctor.spec.js
+++ b/packages/core/spec/node/asciidoctor.spec.js
@@ -1437,30 +1437,84 @@ header_attribute::foo[bar]`
           expect(doc.getAttribute('foo')).to.equal('bar')
         })
 
-        it('should resolve multiple attributes', () => {
-          const registry = asciidoctor.Extensions.create(function () {
-            this.inlineMacro('deg', function () {
-              this.resolveAttributes('1:units', 'precision=1')
-              this.process(function (parent, target, attributes) {
-                const units = attributes['units'] || (parent.getDocument().getAttribute('temperature-unit', 'C'))
-                const precision = parseInt(attributes['precision'])
-                const c = parseFloat(target)
-                if (units === 'C') {
-                  return this.createInline(parent, 'quoted', `${c.toFixed(precision).toString()} &#176;C`, { type: 'unquoted' })
-                } else if (units === 'F') {
-                  return this.createInline(parent, 'quoted', `${(c * 1.8 + 32).toFixed(precision).toString()} &#176;F`, { type: 'unquoted' })
-                } else {
-                  throw new Error(`Unknown temperature units: ${units}`)
-                }
+        describe('Resolve attributes', () => {
+          // resolve attributes according to the specification
+          function itShouldResolveAttributes (when, ...args) {
+            it(`should resolve attributes when ${when}`, () => {
+              const registry = asciidoctor.Extensions.create(function () {
+                this.inlineMacro('deg', function () {
+                  if (args.length > 1) {
+                    this.resolveAttributes(...args)
+                  } else {
+                    this.resolveAttributes(args[0])
+                  }
+                  this.process(function (parent, target, attributes) {
+                    const units = attributes['units'] || (parent.getDocument().getAttribute('temperature-unit', 'C'))
+                    const precision = parseInt(attributes['precision'])
+                    const c = parseFloat(target)
+                    if (units === 'C') {
+                      return this.createInline(parent, 'quoted', `${c.toFixed(precision).toString()} &#176;C`, { type: 'unquoted' })
+                    } else if (units === 'F') {
+                      return this.createInline(parent, 'quoted', `${(c * 1.8 + 32).toFixed(precision).toString()} &#176;F`, { type: 'unquoted' })
+                    } else {
+                      throw new Error(`Unknown temperature units: ${units}`)
+                    }
+                  })
+                })
               })
-            })
-          })
-          const opts = { extension_registry: registry, attributes: { 'temperature-unit': 'F' } }
-          let html = asciidoctor.convert('Room temperature is deg:25[C,precision=0].', opts)
-          expect(html).to.contain('Room temperature is 25 &#176;C.')
+              const opts = { extension_registry: registry, attributes: { 'temperature-unit': 'F' } }
+              let html = asciidoctor.convert('Room temperature is deg:25[C,precision=0].', opts)
+              expect(html).to.contain('Room temperature is 25 &#176;C.')
 
-          html = asciidoctor.convert('Normal body temperature is deg:37[].', opts)
-          expect(html).to.contain('Normal body temperature is 98.6 &#176;F.')
+              html = asciidoctor.convert('Normal body temperature is deg:37[].', opts)
+              expect(html).to.contain('Normal body temperature is 98.6 &#176;F.')
+            })
+          }
+          itShouldResolveAttributes('using a list of arguments as a specification', '1:units', 'precision=1')
+          itShouldResolveAttributes('using an array as a specification', ['1:units', 'precision=1'])
+          itShouldResolveAttributes('using a JSON as a specification', { '1:units': undefined, 'precision': 1 })
+
+          // resolve attributes as text
+          function itShouldResolveAttributesAsText (when, arg) {
+            it(`should resolve attributes as text when ${when}`, () => {
+              const registry = asciidoctor.Extensions.create(function () {
+                this.inlineMacro('attr', function () {
+                  this.matchFormat('short')
+                  this.resolveAttributes(arg)
+                  this.process(function (parent, target, attributes) {
+                    console.log(attributes)
+                    return this.createInline(parent, 'quoted', `${attributes.text}`, { type: 'unquoted' })
+                  })
+                })
+              })
+              const opts = { extension_registry: registry }
+              let html = asciidoctor.convert('attr:[C,precision=0].', opts)
+              expect(html).to.contain('C,precision=0.')
+            })
+          }
+          itShouldResolveAttributesAsText('using false as a specification', false)
+          itShouldResolveAttributesAsText('using undefined as a specification', undefined)
+
+          // resolve named attributes (only)
+          function itShouldResolveNamedAttributes (when, arg) {
+            it(`should resolve named attributes when ${when}`, () => {
+              const registry = asciidoctor.Extensions.create(function () {
+                this.inlineMacro('attr', function () {
+                  this.matchFormat('short')
+                  this.resolveAttributes(arg)
+                  this.process(function (parent, target, attributes) {
+                    console.log(attributes)
+                    return this.createInline(parent, 'quoted', `precision is ${attributes.precision}`, { type: 'unquoted' })
+                  })
+                })
+              })
+              const opts = { extension_registry: registry }
+              let html = asciidoctor.convert('attr:[C,precision=0].', opts)
+              expect(html).to.contain('precision is 0.')
+            })
+          }
+          itShouldResolveNamedAttributes('using empty as a specification', '')
+          itShouldResolveNamedAttributes('using true as a specification', true)
         })
       })
 
@@ -1763,6 +1817,7 @@ header_attribute::foo[bar]`
           return node.getContent()
         }
       }
+
       asciidoctor.ConverterFactory.register(new DelegateConverter(), ['delegate'])
       const options = { safe: 'safe', backend: 'delegate' }
       const result = asciidoctor.convert('content', options)

--- a/packages/core/spec/node/asciidoctor.spec.js
+++ b/packages/core/spec/node/asciidoctor.spec.js
@@ -1817,7 +1817,6 @@ header_attribute::foo[bar]`
           return node.getContent()
         }
       }
-
       asciidoctor.ConverterFactory.register(new DelegateConverter(), ['delegate'])
       const options = { safe: 'safe', backend: 'delegate' }
       const result = asciidoctor.convert('content', options)

--- a/packages/core/spec/node/asciidoctor.spec.js
+++ b/packages/core/spec/node/asciidoctor.spec.js
@@ -1440,7 +1440,7 @@ header_attribute::foo[bar]`
         it('should resolve multiple attributes', () => {
           const registry = asciidoctor.Extensions.create(function () {
             this.inlineMacro('deg', function () {
-              this.resolvesAttributes('1:units', 'precision=1')
+              this.resolveAttributes('1:units', 'precision=1')
               this.process(function (parent, target, attributes) {
                 const units = attributes['units'] || (parent.getDocument().getAttribute('temperature-unit', 'C'))
                 const precision = parseInt(attributes['precision'])

--- a/packages/core/src/asciidoctor-extensions-api.js
+++ b/packages/core/src/asciidoctor-extensions-api.js
@@ -571,7 +571,7 @@ Processor.prototype.positionalAttributes = function (value) {
  * @memberof Extensions/Processor
  */
 Processor.prototype.resolvesAttributes = function (args) {
-  return this.$resolves_attributes(args)
+  return this.$resolves_attributes(Array.prototype.slice.call(arguments))
 }
 
 /**

--- a/packages/core/src/asciidoctor-extensions-api.js
+++ b/packages/core/src/asciidoctor-extensions-api.js
@@ -581,6 +581,12 @@ Processor.prototype.resolveAttributes = function (value) {
     return this.$resolves_attributes(Array.prototype.slice.call(arguments))
   }
   if (typeof value === 'undefined') {
+    // Convert to nil otherwise an exception is thrown at:
+    // https://github.com/asciidoctor/asciidoctor/blob/0bcb4addc17b307f62975aad203fb556a1bcd8a5/lib/asciidoctor/extensions.rb#L583
+    //
+    // if args.size == 1 && !args[0]
+    //
+    // In the above Ruby code, args[0] is undefined and Opal will try to call the function "!" on an undefined object.
     return this.$resolves_attributes(Opal.nil)
   }
   return this.$resolves_attributes(value)

--- a/packages/core/src/asciidoctor-extensions-api.js
+++ b/packages/core/src/asciidoctor-extensions-api.js
@@ -568,14 +568,26 @@ Processor.prototype.positionalAttributes = function (value) {
 }
 
 /**
+ * Specify how to resolve attributes.
+ *
+ * @param {string|Array<string>|Object|boolean} [value] - A specification to resolve attributes.
  * @memberof Extensions/Processor
  */
-Processor.prototype.resolveAttributes = function (args) {
-  return this.$resolves_attributes(Array.prototype.slice.call(arguments))
+Processor.prototype.resolveAttributes = function (value) {
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    return this.$resolves_attributes(toHash(value))
+  }
+  if (arguments.length > 1) {
+    return this.$resolves_attributes(Array.prototype.slice.call(arguments))
+  }
+  if (typeof value === 'undefined') {
+    return this.$resolves_attributes(Opal.nil)
+  }
+  return this.$resolves_attributes(value)
 }
 
 /**
- * @deprecated Please use {Processor#resolveAttributes}.
+ * @deprecated Please use the <code>resolveAttributes</pre> function on the {@link Extensions/Processor}.
  * @memberof Extensions/Processor
  * @see {Processor#resolveAttributes}
  */

--- a/packages/core/src/asciidoctor-extensions-api.js
+++ b/packages/core/src/asciidoctor-extensions-api.js
@@ -570,9 +570,16 @@ Processor.prototype.positionalAttributes = function (value) {
 /**
  * @memberof Extensions/Processor
  */
-Processor.prototype.resolvesAttributes = function (args) {
+Processor.prototype.resolveAttributes = function (args) {
   return this.$resolves_attributes(Array.prototype.slice.call(arguments))
 }
+
+/**
+ * @deprecated Please use {Processor#resolveAttributes}.
+ * @memberof Extensions/Processor
+ * @see {Processor#resolveAttributes}
+ */
+Processor.prototype.resolvesAttributes = Processor.prototype.resolveAttributes
 
 /**
  * @namespace


### PR DESCRIPTION
- `resolvesAttributes` is now deprecated (in favor of `resolveAttributes`)
- `resolveAttributes` can take multiple arguments
- `resolveAttributes` argument can be
  * a String
  * a list of String (either as an Array or as a list of arguments)
  * a boolean
  * undefined
  * a JSON object

I think we should document the format in the Asciidoctor core API.
