### PR TITLE
Add `getSectionNumeral()` function

### DIFF
--- a/packages/core/spec/share/asciidoctor-spec.cjs
+++ b/packages/core/spec/share/asciidoctor-spec.cjs
@@ -594,7 +594,7 @@ This is another paragraph.
         expect(firstSection.title).to.equal('First section')
         expect(firstSection.getSectionName()).to.equal('section')
         expect(firstSection.isNumbered()).to.equal(false)
-        expect(firstSection.getSectionNumber()).to.equal('.')
+        expect(firstSection.getSectionNumeral()).to.equal('.')
         expect(firstSection.isSpecial()).to.equal(false)
         expect(firstSection.getCaption()).to.be.undefined()
         const secondSection = doc.getSections()[1]
@@ -604,7 +604,7 @@ This is another paragraph.
         expect(secondSection.title).to.equal('Second section')
         expect(secondSection.getSectionName()).to.equal('section')
         expect(secondSection.isNumbered()).to.equal(true)
-        expect(secondSection.getSectionNumber()).to.equal('1.')
+        expect(secondSection.getSectionNumeral()).to.equal('1.')
         expect(secondSection.isSpecial()).to.equal(false)
         expect(secondSection.getCaption()).to.be.undefined()
         const abstractSection = doc.getSections()[2]
@@ -614,7 +614,7 @@ This is another paragraph.
         expect(abstractSection.title).to.equal('Abstract section')
         expect(abstractSection.getSectionName()).to.equal('abstract')
         expect(abstractSection.isNumbered()).to.equal(false)
-        expect(firstSection.getSectionNumber()).to.equal('.')
+        expect(firstSection.getSectionNumeral()).to.equal('.')
         expect(abstractSection.isSpecial()).to.equal(true)
         expect(abstractSection.getCaption()).to.be.undefined()
         const appendixSection = doc.getSections()[3]
@@ -623,7 +623,7 @@ This is another paragraph.
         expect(appendixSection.getTitle()).to.equal('Copyright and License')
         expect(appendixSection.title).to.equal('Copyright and License')
         expect(appendixSection.getSectionName()).to.equal('appendix')
-        expect(appendixSection.getSectionNumber()).to.equal('A.')
+        expect(appendixSection.getSectionNumeral()).to.equal('A.')
         expect(appendixSection.isNumbered()).to.equal(true)
         expect(appendixSection.isSpecial()).to.equal(true)
         expect(appendixSection.getCaption()).to.equal('Appx A: ')

--- a/packages/core/spec/share/asciidoctor-spec.cjs
+++ b/packages/core/spec/share/asciidoctor-spec.cjs
@@ -605,6 +605,7 @@ This is another paragraph.
         expect(secondSection.getSectionName()).to.equal('section')
         expect(secondSection.isNumbered()).to.equal(true)
         expect(secondSection.getSectionNumeral()).to.equal('1.')
+        expect(secondSection.getSectionNumber()).to.equal('1.')
         expect(secondSection.isSpecial()).to.equal(false)
         expect(secondSection.getCaption()).to.be.undefined()
         const abstractSection = doc.getSections()[2]

--- a/packages/core/spec/share/asciidoctor-spec.cjs
+++ b/packages/core/spec/share/asciidoctor-spec.cjs
@@ -594,6 +594,7 @@ This is another paragraph.
         expect(firstSection.title).to.equal('First section')
         expect(firstSection.getSectionName()).to.equal('section')
         expect(firstSection.isNumbered()).to.equal(false)
+        expect(firstSection.getSectionNumber()).to.equal('.')
         expect(firstSection.isSpecial()).to.equal(false)
         expect(firstSection.getCaption()).to.be.undefined()
         const secondSection = doc.getSections()[1]
@@ -603,6 +604,7 @@ This is another paragraph.
         expect(secondSection.title).to.equal('Second section')
         expect(secondSection.getSectionName()).to.equal('section')
         expect(secondSection.isNumbered()).to.equal(true)
+        expect(secondSection.getSectionNumber()).to.equal('1.')
         expect(secondSection.isSpecial()).to.equal(false)
         expect(secondSection.getCaption()).to.be.undefined()
         const abstractSection = doc.getSections()[2]
