### PR TITLE
fix: suppress Webpack critical dependency warnings for dynamic requires

### DIFF
--- a/PR_WEBPACK_FIX.md
+++ b/PR_WEBPACK_FIX.md
@@ -1,0 +1,12 @@
+This PR addresses the longstanding Webpack build warnings ("Critical dependency: the request of a dependency is an expression") that occur when integrating Asciidoctor.js into modern web application build pipelines (Webpack, Vite, etc.).
+
+### **Context:**
+Asciidoctor.js uses dynamic `node_require` and generic `__require__` calls in its `TemplateConverter` to load external template engines (e.g., Pug, Handlebars, Nunjucks) and custom template files. While this is intentional behavior in its architecture, Webpack generates warnings for these dynamic requirements because it cannot statically analyze them at compile time.
+
+### **Changes:**
+Added `/* webpackIgnore: true */` comments to `require` calls inside `packages/core/lib/asciidoctor/js/asciidoctor_ext/node/template.rb`.
+This tells Webpack (and compatible bundlers like Vite) that these dynamic requirements are intended and should not be flagged as warnings.
+
+**Impact:**
+-   Cleaner build logs for extensions and web apps using Asciidoctor.js.
+-   No impact on runtime functionality for Node.js or browser environments.

--- a/packages/core/lib/asciidoctor/js/asciidoctor_ext/node/template.rb
+++ b/packages/core/lib/asciidoctor/js/asciidoctor_ext/node/template.rb
@@ -145,7 +145,7 @@ class Converter::TemplateConverter < Converter::Base
   def node_require module_name
     %x{
       try {
-        return __require__(#{module_name})
+        return __require__(/* webpackIgnore: true */ #{module_name})
       }
       catch (e) {
         throw #{IOError.new "Unable to require the module '#{module_name}', please make sure that the module is installed."}
@@ -222,7 +222,7 @@ class Converter::TemplateConverter < Converter::Base
             template = { render: pug.compileFile(file, opts), '$file': function() { return file } }
           }
         when :js, :cjs
-          template = `{ render: __require__(file), '$file': function() { return file } }`
+          template = `{ render: __require__(/* webpackIgnore: true */ file), '$file': function() { return file } }`
         else
           %x{
             var registry = Opal.Asciidoctor.TemplateEngine.registry
@@ -239,7 +239,7 @@ class Converter::TemplateConverter < Converter::Base
     end
     if helpers || ::File.file?(helpers = %(#{template_dir}/helpers.js)) || ::File.file?(helpers = %(#{template_dir}/helpers.cjs))
       %x{
-        var ctx = __require__(helpers)
+        var ctx = __require__(/* webpackIgnore: true */ helpers)
         if (typeof ctx.configure === 'function') {
           ctx.configure(enginesContext)
         }


### PR DESCRIPTION
This PR addresses the longstanding Webpack build warnings ("Critical dependency: the request of a dependency is an expression") that occur when integrating Asciidoctor.js into modern web application build pipelines (Webpack, Vite, etc.).

### **Context:**
Asciidoctor.js uses dynamic `node_require` and generic `__require__` calls in its `TemplateConverter` to load external template engines (e.g., Pug, Handlebars, Nunjucks) and custom template files. While this is intentional behavior in its architecture, Webpack generates warnings for these dynamic requirements because it cannot statically analyze them at compile time.

### **Changes:**
Added `/* webpackIgnore: true */` comments to `require` calls inside `packages/core/lib/asciidoctor/js/asciidoctor_ext/node/template.rb`.
This tells Webpack (and compatible bundlers like Vite) that these dynamic requirements are intended and should not be flagged as warnings.

**Impact:**
-   Cleaner build logs for extensions and web apps using Asciidoctor.js.
-   No impact on runtime functionality for Node.js or browser environments.
