### PR TITLE
Include `cjs` in release

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,12 @@
   "name": "@asciidoctor/core",
   "version": "3.0.0-alpha.4",
   "description": "Asciidoctor - the core library",
-  "main": "dist/node/asciidoctor.js",
+  "exports": {
+    ".": {
+     "require": "./dist/node/asciidoctor.cjs",
+     "import": "./dist/node/asciidoctor.js"
+    }
+  },
   "browser": "dist/browser/asciidoctor.js",
   "module": "dist/browser/asciidoctor.js",
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,10 +2,11 @@
   "name": "@asciidoctor/core",
   "version": "3.0.0-alpha.4",
   "description": "Asciidoctor - the core library",
+  "main": "dist/node/asciidoctor.js",
   "exports": {
     ".": {
-     "require": "./dist/node/asciidoctor.cjs",
-     "import": "./dist/node/asciidoctor.js"
+      "require": "./dist/node/asciidoctor.cjs",
+      "import": "./dist/node/asciidoctor.js"
     }
   },
   "browser": "dist/browser/asciidoctor.js",

--- a/packages/core/tasks/module/builder.cjs
+++ b/packages/core/tasks/module/builder.cjs
@@ -246,5 +246,6 @@ module.exports = class Builder {
     for (const environment of this.environments) {
       bfs.copySync(`build/asciidoctor-${environment}.js`, `dist/${environment}/asciidoctor.js`)
     }
+    bfs.copySync('build/asciidoctor-node.cjs', 'dist/node/asciidoctor.cjs')
   }
 }


### PR DESCRIPTION
Hi, when importing @asciidoctor/core@3.0.0-alpha.4  with Remix (https://remix.run/) I get the following error:

`TypeError: The "path" argument must be of type string or an instance of URL. Received undefined`

Applying to this line:
https://github.com/asciidoctor/asciidoctor.js/blob/aac44ade02c1ad67f1154fb49243fd0f32f09f51/packages/core/src/template-asciidoctor-node.js#L12

This seems to be because `import.meta.url` is not available in `cjs`. Essentially, Remix converts `esm` packages to `cjs` to run on the server (see here: https://remix.run/docs/en/v1/pages/gotchas#importing-esm-packages).

I'm proposing we keep the release as it is, but copy over the `cjs` as a fallback so it can be used as a dual CommonJS/ES module package.