### PR TITLE
📌 Add an explicit dependency on typescript

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1381,29 +1381,29 @@
       }
     },
     "@definitelytyped/header-parser": {
-      "version": "0.0.36",
-      "resolved": "https://registry.npmjs.org/@definitelytyped/header-parser/-/header-parser-0.0.36.tgz",
-      "integrity": "sha512-rzlKeKfNLa+uAvEn64bhSc/ULbOUFepxcpV8WcobVH00Jiknu3gPOTOSnT9CgCLNtKYrcOCUTWmXkt0nV02t7g==",
+      "version": "0.0.38",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/header-parser/-/header-parser-0.0.38.tgz",
+      "integrity": "sha512-z+MO0RPGFUz8FKyxTL9AXz+LNdi9Zwc6lSUYAZlgVTx+E/+zq/GO/q6W4FB+KcsAPtyKOreIMFXsQb6MF71TqA==",
       "dev": true,
       "requires": {
-        "@definitelytyped/typescript-versions": "^0.0.36",
+        "@definitelytyped/typescript-versions": "^0.0.38",
         "@types/parsimmon": "^1.10.1",
         "parsimmon": "^1.13.0"
       }
     },
     "@definitelytyped/typescript-versions": {
-      "version": "0.0.36",
-      "resolved": "https://registry.npmjs.org/@definitelytyped/typescript-versions/-/typescript-versions-0.0.36.tgz",
-      "integrity": "sha512-ci+468ddCIOaAUGVJvVQ6RdHRC6qfkvQgZ4CuITyZJx0n6qrUU+iEqXIuoIb9Nq9yuhHu6UwK9kg5OXCfahFog==",
+      "version": "0.0.38",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/typescript-versions/-/typescript-versions-0.0.38.tgz",
+      "integrity": "sha512-fA3lCbK9ArwDSVrajbSX9wSaO2V9Kc7I5Jg2qgcB8SEqTmTMVTPzA+ieiTh+t2goSh35psVFDZeVQJKGwyqQPA==",
       "dev": true
     },
     "@definitelytyped/utils": {
-      "version": "0.0.36",
-      "resolved": "https://registry.npmjs.org/@definitelytyped/utils/-/utils-0.0.36.tgz",
-      "integrity": "sha512-gBmPS02uONxbQw1uV5TE4O+HmRNrQSLSjKPAYfsRn2Mnan4mCZAXrdfp3Zburj0xQyEtCt0SEDe2Px3txZJOKQ==",
+      "version": "0.0.38",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/utils/-/utils-0.0.38.tgz",
+      "integrity": "sha512-7hpej8eGcp6U06FR4xvu19iZP8sbFI7eBZpuFvKRRBpOCf3sd+fAeMeChTDKwkJ0HDNj7uzdJM+x12SP5a3Akg==",
       "dev": true,
       "requires": {
-        "@definitelytyped/typescript-versions": "^0.0.36",
+        "@definitelytyped/typescript-versions": "^0.0.38",
         "@types/node": "^12.12.29",
         "charm": "^1.0.2",
         "fs-extra": "^8.1.0",
@@ -1414,9 +1414,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.42",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.42.tgz",
-          "integrity": "sha512-R/9QdYFLL9dE9l5cWWzWIZByVGFd7lk7JVOJ7KD+E1SJ4gni7XJRLz9QTjyYQiHIqEAgku9VgxdLjMlhhUaAFg==",
+          "version": "12.12.44",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.44.tgz",
+          "integrity": "sha512-jM6QVv0Sm5d3nW+nUD5jSzPcO6oPqboitSNcwgBay9hifVq/Rauq1PYnROnsmuw45JMBiTnsPAno0bKu2e2xrg==",
           "dev": true
         },
         "fs-extra": {
@@ -3063,20 +3063,19 @@
       }
     },
     "dtslint": {
-      "version": "3.6.9",
-      "resolved": "https://registry.npmjs.org/dtslint/-/dtslint-3.6.9.tgz",
-      "integrity": "sha512-m3inh2igjzQnoJX6cf7DcGaejUwAca4ok7mWTDV5dhFvdCGsHkFabdwdm6vGyhq0Xzo/lV4G1RFdU5tRAsHggQ==",
+      "version": "3.6.10",
+      "resolved": "https://registry.npmjs.org/dtslint/-/dtslint-3.6.10.tgz",
+      "integrity": "sha512-QGSX0nNBLWnw3N9MJKJ8OtmU/r439bwS53RF+vnM4Vt62vCDGQa2yKEBMWpnTS2Few38i7y+UgrfL2OAPepkUw==",
       "dev": true,
       "requires": {
-        "@definitelytyped/header-parser": "^0.0.36",
-        "@definitelytyped/typescript-versions": "^0.0.36",
-        "@definitelytyped/utils": "^0.0.36",
+        "@definitelytyped/header-parser": "^0.0.38",
+        "@definitelytyped/typescript-versions": "^0.0.38",
+        "@definitelytyped/utils": "^0.0.38",
         "dts-critic": "^3.2.4",
         "fs-extra": "^6.0.1",
         "json-stable-stringify": "^1.0.1",
         "strip-json-comments": "^2.0.1",
         "tslint": "5.14.0",
-        "typescript": "^4.0.0-dev.20200601",
         "yargs": "^15.1.0"
       },
       "dependencies": {
@@ -9073,9 +9072,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.0.0-dev.20200601",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.0-dev.20200601.tgz",
-      "integrity": "sha512-vInHlMfXsl78aut2sD+Nj2mFL8Cl3+NxzVKYX9q5FrCEzd7NK7ptrCklBFm5WE2E1gioYofCEo8q4hgIVChfjQ==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
+      "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
       "dev": true
     },
     "uglify-js": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -95,7 +95,8 @@
     "pug": "^2.0.4",
     "puppeteer": "3.3.0",
     "sinon": "8.1.1",
-    "standard": "14.3.4"
+    "standard": "14.3.4",
+    "typescript": "^3.9.5"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
`typescript` is now a peer dependency of `dtslint` so we need to provide it.