### PR TITLE
Add ES interop (for TypeScript)

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -154,6 +154,7 @@ registry.inlineMacro('package', function () {
 * Map `Asciidoctor.Callouts` (#814)
 * Map `Processor.parseAttributes` (#815)
 * Upgrade `@asciidoctor/cli` in the `asciidoctor` package to 3.1.1 (#820)
+* Add ES module interoperability when using TypeScript (#821)
 
 Infrastructure::
 

--- a/packages/core/src/template-asciidoctor-node.js
+++ b/packages/core/src/template-asciidoctor-node.js
@@ -4,6 +4,8 @@ const Opal = require('asciidoctor-opal-runtime').Opal
 // Node module
 ;(function (root, factory) {
   module.exports = factory
+  // default export for ES6 module interop
+  module.exports.default = factory
 }(this, function (moduleConfig) {
 //{{asciidoctorCode}}
 


### PR DESCRIPTION
Otherwise the following code won't compile out-of-the-box with `tsc`:
```ts
import asciidoctor from "@asciidoctor/core"
const processor = asciidoctor()
```