@@ -612,6 +614,7 @@ This is another paragraph.
         expect(abstractSection.title).to.equal('Abstract section')
         expect(abstractSection.getSectionName()).to.equal('abstract')
         expect(abstractSection.isNumbered()).to.equal(false)
+        expect(firstSection.getSectionNumber()).to.equal('.')
         expect(abstractSection.isSpecial()).to.equal(true)
         expect(abstractSection.getCaption()).to.be.undefined()
         const appendixSection = doc.getSections()[3]
@@ -620,6 +623,7 @@ This is another paragraph.
         expect(appendixSection.getTitle()).to.equal('Copyright and License')
         expect(appendixSection.title).to.equal('Copyright and License')
         expect(appendixSection.getSectionName()).to.equal('appendix')
+        expect(appendixSection.getSectionNumber()).to.equal('A.')
         expect(appendixSection.isNumbered()).to.equal(true)
         expect(appendixSection.isSpecial()).to.equal(true)
         expect(appendixSection.getCaption()).to.equal('Appx A: ')

--- a/packages/core/src/asciidoctor-core-api.js
+++ b/packages/core/src/asciidoctor-core-api.js
@@ -745,6 +745,15 @@ Section.prototype.setSectionName = function (value) {
 }
 
 /**
+ * Set the section number of this section.
+ * @returns {string}
+ * @memberof Section
+ */
+Section.prototype.getSectionNumber = function () {
+  return this.$sectnum()
+}
+
+/**
  * Get the flag to indicate whether this is a special section or a child of one.
  * @returns {boolean}
  * @memberof Section

--- a/packages/core/src/asciidoctor-core-api.js
+++ b/packages/core/src/asciidoctor-core-api.js
@@ -749,7 +749,7 @@ Section.prototype.setSectionName = function (value) {
  * @returns {string}
  * @memberof Section
  */
-Section.prototype.getSectionNumber = function () {
+Section.prototype.getSectionNumeral = function () {
   return this.$sectnum()
 }
 

--- a/packages/core/src/asciidoctor-core-api.js
+++ b/packages/core/src/asciidoctor-core-api.js
@@ -753,6 +753,8 @@ Section.prototype.getSectionNumeral = function () {
   return this.$sectnum()
 }
 
+Section.prototype.getSectionNumber = Section.prototype.getSectionNumeral
+
 /**
  * Get the flag to indicate whether this is a special section or a child of one.
  * @returns {boolean}

--- a/packages/core/src/asciidoctor-core-api.js
+++ b/packages/core/src/asciidoctor-core-api.js
@@ -745,7 +745,7 @@ Section.prototype.setSectionName = function (value) {
 }
 
 /**
- * Set the section number of this section.
+ * Get the section number of this section.
  * @returns {string}
  * @memberof Section
  */

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -2248,9 +2248,12 @@ export namespace Asciidoctor {
     setSectionName(value: string): void;
 
     /**
-     * Get the section numeral of this section.
+     * Get the section number of this section.
      */
     getSectionNumeral(): string;
+
+    // alias
+    getSectionNumber(): string;
 
     /**
      * Get the flag to indicate whether this is a special section or a child of one.

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -2242,15 +2242,15 @@ export namespace Asciidoctor {
     getSectionName(): string;
 
     /**
-     * Get the section name of this section.
-     */
-    getSectionNumber(): string;
-
-    /**
      * Set the section name of this section.
      * @param value - The section name
      */
     setSectionName(value: string): void;
+
+    /**
+     * Get the section number of this section.
+     */
+    getSectionNumber(): string;
 
     /**
      * Get the flag to indicate whether this is a special section or a child of one.

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -2250,7 +2250,7 @@ export namespace Asciidoctor {
     /**
      * Get the section number of this section.
      */
-    getSectionNumber(): string;
+    getSectionNumeral(): string;
 
     /**
      * Get the flag to indicate whether this is a special section or a child of one.

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -2242,6 +2242,11 @@ export namespace Asciidoctor {
     getSectionName(): string;
 
     /**
+     * Get the section name of this section.
+     */
+    getSectionNumber(): string;
+
+    /**
      * Set the section name of this section.
      * @param value - The section name
      */


### PR DESCRIPTION
Currently using `$sectnum()` in a custom asciidoc section converter—figured it might be useful to get the function wrapper included and typed.

First time contributor, hopefully it's all formatted correctly.