### PR TITLE
Fix missing docs for `resolveSubstitutions` in `AbstractNode`

### DIFF
--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -2706,6 +2706,10 @@ export namespace Table {
  * The state and methods on this class are common to all content segments in an AsciiDoc document.
  */
 export class AbstractNode implements Logging {
+
+  node_name: string;
+  context: string
+
   /**
    * Resolve the list of comma-delimited subs against the possible options.
    *
@@ -2716,10 +2720,6 @@ export class AbstractNode implements Logging {
    *
    * @returns An Array of Strings representing the substitution operation or nothing if no subs are found.
    */
-
-  node_name: string;
-  context: string
-
   resolveSubstitutions(subs: string, type?: string, defaults?: string[], subject?: string): string[] | undefined;
 
   /**

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -2708,7 +2708,7 @@ export namespace Table {
 export class AbstractNode implements Logging {
 
   node_name: string;
-  context: string
+  context: string;
 
   /**
    * Resolve the list of comma-delimited subs against the possible options.


### PR DESCRIPTION
Minor type fix for `AbstractNode` class that moves `node_name` and `context` up to fix the documentation for `resolveSubstitutions`.