### PR TITLE
📝 Fix two 404ing links to the GraalVM docs

### DIFF
--- a/docs/modules/setup/pages/install.adoc
+++ b/docs/modules/setup/pages/install.adoc
@@ -71,7 +71,7 @@ const asciidoctor = Asciidoctor()
 
 === Node.js application
 
-https://www.graalvm.org/docs/reference-manual/languages/js/[GraalVM can run Node.js applications]. +
+https://www.graalvm.org/reference-manual/js/[GraalVM can run Node.js applications]. +
 To install `asciidoctor.js` module, use the `npm` executable in the [.path]_/bin_ folder of the GraalVM package.
 
 Create the following code snippet to a file named `app.js` and save it in the same directory where you installed the Node.js modules:
@@ -89,7 +89,7 @@ Then execute it on GraalVM using the `node` command (available in the [.path]_/b
 
 === Embed in a JVM-based application
 
-https://www.graalvm.org/docs/graalvm-as-a-platform/embed/[With the Graal Polyglot API, you can embed JavaScript code in a JVM-based application].
+https://www.graalvm.org/reference-manual/embed-languages/[With the Graal Polyglot API, you can embed JavaScript code in a JVM-based application].
 
 IMPORTANT: The Graal Polyglot feature gives you a "pure" JavaScript (ECMAScript) engine, not a Node.js engine.
 In other words, Node.js features such as `require` or core module such as `fs` won't be available.


### PR DESCRIPTION
Spotted a couple of 404s in the JS installation guide. Suggested fixes:

https://www.graalvm.org/docs/reference-manual/languages/js/ -> https://www.graalvm.org/reference-manual/js/
https://www.graalvm.org/docs/graalvm-as-a-platform/embed/ -> https://www.graalvm.org/reference-manual/embed-languages/ (was unsure about this one, also considered https://www.graalvm.org/reference-manual/polyglot-programming/ and https://www.graalvm.org/reference-manual/js/JavaInteroperability/)