### PR TITLE
Asciidoctor core now uses read_contents to download and embed custom stylesheet

### DIFF
--- a/packages/core/lib/asciidoctor/js/asciidoctor_ext/browser/abstract_node.rb
+++ b/packages/core/lib/asciidoctor/js/asciidoctor_ext/browser/abstract_node.rb
@@ -3,7 +3,7 @@ class AbstractNode
   def read_contents target, opts = {}
     doc = @document
     if (Helpers.uriish? target) || ((start = opts[:start]) && (Helpers.uriish? start) && (target = doc.path_resolver.web_path target, start))
-      if (doc.path_resolver.descends_from? target, doc.base_dir) || (doc.attr? 'allow-uri-read')
+      if (doc.path_resolver.descends_from? target, doc.base_dir) || (target.start_with? 'chrome://') || (doc.attr? 'allow-uri-read')
         begin
           if opts[:normalize]
             (Helpers.prepare_source_string ::File.read(target)).join LF

--- a/packages/core/spec/browser/asciidoctor-spec.js
+++ b/packages/core/spec/browser/asciidoctor-spec.js
@@ -63,13 +63,16 @@ import Asciidoctor from '../../build/asciidoctor-browser.js'
           standalone: true,
           attributes
         }
+        const defaultLogger = asciidoctor.LoggerManager.getLogger()
+        const memoryLogger = asciidoctor.MemoryLogger.create()
         try {
+          asciidoctor.LoggerManager.setLogger(memoryLogger)
           asciidoctor.convert('Hello world', options)
-          expect.fail('the resource does not exist and the converter should throw an exception!')
-        } catch (e) {
-          // the resource does not exist but chrome:// is a root path and should not be prepended by "./"
-          // we expect the processor to try to load the resource 'chrome://asciidoctor/extension/css/asciidoctor-plus.css' and fail!
-          expect(e.message).to.include('Failed to load \'chrome://asciidoctor/extension/css/asciidoctor-plus.css\'')
+          const errorMessage = memoryLogger.getMessages()[0]
+          expect(errorMessage.getSeverity()).to.equal('WARN')
+          expect(errorMessage.getText()).to.include('could not retrieve contents of stylesheet at URI: chrome://asciidoctor/extension/css/asciidoctor-plus.css')
+        } finally {
+          asciidoctor.LoggerManager.setLogger(defaultLogger)
         }
       })
     })

--- a/packages/core/spec/browser/asciidoctor-spec.js
+++ b/packages/core/spec/browser/asciidoctor-spec.js
@@ -71,6 +71,14 @@ import Asciidoctor from '../../build/asciidoctor-browser.js'
           const errorMessage = memoryLogger.getMessages()[0]
           expect(errorMessage.getSeverity()).to.equal('WARN')
           expect(errorMessage.getText()).to.include('could not retrieve contents of stylesheet at URI: chrome://asciidoctor/extension/css/asciidoctor-plus.css')
+        } catch (e) {
+          // the resource does not exist but chrome:// is a root path and should not be prepended by "./"
+          // we expect the processor to try to load the resource 'chrome://asciidoctor/extension/css/asciidoctor-plus.css' and fail!
+          if (asciidoctorCoreSemVer.lte('2.0.10')) {
+            expect(e.message).to.include('Failed to load \'chrome://asciidoctor/extension/css/asciidoctor-plus.css\'')
+          } else {
+            throw e
+          }
         } finally {
           asciidoctor.LoggerManager.setLogger(defaultLogger)
         }

--- a/packages/core/spec/share/asciidoctor-spec.js
+++ b/packages/core/spec/share/asciidoctor-spec.js
@@ -1020,6 +1020,7 @@ paragraph 3
           doctype: 'article',
           safe: 'unsafe',
           header_footer: true,
+          base_dir: testOptions.baseDir,
           attributes: ['showtitle', 'stylesheet=asciidoctor.css', 'stylesdir=' + testOptions.baseDir + '/build/css']
         }
         const html = asciidoctor.convert('=== Test', options)


### PR DESCRIPTION
Adjust the implementation to be compatible with https://github.com/asciidoctor/asciidoctor/pull/3766