### PR TITLE
Generate ESM based on #Mogztter:esm-module

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,7 @@
   "description": "Asciidoctor - the core library",
   "main": "dist/node/asciidoctor.js",
   "browser": "dist/browser/asciidoctor.js",
-  "module": "dist/browser/asciidoctor.js",
+  "module": "dist/browser/asciidoctor.esm.js",
   "type": "module",
   "types": "types",
   "engines": {

--- a/packages/core/spec/esm/index.html
+++ b/packages/core/spec/esm/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Asciidoctor.js tests</title>
+  <meta charset="utf-8">
+</head>
+<body>
+<script type="module">
+  import Asciidoctor from '../../build/asciidoctor-esm.js'
+
+  console.log(Asciidoctor.convert('Hello *world*'))
+  // prints:
+  //<div class="paragraph">
+  //<p>Hello <strong>world</strong></p>
+  //</div>
+</script>
+</body>
+</html>

--- a/packages/core/src/template-asciidoctor-esm.js
+++ b/packages/core/src/template-asciidoctor-esm.js
@@ -1,0 +1,19 @@
+//{{opalCode}}
+
+//{{asciidoctorCode}}
+
+//{{asciidoctorAPI}}
+
+//{{asciidoctorVersion}}
+
+/**
+ * Get Asciidoctor.js version number.
+ *
+ * @memberof Asciidoctor
+ * @returns {string} - returns the version number of Asciidoctor.js.
+ */
+Opal.Asciidoctor.prototype.getVersion = function () {
+  return ASCIIDOCTOR_JS_VERSION
+}
+
+export default Opal.Asciidoctor


### PR DESCRIPTION
Reintroduction of this previous pull request: https://github.com/asciidoctor/asciidoctor.js/pull/1104
Is there a reason this was abandoned? This seems to work fine for me in browser.

I'm writing a [react renderer ](https://github.com/oxidecomputer/react-asciidoc), and the lack of an ESM module is a blocker. I could fork until Asciidoctor 3.0 is released?

Fixes: https://github.com/asciidoctor/asciidoctor.js/issues/686#issuecomment-916854429