### PR TITLE
Test types against the built file (not the dist file)

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@asciidoctor/core",
-  "version": "2.0.3",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -96,6 +96,6 @@
     ]
   },
   "_moduleAliases": {
-    "@asciidoctor/core": "dist/node/asciidoctor.js"
+    "@asciidoctor/core": "build/asciidoctor-node.js"
   }
 }


### PR DESCRIPTION
Otherwise `npm run build` can fail.