### PR TITLE
Fix: Default condition should be last one

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,16 +9,16 @@
   "exports": {
     "node": {
       "import": {
-        "default": "./dist/node/asciidoctor.js",
-        "types": "./types/index.d.ts"
+        "types": "./types/index.d.ts",
+        "default": "./dist/node/asciidoctor.js"
       },
       "require": {
-        "default": "./dist/node/asciidoctor.cjs",
-        "types": "./types/index.d.cts"
+        "types": "./types/index.d.cts",
+        "default": "./dist/node/asciidoctor.cjs"
       }
     },
-    "default": "./dist/browser/asciidoctor.js",
-    "types": "./types/index.d.ts"
+    "types": "./types/index.d.ts",
+    "default": "./dist/browser/asciidoctor.js"
   },
   "types": "types/index.d.ts",
   "engines": {


### PR DESCRIPTION
In newer versions of Node.js, the module resolution fails as Node expects the default condition to be the last one:

```
Module not found: Error: Default condition should be last one
```

As discussed [here](https://stackoverflow.com/questions/76127288/module-not-found-error-default-condition-should-be-last-one) this simple switch should fix the import