### PR TITLE
⬆️ Upgrade to Asciidoctor Opal runtime 0.3.2

### DIFF
--- a/packages/core/package-lock.json
+++ b/packages/core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@asciidoctor/core",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1322,29 +1322,29 @@
       }
     },
     "@definitelytyped/header-parser": {
-      "version": "0.0.64",
-      "resolved": "https://registry.npmjs.org/@definitelytyped/header-parser/-/header-parser-0.0.64.tgz",
-      "integrity": "sha512-vwh6ojw0PYptEiAogAdKNrwYy2Dv0zZj6M5bjKAoF7/xOmY5B/QluJnNmgF7Q+fxLG2vVxYDbkc26r04xYIZQA==",
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/header-parser/-/header-parser-0.0.71.tgz",
+      "integrity": "sha512-5iASXqlpqorWJ81D/QlwvbXmgnEOvcekv33aZTMSe7ubCJ1S/IdBwbTIBpPZbS3GnBzXbCT0749a1bVxG+wTfg==",
       "dev": true,
       "requires": {
-        "@definitelytyped/typescript-versions": "^0.0.64",
+        "@definitelytyped/typescript-versions": "^0.0.71",
         "@types/parsimmon": "^1.10.1",
         "parsimmon": "^1.13.0"
       }
     },
     "@definitelytyped/typescript-versions": {
-      "version": "0.0.64",
-      "resolved": "https://registry.npmjs.org/@definitelytyped/typescript-versions/-/typescript-versions-0.0.64.tgz",
-      "integrity": "sha512-h+RvQPzvC/yVtZ/FqttXoIac/X1htXrmuNbvmQP+RiVonGunKq7S8ona5tm7ckiheur6VvtKQGe+zQIDF3sErQ==",
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/typescript-versions/-/typescript-versions-0.0.71.tgz",
+      "integrity": "sha512-XJvyYfWQyntq+EdCqRinni9BwenPAoCXTZ3aaKfuir14bEbkIyeyQjuh1R0VkqdahIavyyAoGmYHe9OSYqFwTw==",
       "dev": true
     },
     "@definitelytyped/utils": {
-      "version": "0.0.64",
-      "resolved": "https://registry.npmjs.org/@definitelytyped/utils/-/utils-0.0.64.tgz",
-      "integrity": "sha512-ahxruUzplmVwWnJavaRcj8JN4B6znkYjmSTGyWSzgc+aL596nVZGyVRDlOL5mKSnJk1MzT4Uj4Gx0bg3l6CPHw==",
+      "version": "0.0.71",
+      "resolved": "https://registry.npmjs.org/@definitelytyped/utils/-/utils-0.0.71.tgz",
+      "integrity": "sha512-/IueyLKglPxweW1d7VvuTlnFxBNVv1qcSL2Y+u/LW7aBMXfD8bcuHl7awAMVRAGhTeBpo7qGubrCqMSNfOlUyA==",
       "dev": true,
       "requires": {
-        "@definitelytyped/typescript-versions": "^0.0.64",
+        "@definitelytyped/typescript-versions": "^0.0.71",
         "@types/node": "^12.12.29",
         "charm": "^1.0.2",
         "fs-extra": "^8.1.0",
@@ -1355,15 +1355,15 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.19.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.6.tgz",
-          "integrity": "sha512-U2VopDdmBoYBmtm8Rz340mvvSz34VgX/K9+XCuckvcLGMkt3rbMX8soqFOikIPlPBc5lmw8By9NUK7bEFSBFlQ==",
+          "version": "12.20.4",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.4.tgz",
+          "integrity": "sha512-xRCgeE0Q4pT5UZ189TJ3SpYuX/QGl6QIAOAIeDSbAVAd2gX1NxSZup4jNVK7cxIeP8KDSbJgcckun495isP1jQ==",
           "dev": true
         },
         "bl": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-          "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
           "dev": true,
           "requires": {
             "buffer": "^5.5.0",
@@ -1391,9 +1391,9 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "version": "4.2.6",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+          "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
           "dev": true
         },
         "readable-stream": {
@@ -1408,9 +1408,9 @@
           }
         },
         "tar-stream": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
