### PR TITLE
Flag the macos runner as experimental and allow failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,14 +6,17 @@ jobs:
   build:
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-        node-version:
-          - 12.x
-          - 13.x
+        os: [ubuntu-latest]
+        node-version: [12.x, 13.x]
         asciidoctor-core-version: [v2.0.10, master]
+        experimental: [false]
+        include:
+          - node-version: 13.x
+            os: macos-latest
+            experimental: true
+            asciidoctor-core-version: v2.0.10
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Node ${{ matrix.node-version }}


### PR DESCRIPTION
The macos runner is not stable enough and thus produce false positive.
We still want to make sure that the build is running fine on macos but the job build should not fail if only the macos runner failed.

resolves #887 