### PR TITLE
resolves #1475 bridge common Ruby object methods (backport v2.2.x)

### DIFF
--- a/packages/core/spec/node/asciidoctor.spec.js
+++ b/packages/core/spec/node/asciidoctor.spec.js
@@ -2416,6 +2416,18 @@ getAttribute('fragment'): ${typeof node.getAttribute('fragment') === 'undefined'
       }
     }
 
+    it('should bridge common Ruby object methods', () => {
+      asciidoctor.ConverterFactory.register(new DummyConverter(), ['dummy'])
+      const converterFactory = asciidoctor.ConverterFactory.getDefault()
+      const dummyConverterInstance = converterFactory.create('dummy')
+      const html5ConverterInstance = converterFactory.create('html5')
+      expect(dummyConverterInstance['$=='](dummyConverterInstance)).to.be.true()
+      expect(html5ConverterInstance['$=='](html5ConverterInstance)).to.be.true()
+      expect(dummyConverterInstance['$=='](html5ConverterInstance)).to.be.false()
+      expect(typeof html5ConverterInstance.$send).to.equal('function')
+      expect(typeof dummyConverterInstance.$send).to.equal('function')
+      expect(dummyConverterInstance.$send('convert', { getContent: () => 'Hello World' }, 'paragraph')).to.equal('Hello World')
+    })
     it('should get inline anchor attributes', () => {
       asciidoctor.ConverterFactory.register(new XrefConverter(), ['xref'])
       const html = asciidoctor.convert('xref:file.adoc[]', { backend: 'xref' })

--- a/packages/core/src/asciidoctor-extensions-api.js
+++ b/packages/core/src/asciidoctor-extensions-api.js
@@ -1307,6 +1307,21 @@ ConverterFactory.register = function (converter, backends) {
   var bridgeComposedMethodToInstance = function (obj, instance) {
     bridgeMethodToInstance(obj, instance, '$composed', 'composed')
   }
+  var bridgeEqEqMethodToInstance = function (obj, instance) {
+    bridgeMethodToInstance(obj, instance, '$==', '==', function (other) {
+      return instance === other
+    })
+  }
+  var bridgeSendMethodToInstance = function (obj, instance) {
+    bridgeMethodToInstance(obj, instance, '$send', 'send', function (symbol) {
+      var [, ...args] = Array.from(arguments)
+      var func = instance['$' + symbol]
+      if (func) {
+        return func.apply(instance, args)
+      }
+      throw new Error(`undefined method \`${symbol}\` for \`${instance.toString()}\``)
+    })
+  }
   var bridgeMethodToInstance = function (obj, instance, methodName, functionName, defaultImplementation) {
     if (typeof obj[methodName] === 'undefined') {
       if (typeof obj[functionName] === 'function') {
@@ -1373,6 +1388,8 @@ ConverterFactory.register = function (converter, backends) {
     }
     bridgeHandlesMethodToInstance(converter, converter)
     bridgeComposedMethodToInstance(converter, converter)
+    bridgeEqEqMethodToInstance(converter, converter)
+    bridgeSendMethodToInstance(converter, converter)
     addRespondToMethod(converter)
     object = converter
   }

--- a/packages/core/src/asciidoctor-extensions-api.js
+++ b/packages/core/src/asciidoctor-extensions-api.js
@@ -1314,7 +1314,7 @@ ConverterFactory.register = function (converter, backends) {
   }
   var bridgeSendMethodToInstance = function (obj, instance) {
     bridgeMethodToInstance(obj, instance, '$send', 'send', function (symbol) {
-      var [, ...args] = Array.from(arguments)
+      var args = Array.prototype.slice.call(arguments, 1)
       var func = instance['$' + symbol]
       if (func) {
         return func.apply(instance, args)


### PR DESCRIPTION
We are using https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from which is not available in IE.

I think we should mention that in the next release but I don't want to include a polyfill. 