### PR TITLE
✨ Support Stream.Writable as to_file

### DIFF
--- a/packages/core/spec/node/asciidoctor.spec.js
+++ b/packages/core/spec/node/asciidoctor.spec.js
@@ -1,6 +1,6 @@
 /* global it, describe, before, after, afterEach */
-import path from 'path'
 import { Writable } from 'stream'
+import path from 'path'
 import { fileURLToPath } from 'url'
 import fs from 'fs'
 import process from 'process'
@@ -9,7 +9,6 @@ import dirtyChai from 'dirty-chai'
 import dot from 'dot'
 import nunjucks from 'nunjucks'
 import Opal from 'asciidoctor-opal-runtime' // for testing purpose only
-
 import semVer from '../share/semver.cjs'
 import MockServer from '../share/mock-server.cjs'
 import shareSpec from '../share/asciidoctor-spec.cjs'
@@ -925,6 +924,26 @@ image::https://asciidoctor.org/images/octocat.jpg[GitHub mascot]`
       } finally {
         removeFile(expectFilePath)
       }
+    })
+
+    it('should be able to convert a file into a Writable stream', () => {
+      const data = []
+      const writableStream = new Writable({
+        write (chunk, encoding, callback) {
+          data.push(chunk.toString())
+          callback()
+        }
+      })
+      const doc = asciidoctor.convert(`= Document Title
+:author: Guillaume Grossetie
+
+This is a preamble.
+
+== Section Title
+
+This is a paragraph.`, { to_file: writableStream, header_footer: false })
+      expect(doc.getAttribute('author')).to.equal('Guillaume Grossetie')
+      expect(data.join('')).to.contain('This is a paragraph.')
     })
 
     it('should be able to apply default inline substitutions to text', () => {

--- a/packages/core/src/asciidoctor-core-api.js
+++ b/packages/core/src/asciidoctor-core-api.js
@@ -255,7 +255,19 @@ Asciidoctor.prototype.convert = function (input, options) {
   if (typeof input === 'object' && input.constructor.name === 'Buffer') {
     input = input.toString('utf8')
   }
-  const result = this.$convert(input, prepareOptions(options))
+  const toFile = options && options.to_file
+  if (typeof toFile === 'object' && toFile.constructor.name === 'Writable' && typeof toFile.write === 'function') {
+    toFile['$respond_to?'] = (name) => name === 'write'
+    toFile.$object_id = () => ''
+    toFile.$write = function (data) {
+      this.write(data)
+    }
+  }
+  const opts = prepareOptions(options)
+  const result = this.$convert(input, opts)
+  if (typeof toFile === 'object' && toFile.constructor.name === 'Writable' && typeof toFile.end === 'function') {
+    toFile.end()
+  }
   return result === Opal.nil ? '' : result
 }
 


### PR DESCRIPTION
It can be useful when you want both the `Asciidoctor.Document` and the result in a single call:

```js
const data = []
const writableStream = new Writable({
  write (chunk, encoding, callback) {
    data.push(chunk.toString())
    callback()
  }
})
const doc = asciidoctor.convert(text, { to_file: writableStream, safe: safe })
const html = data.join('')
```