### PR TITLE
resolves #1719 add context and node_name accessor in the type definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules/
 npm-debug.log
+/.idea/

--- a/packages/core/.gitignore
+++ b/packages/core/.gitignore
@@ -6,3 +6,6 @@ npm-debug.log
 
 # generated using rollup
 /spec/node/asciidoctor.spec.cjs
+
+# IntelliJ project files
+/.idea/

--- a/packages/core/spec/node/asciidoctor.spec.js
+++ b/packages/core/spec/node/asciidoctor.spec.js
@@ -825,6 +825,22 @@ image::https://asciidoctor.org/images/octocat.jpg[GitHub mascot]`
       expect(blocksWithLineNumber.length >= 18).to.be.true()
     })
 
+    it('should be able to convert the context of a block', () => {
+      const doc = asciidoctor.loadFile(resolveFixture('documentblocks.adoc'))
+      const blocks = doc.findBy({ context: 'ulist' })
+      expect(blocks.length).to.equal(2)
+      blocks[0].context = 'colist'
+      expect(blocks[0].getContext()).to.equal('colist')
+    })
+
+    it('should be able to set the name of a node', () => {
+      const doc = asciidoctor.loadFile(resolveFixture('documentblocks.adoc'))
+      const blocks = doc.findBy({ context: 'ulist' })
+      expect(blocks.length).to.equal(2)
+      blocks[0].node_name = 'colist'
+      expect(blocks[0].getNodeName()).to.equal('colist')
+    })
+
     if (asciidoctorCoreSemVer.gte('200')) {
       // REMIND: Before Asciidoctor 2.0.0 date was not UTC
       it('should get document date (and honor SOURCE_DATE_EPOCH)', () => {

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -2716,6 +2716,10 @@ export class AbstractNode implements Logging {
    *
    * @returns An Array of Strings representing the substitution operation or nothing if no subs are found.
    */
+
+  node_name: string;
+  context: string
+
   resolveSubstitutions(subs: string, type?: string, defaults?: string[], subject?: string): string[] | undefined;
 
   /**

--- a/packages/core/types/tests.ts
+++ b/packages/core/types/tests.ts
@@ -108,6 +108,19 @@ assert(doc.getSourcemap());
 // Block
 const block = processor.Block.create(doc, 'paragraph');
 assert(block.getContext() === 'paragraph');
+
+// Try to alter the block context
+block.context = 'ulist';
+assert(block.getContext() === 'ulist');
+block.context = 'paragraph';
+assert(block.getContext() === 'paragraph');
+
+// Try to alter the name of the node
+block.node_name = 'ulist'
+assert(block.getNodeName() === 'ulist')
+block.node_name = 'paragraph'
+assert(block.getNodeName() === 'paragraph')
+
 assert(block.applySubstitutions('<html> -- the root of all web') === '&lt;html&gt;&#8201;&#8212;&#8201;the root of all web');
 assert(Object.keys(block.getAttributes()).length === 0);
 block.setAttribute('awesome', true);


### PR DESCRIPTION
Hi there 👋🏾

In previous versions of the API, it was possible to change the context and name of a block/node by reassigning it in the source code.

```Javascript
block.context = block.node_name = newName
```

I noticed that the ability to do this has been removed from the API. 

It isn't a function that is going to get used a lot, but some code I wrote a while back does rely on it.

This PR will restore the functionality, but uses proper `set` functions to change the values.

