### PR TITLE
Extensions parseContent should call toHash on attrs.

### DIFF
--- a/packages/core/src/asciidoctor-extensions-api.js
+++ b/packages/core/src/asciidoctor-extensions-api.js
@@ -703,7 +703,7 @@ Processor.prototype.createInline = function (parent, context, text, opts) {
  * @memberof Extensions/Processor
  */
 Processor.prototype.parseContent = function (parent, content, attrs) {
-  return this.$parse_content(parent, content, attrs)
+  return this.$parse_content(parent, content, toHash(attrs))
 }
 
 /**


### PR DESCRIPTION
Fixes #1036 