### PR TITLE
Add backtick_javascript comments for Opal 2

### DIFF
--- a/packages/core/lib/asciidoctor/js/asciidoctor_ext.rb
+++ b/packages/core/lib/asciidoctor/js/asciidoctor_ext.rb
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 require 'asciidoctor/js/asciidoctor_ext/stylesheet'
 require 'asciidoctor/js/asciidoctor_ext/document'
 require 'asciidoctor/js/asciidoctor_ext/substitutors'

--- a/packages/core/lib/asciidoctor/js/asciidoctor_ext/browser/abstract_node.rb
+++ b/packages/core/lib/asciidoctor/js/asciidoctor_ext/browser/abstract_node.rb
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 module Asciidoctor
 class AbstractNode
   def read_contents target, opts = {}

--- a/packages/core/lib/asciidoctor/js/asciidoctor_ext/document.rb
+++ b/packages/core/lib/asciidoctor/js/asciidoctor_ext/document.rb
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 module Asciidoctor
 class Document < AbstractBlock
 

--- a/packages/core/lib/asciidoctor/js/asciidoctor_ext/node/abstract_node.rb
+++ b/packages/core/lib/asciidoctor/js/asciidoctor_ext/node/abstract_node.rb
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 module Asciidoctor
 class AbstractNode
   def generate_data_uri_from_uri image_uri, cache_uri = false

--- a/packages/core/lib/asciidoctor/js/asciidoctor_ext/node/open_uri.rb
+++ b/packages/core/lib/asciidoctor/js/asciidoctor_ext/node/open_uri.rb
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 require 'stringio'
 
 module OpenURI

--- a/packages/core/lib/asciidoctor/js/asciidoctor_ext/node/stylesheet.rb
+++ b/packages/core/lib/asciidoctor/js/asciidoctor_ext/node/stylesheet.rb
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 module Asciidoctor
 class Stylesheets
   def primary_stylesheet_data

--- a/packages/core/lib/asciidoctor/js/asciidoctor_ext/node/template.rb
+++ b/packages/core/lib/asciidoctor/js/asciidoctor_ext/node/template.rb
@@ -1,4 +1,6 @@
+# backtick_javascript: true
 # frozen_string_literal: true
+
 module Asciidoctor
 # A {Converter} implementation that uses templates composed in template languages
 # to convert {AbstractNode} objects from a parsed AsciiDoc document tree to the backend format.

--- a/packages/core/lib/asciidoctor/js/asciidoctor_ext/parser.rb
+++ b/packages/core/lib/asciidoctor/js/asciidoctor_ext/parser.rb
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 module Asciidoctor
 class Parser
   if `String.prototype.repeat`

--- a/packages/core/lib/asciidoctor/js/asciidoctor_ext/substitutors.rb
+++ b/packages/core/lib/asciidoctor/js/asciidoctor_ext/substitutors.rb
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 module Asciidoctor
 module Substitutors
   # Avoid using Kernel#sprintf for performance and bundle size reasons

--- a/packages/core/lib/asciidoctor/js/opal_ext.rb
+++ b/packages/core/lib/asciidoctor/js/opal_ext.rb
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 require 'asciidoctor/js/opal_ext/kernel'
 require 'asciidoctor/js/opal_ext/file'
 require 'asciidoctor/js/opal_ext/match_data'

