### PR TITLE
 Replace header_footer option with standalone

### DIFF
--- a/docs/modules/extend/pages/converter/custom-converter.adoc
+++ b/docs/modules/extend/pages/converter/custom-converter.adoc
@@ -48,7 +48,7 @@ class CustomConverter {
 <1> `node` is a node that extends {uri-abstractnode-jsdoc}[AbstractNode].
 <2> `transform` will only be defined when the node is a {uri-document-jsdoc}[Document]. +
 The value will be equals to `embedded` if we convert to an embeddable document,
-or `document` if we convert to a standalone document (ie. `header_footer` is equals to `true`).
+or `document` if we convert to a standalone document (ie. `standalone` is equals to `true`).
 
 To register a custom converter we can use the function `register` on the `ConverterFactory`:
 

--- a/docs/modules/processor/pages/convert-options.adoc
+++ b/docs/modules/processor/pages/convert-options.adoc
@@ -43,11 +43,6 @@ Instead of providing a JavaScript function containing extensions to register, th
 |_not set_
 |`Extensions.Registry` instance
 
-|header_footer
-|If true, add the document header and footer (i.e., framing) around the body content in the output.
-|false
-|_boolean_
-
 |mkdirs
 |If true, the processor will create the necessary output directories if they don't yet exist.
 |false
@@ -66,6 +61,11 @@ Instead of providing a JavaScript function containing extensions to register, th
 |sourcemap
 |Keeps track of the file and line number for each parsed block.
  (Useful for tooling applications where the association between the converted output and the source file is important).
+|false
+|_boolean_
+
+|standalone
+|If true, add the document header and footer (i.e., framing) around the body content in the output.
 |false
 |_boolean_
 

--- a/docs/modules/setup/pages/install.adoc
+++ b/docs/modules/setup/pages/install.adoc
@@ -23,7 +23,7 @@ See below for a link to the right one and instructions on how to use it.
 
 == Basic browser setup
 
-Just include Asciidoctor.js in a script tag.
+Include Asciidoctor.js in a `<script>` tag.
 You can instantiate the processor using the `Asciidoctor` global variable.
 
 ```html

--- a/docs/modules/setup/pages/quick-tour.adoc
+++ b/docs/modules/setup/pages/quick-tour.adoc
@@ -25,10 +25,10 @@ console.log(html)
 [NOTE]
 ====
 When converting a string, the header and footer are excluded by default to make Asciidoctor consistent with other lightweight markup engines like Markdown.
-If you want the header and footer, just enable it using the `header_footer` option:
+If you want to produce a standalone document, just enable it using the `standalone` option:
 
 ```js
-var html = asciidoctor.convert('*This* is Asciidoctor.', { 'header_footer': true })
+var html = asciidoctor.convert('*This* is Asciidoctor.', { standalone: true })
 ```
 ====
 
@@ -43,7 +43,7 @@ The variable `doc` will contain an {uri-js-api-doc}/#document[Asciidoctor.Docume
 Alternatively, you can capture the HTML 5 output in a variable instead of writing it to a file:
 
 ```js
-var html = asciidoctor.convertFile('/path/to/file.adoc', { 'to_file': false, 'header_footer': true })
+var html = asciidoctor.convertFile('/path/to/file.adoc', { to_file: false, standalone: true })
 ```
 
 [NOTE]
@@ -101,11 +101,11 @@ TIP: The default stylesheet is located at [.path]_node_modules/asciidoctor.js/di
 When you generate a document using Node.js, the `asciidoctor.css` stylesheet is embedded into the HTML output by default (when the safe mode is less than `secure`).
 
 ```js
-asciidoctor.convertFile('/path/to/file.adoc', { 'safe': 'safe' })
+asciidoctor.convertFile('/path/to/file.adoc', { safe: 'safe' })
 ```
 
 To have your document link to the stylesheet, set the `linkcss` attribute:
 
 ```js
-asciidoctor.convertFile('/path/to/file.adoc', { 'safe': 'safe', 'attributes': { 'linkcss': true } })
+asciidoctor.convertFile('/path/to/file.adoc', { safe: 'safe', attributes: { linkcss: true } })
 ```

--- a/docs/modules/setup/pages/quick-tour.adoc
+++ b/docs/modules/setup/pages/quick-tour.adoc
@@ -25,7 +25,7 @@ console.log(html)
 [NOTE]
 ====
 When converting a string, the header and footer are excluded by default to make Asciidoctor consistent with other lightweight markup engines like Markdown.
-If you want to produce a standalone document, just enable it using the `standalone` option:
+If you want to produce a standalone document, enable it using the `standalone` option:
 
 ```js
 var html = asciidoctor.convert('*This* is Asciidoctor.', { standalone: true })


### PR DESCRIPTION
My understanding is that `header_footer` is "legacy" and we should encourage users to use `standalone`? The term standalone is great because it translates better when we explain that we can produce "'embedded" or "standalone" document using `--embedded` from the CLI or the `standalone` option.

@mojavelinux Is that correct?

Also remove "just".