### PR TITLE
Updated path to default Asciidoctor CSS file (NPM dist) in quick-tour.adoc

### DIFF
--- a/docs/modules/setup/pages/quick-tour.adoc
+++ b/docs/modules/setup/pages/quick-tour.adoc
@@ -96,7 +96,7 @@ var doc = asciidoctor.load(fs.readFileSync('/path/to/file.adoc'))
 Asciidoctor.js uses CSS for HTML document styling.
 It comes bundled with a stylesheet, named `asciidoctor.css`.
 
-TIP: The default stylesheet is located at [.path]_node_modules/asciidoctor.js/dist/css/asciidoctor.css_
+TIP: The default stylesheet is located at [.path]_node_modules/@asciidoctor/core/dist/css/asciidoctor.css_
 
 When you generate a document using Node.js, the `asciidoctor.css` stylesheet is embedded into the HTML output by default (when the safe mode is less than `secure`).
 


### PR DESCRIPTION
Docs still mention a node_modules path to `asciidoctor.js` that no longer exists, at least as of  "asciidoctor" package v2.2.7. Looks like that has moved to `@asciidoctor/core` package.