### PR TITLE
remove call to convert() on return value of process method for inline macro extension

### DIFF
--- a/docs/modules/extend/examples/extensions/emoticon-inline-macro-processor.js
+++ b/docs/modules/extend/examples/extensions/emoticon-inline-macro-processor.js
@@ -10,7 +10,7 @@ module.exports = function (registry) {
       } else {
         text = ':)'
       }
-      return self.createInline(parent, 'quoted', text, { 'type': 'strong' }).convert()
+      return self.createInline(parent, 'quoted', text, { 'type': 'strong' })
     })
   })
 }


### PR DESCRIPTION
- the process method should return an Inline object, not a string