### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,77 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v2.1.3
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Install dependencies
+        run: |
+          npm ci
+          npm ci --prefix packages/core
+      - name: Lint, build and test
+        env:
+          ASCIIDOCTOR_CORE_VERSION: v2.0.9
+        run: |
+          npm run lint
+          npm t
+          npm run travis --prefix packages/core
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+          registry-url: https://registry.npmjs.org/
+      # install dependencies
+      - name: Install dependencies
+        run: |
+          npm ci
+          npm ci --prefix packages/core
+      # package and publish
+      - name: Package and publish
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          ./scripts/package.sh
+          ./scripts/publish.sh
+      # create the GitHub release
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          draft: false
+          prerelease: false
+      # upload assets
+      - name: Upload source code as a zip file
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: packages/core/bin/asciidoctor.js.dist.zip
+          asset_name: asciidoctor.js.dist.zip
+          asset_content_type: application/zip
+      - name: Upload source code as a tar.gz file
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: packages/core/bin/asciidoctor.js.dist.tar.gz
+          asset_name: asciidoctor.js.dist.tar.gz
+          asset_content_type: application/tar+gzip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           npm ci --prefix packages/core
       - name: Lint, build and test
         env:
-          ASCIIDOCTOR_CORE_VERSION: v2.0.9
+          ASCIIDOCTOR_CORE_VERSION: v2.0.10
         run: |
           npm run lint
           npm t


### PR DESCRIPTION
- [x] Perform the release on tag
- [x] Notify asciidoctor/docs.asciidoctor.org via Netlify when something is pushed on master branch (documentation)

Should we run everything in GitHub Actions (ie. replace Travis AND AppVeyor)?