--- a/packages/core/lib/asciidoctor/js/opal_ext/array.rb
+++ b/packages/core/lib/asciidoctor/js/opal_ext/array.rb
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 class Array
   %x{
     var encode;

--- a/packages/core/lib/asciidoctor/js/opal_ext/base64.rb
+++ b/packages/core/lib/asciidoctor/js/opal_ext/base64.rb
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 module Base64
   %x{
     var encode, decode;

--- a/packages/core/lib/asciidoctor/js/opal_ext/browser.rb
+++ b/packages/core/lib/asciidoctor/js/opal_ext/browser.rb
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 %x(
   var platform, engine, framework, ioModule;
 

--- a/packages/core/lib/asciidoctor/js/opal_ext/browser/file.rb
+++ b/packages/core/lib/asciidoctor/js/opal_ext/browser/file.rb
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 class File
 
   def self.read(path)

--- a/packages/core/lib/asciidoctor/js/opal_ext/electron/io.rb
+++ b/packages/core/lib/asciidoctor/js/opal_ext/electron/io.rb
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 # Workaround for https://github.com/electron/electron/issues/2033
 $stdout.write_proc = `function(s){console.log(s)}`
 $stderr.write_proc = `function(s){console.error(s)}`

--- a/packages/core/lib/asciidoctor/js/opal_ext/file.rb
+++ b/packages/core/lib/asciidoctor/js/opal_ext/file.rb
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 class File
 
   attr_reader :eof

--- a/packages/core/lib/asciidoctor/js/opal_ext/graalvm.rb
+++ b/packages/core/lib/asciidoctor/js/opal_ext/graalvm.rb
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 %x(
   var platform, engine, framework, ioModule;
 

--- a/packages/core/lib/asciidoctor/js/opal_ext/graalvm/dir.rb
+++ b/packages/core/lib/asciidoctor/js/opal_ext/graalvm/dir.rb
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 class Dir
   class << self
     def pwd

--- a/packages/core/lib/asciidoctor/js/opal_ext/graalvm/file.rb
+++ b/packages/core/lib/asciidoctor/js/opal_ext/graalvm/file.rb
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 class File
 
   def self.read(path)

--- a/packages/core/lib/asciidoctor/js/opal_ext/kernel.rb
+++ b/packages/core/lib/asciidoctor/js/opal_ext/kernel.rb
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 module Kernel
   # basic implementation of open, enough to work with reading files over XMLHttpRequest
   def open(path, *rest)

--- a/packages/core/lib/asciidoctor/js/opal_ext/logger.rb
+++ b/packages/core/lib/asciidoctor/js/opal_ext/logger.rb
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 class Logger
   class Formatter
     def call(severity, time, progname, msg)

--- a/packages/core/lib/asciidoctor/js/opal_ext/node.rb
+++ b/packages/core/lib/asciidoctor/js/opal_ext/node.rb
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 %x(
   var isElectron = typeof navigator === 'object' && typeof navigator.userAgent === 'string' && typeof navigator.userAgent.indexOf('Electron') !== -1,
       platform,

--- a/packages/core/lib/asciidoctor/js/opal_ext/number.rb
+++ b/packages/core/lib/asciidoctor/js/opal_ext/number.rb
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 class Number < Numeric
   def round(ndigits = undefined)
     ndigits = Opal.coerce_to!(ndigits, Integer, :to_int)

--- a/packages/core/lib/asciidoctor/js/opal_ext/phantomjs/file.rb
+++ b/packages/core/lib/asciidoctor/js/opal_ext/phantomjs/file.rb
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 class File
 
   def self.read(path)

--- a/packages/core/lib/asciidoctor/js/opal_ext/spidermonkey/file.rb
+++ b/packages/core/lib/asciidoctor/js/opal_ext/spidermonkey/file.rb
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 class File
 
   def self.read(path)

--- a/packages/core/lib/asciidoctor/js/opal_ext/string.rb
+++ b/packages/core/lib/asciidoctor/js/opal_ext/string.rb
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 class String
   # Safely truncate the string to the specified number of bytes.
   def limit_bytesize size

--- a/packages/core/lib/asciidoctor/js/opal_ext/umd.rb
+++ b/packages/core/lib/asciidoctor/js/opal_ext/umd.rb
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 %x(
   var isNode = typeof process === 'object' && typeof process.versions === 'object' && process.browser != true,
       isElectron = typeof navigator === 'object' && typeof navigator.userAgent === 'string' && typeof navigator.userAgent.indexOf('Electron') !== -1,


### PR DESCRIPTION
In Opal 2 backtick_javascript defaults to false, because Kernel#backtick is implemented. Files using inline JavaScript must add the `# backtick_javascript: true` magic comment. This PR does that. I hope i got them all.