### PR TITLE
fix(core): typings path and export

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,12 +8,19 @@
   "module": "dist/browser/asciidoctor.js",
   "exports": {
     "node": {
-      "import": "./dist/node/asciidoctor.js",
-      "require": "./dist/node/asciidoctor.cjs"
+      "import": {
+        "default": "./dist/node/asciidoctor.js",
+        "types": "./types/index.d.ts"
+      },
+      "require": {
+        "default": "./dist/node/asciidoctor.cjs",
+        "types": "./types/index.d.ts"
+      }
     },
-    "default": "./dist/browser/asciidoctor.js"
+    "default": "./dist/browser/asciidoctor.js",
+    "types": "./types/index.d.ts"
   },
-  "types": "types",
+  "types": "types/index.d.ts",
   "engines": {
     "node": ">=16",
     "npm": ">=8"


### PR DESCRIPTION
Typescript compiler doesn't seem to find the types unless the full path is specified.
And since the types path doesn't match the exports path, it needs to be added there as well

<img width="676" alt="image" src="https://github.com/asciidoctor/asciidoctor.js/assets/593151/bb366c03-ebc9-4d19-b18e-774b972f995a">
