### PR TITLE
📝 Draw a connection between safe mode and include

### DIFF
--- a/docs/modules/processor/pages/convert-options.adoc
+++ b/docs/modules/processor/pages/convert-options.adoc
@@ -54,7 +54,8 @@ Instead of providing a JavaScript function containing extensions to register, th
 |_boolean_
 
 |safe
-|Sets the safe mode.
+|Sets the safe mode. +
+Disables potentially dangerous macros in source files, such as `include::[]`.
 |secure
 |unsafe, safe, server or secure
 

--- a/docs/modules/processor/pages/convert-options.adoc
+++ b/docs/modules/processor/pages/convert-options.adoc
@@ -54,7 +54,7 @@ Instead of providing a JavaScript function containing extensions to register, th
 |_boolean_
 
 |safe
-|Sets the safe mode. +
+|Sets the xref:asciidoctor::safe-modes.adoc[safe mode]. +
 Disables potentially dangerous macros in source files, such as `include::[]`.
 |secure
 |unsafe, safe, server or secure


### PR DESCRIPTION
Mention that safe mode can disable potentially dangerous macros such as `include::[]`

Ref #1369

//cc @saneef