### PR TITLE
Add GitHub actions to build and notify

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version:
+          - 12.x
+          - 13.x
+        asciidoctor-core-version: [v2.0.10, master]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Node ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install dependencies
+      run: |
+        npm ci
+        npm ci --prefix packages/core
+    - name: Lint, build and test
+      env:
+        ASCIIDOCTOR_CORE_VERSION: ${{ matrix.asciidoctor-core-version }}
+      run: |
+        npm run lint
+        npm run test
+        npm run travis --prefix packages/core

--- a/.github/workflows/documentation-notify.yml
+++ b/.github/workflows/documentation-notify.yml
@@ -1,0 +1,16 @@
+name: Documentation notify
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Notify Netlify
+        env:
+          NETLIFY_WEBHOOK_URL: ${{ secrets.NETLIFY_WEBHOOK_URL }}
+        run: ./scripts/notify.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,3 @@ jobs:
           file_glob: true
           on:
             tags: true
-    - stage: notify
-      if: |
-        repo = 'asciidoctor/asciidoctor.js' AND \
-        branch = master AND \
-        type = 'push'
-      script: ./scripts/notify.sh

--- a/scripts/notify.sh
+++ b/scripts/notify.sh
@@ -4,5 +4,5 @@
 set -e
 
 # Trigger a deployment on asciidoctor/docs.asciidoctor.org (using Netlify webhook).
-# The variable "NETLIFY_WEBHOOK_URL" is defined on Travis.
+# The variable "NETLIFY_WEBHOOK_URL" is defined on Travis/GitHub.
 curl -X POST -d '' "$NETLIFY_WEBHOOK_URL"


### PR DESCRIPTION
To make the transition as smooth as possible, I plan to do the following:

1. Build the project on both GitHub Actions AND Travis + AppVeyor. The release is still performed by Travis.
1. Build the project on GitHub Actions only. The release is still performed by Travis.
1. Build and release the project on GitHub Actions.

This pull request is the first step.