-          "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+          "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
           "dev": true,
           "requires": {
             "bl": "^4.0.3",
@@ -1492,9 +1492,9 @@
       "dev": true
     },
     "@types/parsimmon": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/@types/parsimmon/-/parsimmon-1.10.4.tgz",
-      "integrity": "sha512-M56NfQHfaWuaj6daSgCVs7jh8fXLI3LmxjRoQxmOvYesgIkI+9HPsDLO0vd7wX7cwA0D0ZWFEJdp0VPwLdS+bQ==",
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@types/parsimmon/-/parsimmon-1.10.6.tgz",
+      "integrity": "sha512-FwAQwMRbkhx0J6YELkwIpciVzCcgEqXEbIrIn3a2P5d3kGEHQ3wVhlN3YdVepYP+bZzCYO6OjmD4o9TGOZ40rA==",
       "dev": true
     },
     "@types/unist": {
@@ -1741,9 +1741,9 @@
       "dev": true
     },
     "asciidoctor-opal-runtime": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/asciidoctor-opal-runtime/-/asciidoctor-opal-runtime-0.3.0.tgz",
-      "integrity": "sha512-YapVwl2qbbs6sIe1dvAlMpBzQksFVTSa2HOduOKFNhZlE9bNmn+moDgGVvjWPbzMPo/g8gItyTHfWB2u7bQxag==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/asciidoctor-opal-runtime/-/asciidoctor-opal-runtime-0.3.2.tgz",
+      "integrity": "sha512-J9N2VMItYiJ0TVuCUsrD3cGxB5Y1noIuTACJ0LP7I3V4IhcQ3/LQwvLot0+AcXZTpLSN3KS2CauwNPri7+pkLA==",
       "requires": {
         "glob": "7.1.3",
         "unxhr": "1.0.1"
@@ -3038,7 +3038,7 @@
       "integrity": "sha512-OjLTrSBCFbi1tDAiOXcP7G20W3HI3eIzkpSpLwvH7oDFZYdqFCMe9lsNhMZFXqsNcSTpRg3+PBS4fF27+h1qew==",
       "dev": true,
       "requires": {
-        "@definitelytyped/header-parser": "^0.0.64",
+        "@definitelytyped/header-parser": "^0.0.71",
         "command-exists": "^1.2.8",
         "rimraf": "^3.0.2",
         "semver": "^6.2.0",
@@ -3161,9 +3161,9 @@
           "dev": true
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -3232,19 +3232,20 @@
       }
     },
     "dtslint": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/dtslint/-/dtslint-4.0.6.tgz",
