### PR TITLE
chore(build): build types and core before publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,24 @@ jobs:
         run: echo ok go
   build:
     needs: activate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint and build
+        run: |
+          npm run lint
+          npm run build --prefix packages/core
+      - name: Check no uncommitted changes after build
+        run: git diff --exit-code
+
+  test:
+    needs: build
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-15]
@@ -40,20 +58,19 @@ jobs:
         run: |
           npm ci
           npx playwright install chromium
-      - name: Lint, build and test
+      - name: Test
         shell: bash
         run: |
-          npm run lint
           npm t --prefix packages/core
           npm run test:browser --prefix packages/core
 
   native_images:
-    needs: build
+    needs: test
     uses: ./.github/workflows/native-image.yml
 
   docs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository_owner == 'asciidoctor'
-    needs: build
+    needs: test
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,9 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci
-          npx playwright install
+      # build
+      - name: Build core
+        run: npm run build --prefix packages/core
       # publish
       - name: Publish
         env:

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,7 +18,7 @@
     "node": ">=24"
   },
   "scripts": {
-    "build": "npm run build:data && rollup -c",
+    "build": "npm run build:data && rollup -c && npm run build:types",
     "build:data": "node scripts/generate-stylesheet-data.js",
     "build:types": "tsc && node scripts/strip-internal.js && node scripts/patch-jsdoc.js",
     "docs": "typedoc --tsconfig tsconfig.docs.json",

--- a/packages/core/scripts/patch-jsdoc.js
+++ b/packages/core/scripts/patch-jsdoc.js
@@ -10,9 +10,10 @@
 import ts from 'typescript'
 import { existsSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-const srcDir = new URL('../src', import.meta.url).pathname
-const typesDir = new URL('../types', import.meta.url).pathname
+const srcDir = fileURLToPath(new URL('../src', import.meta.url))
+const typesDir = fileURLToPath(new URL('../types', import.meta.url))
 
 /** Returns the raw text of the last leading JSDoc comment for a node, or null. */
 function leadingJSDoc(node, src) {
@@ -61,6 +62,52 @@ function reindent(jsdoc, indent) {
     .split('\n')
     .map((line, i) => (i === 0 ? indent + line : indent + ' ' + line.trimStart()))
     .join('\n')
+}
+
+/**
+ * Parses a JS source file and returns the set of class names annotated with @abstract.
+ * TypeScript does not translate the @abstract JSDoc tag to `abstract class` in .d.ts output,
+ * so we detect it here and apply it as a post-processing step.
+ */
+function collectAbstractClasses(jsPath) {
+  const src = readFileSync(jsPath, 'utf-8')
+  const sf = ts.createSourceFile(jsPath, src, ts.ScriptTarget.Latest, true)
+  const names = new Set()
+
+  for (const stmt of sf.statements) {
+    if (!ts.isClassDeclaration(stmt) || !stmt.name) continue
+    const ranges = ts.getLeadingCommentRanges(src, stmt.getFullStart()) ?? []
+    const hasAbstractTag = ranges.some((r) => {
+      const text = src.slice(r.pos, r.end)
+      return text.includes('@abstract')
+    })
+    if (hasAbstractTag) names.add(stmt.name.text)
+  }
+
+  return names
+}
+
+/**
+ * Patches a .d.ts file by adding the `abstract` keyword to class declarations
+ * that correspond to @abstract-annotated classes in the JS source.
+ * Returns true if any changes were made.
+ */
+function patchAbstractClasses(dtsPath, abstractClassNames) {
+  if (!abstractClassNames.size) return false
+  let src = readFileSync(dtsPath, 'utf-8')
+  let changed = false
+
+  for (const name of abstractClassNames) {
+    const before = src
+    src = src.replace(
+      new RegExp(`(export\\s+(?:declare\\s+)?)class\\s+${name}\\b`, 'g'),
+      `$1abstract class ${name}`
+    )
+    if (src !== before) changed = true
+  }
+
+  if (changed) writeFileSync(dtsPath, src, 'utf-8')
+  return changed
 }
 
 /**
@@ -118,6 +165,11 @@ function walk(dir) {
 
     const jsPath = join(srcDir, entry.replace(/\.d\.ts$/, '.js'))
     if (!existsSync(jsPath)) continue
+
+    const abstractClasses = collectAbstractClasses(jsPath)
+    if (patchAbstractClasses(full, abstractClasses)) {
+      console.log(`patched abstract class(es) in ${entry}`)
+    }
 
     const jsdocByExport = collectPropertyJSDoc(jsPath)
     if (!jsdocByExport.size) continue

--- a/packages/core/scripts/strip-internal.js
+++ b/packages/core/scripts/strip-internal.js
@@ -14,6 +14,7 @@ import ts from 'typescript'
 import { readFileSync, writeFileSync } from 'node:fs'
 import { readdirSync, statSync } from 'node:fs'
 import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 function isInternal(node) {
   return ts.getJSDocTags(node).some((tag) => tag.tagName.escapedText === 'internal')
@@ -76,5 +77,5 @@ function walkDir(dir) {
   }
 }
 
-const typesDir = new URL('../types', import.meta.url).pathname
+const typesDir = fileURLToPath(new URL('../types', import.meta.url))
 walkDir(typesDir)

--- a/packages/core/src/abstract_block.js
+++ b/packages/core/src/abstract_block.js
@@ -41,6 +41,7 @@ class StopIteration extends Error {}
 
 /**
  * @template {string | any[]} [TContent=string]
+ * @abstract
  */
 export class AbstractBlock extends AbstractNode {
   /** @type {string|null} */
@@ -50,6 +51,11 @@ export class AbstractBlock extends AbstractNode {
   /** @type {string|null} */
   #caption = null
 
+  /**
+   * @param {AbstractBlock} parent
+   * @param {string} context
+   * @param {object} [opts={}]
+   */
   constructor(parent, context, opts = {}) {
     super(parent, context, opts)
     this.contentModel = 'compound'
@@ -245,7 +251,7 @@ export class AbstractBlock extends AbstractNode {
   /**
    * Append a content block to this block's list of blocks.
    * @param {AbstractBlock} block - The new child block.
-   * @returns {this} this block (enables chaining).
+   * @returns {AbstractBlock} this block (enables chaining).
    */
   append(block) {
     if (block.parent !== this) block.parent = this

--- a/packages/core/src/abstract_node.js
+++ b/packages/core/src/abstract_node.js
@@ -61,14 +61,22 @@ async function isReadable(path) {
 /**
  * An abstract base class that provides state and methods for managing a node of AsciiDoc content.
  * The state and methods on this class are common to all content segments in an AsciiDoc document.
+ * @abstract
  */
 export class AbstractNode {
+  /**
+   * @param {AbstractNode} parent
+   * @param {string} context
+   * @param {object} [opts={}]
+   */
   constructor(parent, context, opts = {}) {
     // document is a special case – should refer to itself
     if (context === 'document') {
+      /** @type {AbstractNode} */
       this.document = this
     } else if (parent) {
       this._parent = parent
+      /** @type {AbstractNode} */
       this.document = parent.document
     }
     this.context = context

--- a/packages/core/src/table.js
+++ b/packages/core/src/table.js
@@ -450,9 +450,10 @@ class Cell extends AbstractBlock {
       if (parentDoctitle) parentDoc.attributes.doctitle = parentDoctitle
       cell._innerDocument = innerDoc
     }
-    return cell
+    return /** @type {Table.Cell} */ cell
   }
 
+  /** @returns {Promise<Table.Cell>} */
   async reinitialize(hasHeader) {
     if (hasHeader) {
       this._reinitializeArgs = null
@@ -462,7 +463,7 @@ class Cell extends AbstractBlock {
       this.style = this.attributes.style ?? null
     }
     if (this._cursor) this._catalogInlineAnchor()
-    return this
+    return /** @type {Table.Cell} */ (this)
   }
 
   _catalogInlineAnchor(cellText = this._text, cursor = null) {

--- a/packages/core/types/abstract_block.d.ts
+++ b/packages/core/types/abstract_block.d.ts
@@ -1,8 +1,14 @@
 /**
  * @template {string | any[]} [TContent=string]
+ * @abstract
  */
-export class AbstractBlock<TContent extends string | any[] = string> extends AbstractNode {
-    constructor(parent: any, context: any, opts?: {});
+export abstract class AbstractBlock<TContent extends string | any[] = string> extends AbstractNode {
+    /**
+     * @param {AbstractBlock} parent
+     * @param {string} context
+     * @param {object} [opts={}]
+     */
+    constructor(parent: AbstractBlock, context: string, opts?: object);
     contentModel: string;
     blocks: any[];
     subs: any[];
@@ -98,9 +104,9 @@ export class AbstractBlock<TContent extends string | any[] = string> extends Abs
     /**
      * Append a content block to this block's list of blocks.
      * @param {AbstractBlock} block - The new child block.
-     * @returns {this} this block (enables chaining).
+     * @returns {AbstractBlock} this block (enables chaining).
      */
-    append(block: AbstractBlock): this;
+    append(block: AbstractBlock): AbstractBlock;
     /**
      * Determine whether this block contains block content.
      * @returns {boolean}

--- a/packages/core/types/abstract_node.d.ts
+++ b/packages/core/types/abstract_node.d.ts
@@ -1,22 +1,29 @@
 /**
  * An abstract base class that provides state and methods for managing a node of AsciiDoc content.
  * The state and methods on this class are common to all content segments in an AsciiDoc document.
+ * @abstract
  */
-export class AbstractNode {
-    constructor(parent: any, context: any, opts?: {});
-    document: any;
-    _parent: any;
-    context: any;
+export abstract class AbstractNode {
+    /**
+     * @param {AbstractNode} parent
+     * @param {string} context
+     * @param {object} [opts={}]
+     */
+    constructor(parent: AbstractNode, context: string, opts?: object);
+    /** @type {AbstractNode} */
+    document: AbstractNode;
+    _parent: AbstractNode;
+    context: string;
     nodeName: string;
     id: string;
     attributes: any;
     passthroughs: any[];
-    set parent(parent: any);
+    set parent(parent: AbstractNode);
     /**
      * Get/Set the parent of this node.
      * The setter also updates the document reference.
      */
-    get parent(): any;
+    get parent(): AbstractNode;
     set role(names: any);
     /**
      * Get the space-separated role string for this node.

--- a/packages/core/types/list.d.ts
+++ b/packages/core/types/list.d.ts
@@ -41,7 +41,7 @@ export class ListItem extends AbstractBlock<string> {
     _text: string;
     subs: string[];
     /** Contextual alias for parent. */
-    get list(): any;
+    get list(): import("./abstract_node.js").AbstractNode;
     /**
      * Return the text of this list item with substitutions applied.
      * Synchronous because text is pre-computed during parse().

--- a/packages/core/types/table.d.ts
+++ b/packages/core/types/table.d.ts
@@ -43,9 +43,10 @@ declare class Rows {
     };
 }
 declare class Column extends AbstractNode {
+    constructor(table: any, index: any, attributes?: {});
     style: any;
     /** Alias for parent (always a Table). */
-    get table(): any;
+    get table(): AbstractNode;
     isBlock(): boolean;
     isInline(): boolean;
 }
@@ -67,7 +68,7 @@ declare class Cell extends AbstractBlock<string> {
     static create(column: {
         style: any;
         /** Alias for parent (always a Table). */
-        get table(): any;
+        get table(): AbstractNode;
         /**
          * Calculate and assign the widths for this column.
          * @param {number|null} colPcwidth
@@ -79,15 +80,15 @@ declare class Cell extends AbstractBlock<string> {
         assignWidth(colPcwidth: number | null, widthBase: number | null, precision: number): number;
         isBlock(): boolean;
         isInline(): boolean;
-        document: any;
-        _parent: any;
-        context: any;
+        document: AbstractNode;
+        _parent: AbstractNode;
+        context: string;
         nodeName: string;
         id: string;
         attributes: any;
         passthroughs: any[];
-        get parent(): any;
-        set parent(parent: any);
+        get parent(): AbstractNode;
+        set parent(parent: AbstractNode);
         get role(): any;
         set role(names: any);
         get roles(): any;
@@ -141,7 +142,7 @@ declare class Cell extends AbstractBlock<string> {
         readAsset(path: string, opts?: any): Promise<string | null>;
         readContents(target: string, opts?: any): Promise<string | null>;
         isUri(str: string): boolean;
-        readonly logger: any;
+        get logger(): any;
     }, cellText: string, attributes?: any, opts?: any): Promise<typeof Cell>;
     constructor(column: any, cellText: any, attributes?: {}, opts?: {});
     _cursor: any;
@@ -150,13 +151,13 @@ declare class Cell extends AbstractBlock<string> {
     rowspan: number;
     _innerDocSetup: {
         lines: any;
-        parentDoc: any;
+        parentDoc: AbstractNode;
         parentDoctitle: any;
         options: {
             safe: any;
             backend: any;
             header_footer: boolean;
-            parent: any;
+            parent: AbstractNode;
             cursor: any;
         };
     };
@@ -164,8 +165,9 @@ declare class Cell extends AbstractBlock<string> {
     _text: any;
     style: any;
     /** Alias for parent (always a Column). */
-    get column(): any;
-    reinitialize(hasHeader: any): Promise<typeof Cell | this>;
+    get column(): AbstractNode;
+    /** @returns {Promise<Table.Cell>} */
+    reinitialize(hasHeader: any): Promise<typeof Cell>;
     _catalogInlineAnchor(cellText?: any, cursor?: any): void;
     set text(val: string | null);
     /**


### PR DESCRIPTION
- support `@abstract` annotation when generating types
- check that `npm run build` has been run


resolves https://github.com/asciidoctor/asciidoctor.js/issues/1117