### PR TITLE
📦 Define web-optimized 'module' entrypoint

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,7 @@
   "description": "Asciidoctor - the core library",
   "main": "dist/node/asciidoctor.js",
   "browser": "dist/browser/asciidoctor.js",
+  "module": "dist/browser/asciidoctor.js",
   "types": "types",
   "engines": {
     "node": ">=12",


### PR DESCRIPTION
`dist/browser/asciidoctor.js` is now an ES6 module.