-      "integrity": "sha512-bj5EaTeAqVXDHo/ut8oTRN/hZNTVKTAsNkavyH/T7XeDU/bqrctlYJmQo2HWJzPDoNCjq6NdVgvOnmQBGmSHsg==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/dtslint/-/dtslint-4.0.7.tgz",
+      "integrity": "sha512-gwpBnxky+vUfCL74U5ao+wQf4sw9jD+cZ9ukiTFrkwkhNibqfyOZyg4cnFf1lB0Hm5ZFSQdi09DdjarDQLgofA==",
       "dev": true,
       "requires": {
-        "@definitelytyped/header-parser": "^0.0.64",
-        "@definitelytyped/typescript-versions": "^0.0.64",
-        "@definitelytyped/utils": "^0.0.64",
+        "@definitelytyped/header-parser": "^0.0.71",
+        "@definitelytyped/typescript-versions": "^0.0.71",
+        "@definitelytyped/utils": "^0.0.71",
         "dts-critic": "^3.3.4",
         "fs-extra": "^6.0.1",
         "json-stable-stringify": "^1.0.1",
         "strip-json-comments": "^2.0.1",
         "tslint": "5.14.0",
+        "tsutils": "^2.29.0",
         "yargs": "^15.1.0"
       },
       "dependencies": {
@@ -3348,9 +3349,9 @@
           "dev": true
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
           "dev": true,
           "requires": {
             "emoji-regex": "^8.0.0",
@@ -5702,9 +5703,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "inquirer": {
@@ -6668,18 +6669,18 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
+      "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "version": "2.1.29",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
+      "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
       "dev": true,
       "requires": {
-        "mime-db": "1.44.0"
+        "mime-db": "1.46.0"
       }
     },
     "mimic-fn": {
@@ -8116,9 +8117,9 @@
       }
     },
     "pug-code-gen": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-2.0.2.tgz",
-      "integrity": "sha512-kROFWv/AHx/9CRgoGJeRSm+4mLWchbgpRzTEn8XCiwwOy6Vh0gAClS8Vh5TEJ9DBjaP8wCjS3J6HKsEsYdvaCw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pug-code-gen/-/pug-code-gen-2.0.3.tgz",
+      "integrity": "sha512-r9sezXdDuZJfW9J91TN/2LFbiqDhmltTFmGpHTsGdrNGp3p4SxAjjXEfnuK2e4ywYsRIVP0NeLbSAMHUcaX1EA==",
       "dev": true,
       "requires": {
         "constantinople": "^3.1.2",
@@ -8273,7 +8274,8 @@
       "dependencies": {
         "bl": {
           "version": "4.0.2",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
+          "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
           "dev": true,
           "requires": {
             "buffer": "^5.5.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -67,7 +67,7 @@
   },
   "homepage": "https://github.com/asciidoctor/asciidoctor.js",
   "dependencies": {
-    "asciidoctor-opal-runtime": "0.3.0",
+    "asciidoctor-opal-runtime": "0.3.2",
     "unxhr": "1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Version 0.3.1 and 0.3.2 include two important fixes:

- https://github.com/Mogztter/asciidoctor-opal-node-runtime/releases/tag/v0.3.2
- https://github.com/Mogztter/asciidoctor-opal-node-runtime/releases/tag/v0.3.1

When the latest version of Node.js, Asciidoctor.js with 0.3.2 is approximately 1.65 times faster:

#### Asciidoctor.js with Node.js v14.15.4 (baseline)

```console
$ node build/benchmark/node.js
Load scripts: 0.057s
Run #1: 2.992s
Run #2: 2.83s
Run #3: 2.751s
Run #4: 2.729s
avg: 2825.50
stddev: 103.20
50th: 2790.50
75th: 2870.50
90th: 2943.40
99th: 2987.14
```
```console
$ node build/benchmark/node.js
Load scripts: 0.057s
Run #1: 2.964s
Run #2: 2.827s
Run #3: 2.796s
Run #4: 2.757s
avg: 2836.00
stddev: 77.95
50th: 2811.50
75th: 2861.25
90th: 2922.90
99th: 2959.89
```

#### Asciidoctor.js with Node.js v14.15.4 (0.3.2)

```console
$ node build/benchmark/node.js
Load scripts: 0.066s
Run #1: 1.822s
Run #2: 1.681s
Run #3: 1.6s
Run #4: 1.553s
avg: 1664.00
stddev: 102.07
50th: 1640.50
75th: 1716.25
90th: 1779.70
99th: 1817.77
```
```console
$ node build/benchmark/node.js
Load scripts: 0.058s
Run #1: 1.861s
Run #2: 1.671s
Run #3: 1.601s
Run #4: 1.543s
avg: 1669.00
stddev: 119.76
50th: 1636.00
75th: 1718.50
90th: 1804.00
99th: 1855.30
```

For reference, Asciidoctor.js with 0.3.2 (Node.js v10.22.1) is still faster.

```console
$ node build/benchmark/node.js
Load scripts: 0.08s
Run #1: 1.051s
Run #2: 0.754s
Run #3: 0.71s
Run #4: 0.68s
avg: 798.75
stddev: 148.00
50th: 732.00
75th: 828.25
90th: 961.90
99th: 1042.09
```
```console
$ node build/benchmark/node.js
Load scripts: 0.083s
Run #1: 1.01s
Run #2: 0.786s
Run #3: 0.713s
Run #4: 0.686s
avg: 798.75
stddev: 127.33
50th: 749.50
75th: 842.00
90th: 942.80
99th: 1003.28
```

In other words, Asciidoctor.js with 0.3.2 and Node.js > 10 is now only 1.8 times slower (down to 3 times slower with 0.3.0 and Node.js > 10).