### PR TITLE
Reduce breaking changes — add missing API methods and fix docs  

### DIFF
--- a/docs/modules/setup/pages/install.adoc
+++ b/docs/modules/setup/pages/install.adoc
@@ -43,7 +43,7 @@ Learn more about https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/M
 
 [source,js]
 ----
-import asciidoctor from '@asciidoctor/core'
+import { convert } from '@asciidoctor/core'
 ----
 
 [NOTE]
@@ -51,7 +51,7 @@ import asciidoctor from '@asciidoctor/core'
 `@asciidoctor/core` is also available as a CommonJS (CJS) module:
 [source,js]
 ----
-const asciidoctor = require('@asciidoctor/core')
+const { convert } = require('@asciidoctor/core')
 ----
 ====
 

--- a/docs/modules/setup/pages/migration-guide.adoc
+++ b/docs/modules/setup/pages/migration-guide.adoc
@@ -168,11 +168,6 @@ Some internal properties and options that retained the Ruby `snake_case` style i
 | `Asciidoctor.getRuntime()` → `Object`
 | Returns platform / engine / GEM_HOME info; no equivalent concept in a native JS library
 
-| `Section.setIndex(index)` / `setSectionName(name)` / `setSpecial(value)`
-| Internal setters used by the parser; not yet exposed as public API
-
-| `ListItem.getList()` → `List`
-| Use `getParent()` instead
 |===
 
 == New in v4

--- a/docs/modules/setup/pages/migration-guide.adoc
+++ b/docs/modules/setup/pages/migration-guide.adoc
@@ -18,19 +18,19 @@ All parsing and conversion operations now return a `Promise` and must be awaited
 | v3 (Opal) | v4 (native) | Note
 
 | `asciidoctor.load(source, opts)` → `Document`
-| `asciidoctor.load(source, opts)` → `Promise<Document>`
+| `load(source, opts)` → `Promise<Document>`
 | Must be awaited
 
 | `asciidoctor.loadFile(path, opts)` → `Document`
-| `asciidoctor.loadFile(path, opts)` → `Promise<Document>`
+| `loadFile(path, opts)` → `Promise<Document>`
 | Must be awaited
 
 | `asciidoctor.convert(source, opts)` → `string`
-| `asciidoctor.convert(source, opts)` → `Promise<string>`
+| `convert(source, opts)` → `Promise<string>`
 | Must be awaited
 
 | `asciidoctor.convertFile(path, opts)` → `string`
-| `asciidoctor.convertFile(path, opts)` → `Promise<string>`
+| `convertFile(path, opts)` → `Promise<string>`
 | Must be awaited
 
 | `document.parse(data?)` → `Document`
@@ -54,11 +54,6 @@ v4 uses named exports — import only what you need, no factory call needed.
 | `require('@asciidoctor/core')()` → must call the factory
 | `import { load, convert } from '@asciidoctor/core'` → use functions directly
 |===
-
-=== ESM only
-
-v4 is distributed exclusively as ES modules.
-Use `import` instead of `require`.
 
 === Strict camelCase naming
 

--- a/packages/core/src/abstract_block.js
+++ b/packages/core/src/abstract_block.js
@@ -518,10 +518,10 @@ export class AbstractBlock extends AbstractNode {
     if (this.context === 'document') return null
     const p = this.parent
     if (p.context === 'dlist' && this.context === 'list_item') {
-      const idx = p.items.findIndex(
+      const idx = p.getItems().findIndex(
         ([terms, desc]) => terms.includes(this) || desc === this
       )
-      const sib = p.items[idx + 1]
+      const sib = p.getItems()[idx + 1]
       return sib ? sib : p.nextAdjacentBlock()
     }
     const idx = p.blocks.indexOf(this)

--- a/packages/core/src/abstract_block.js
+++ b/packages/core/src/abstract_block.js
@@ -267,7 +267,7 @@ export class AbstractBlock extends AbstractNode {
    * @returns {AbstractBlock} this block (enables chaining).
    */
   append(block) {
-    if (block.parent !== this) block.parent = this
+    if (block.getParent() !== this) block.parent = this
     this.blocks.push(block)
     return this
   }
@@ -516,7 +516,7 @@ export class AbstractBlock extends AbstractNode {
    */
   nextAdjacentBlock() {
     if (this.context === 'document') return null
-    const p = this.parent
+    const p = this.getParent()
     if (p.context === 'dlist' && this.context === 'list_item') {
       const idx = p.getItems().findIndex(
         ([terms, desc]) => terms.includes(this) || desc === this

--- a/packages/core/src/abstract_node.js
+++ b/packages/core/src/abstract_node.js
@@ -72,12 +72,12 @@ export class AbstractNode {
   constructor(parent, context, opts = {}) {
     // document is a special case – should refer to itself
     if (context === 'document') {
-      /** @type {AbstractNode} */
-      this.document = this
+      /** @type {Document} */
+      this.document = /** @type {Document} */ this
     } else if (parent) {
-      /** @type {AbstractNode} */
+      /** @internal */
       this._parent = parent
-      /** @type {AbstractNode} */
+      /** @type {Document} */
       this.document = parent.document
     }
     this.context = context
@@ -90,13 +90,9 @@ export class AbstractNode {
   }
 
   /**
-   * Get/Set the parent of this node.
-   * The setter also updates the document reference.
+   * Set the parent of this node.
+   * Also updates the document reference.
    */
-  get parent() {
-    return this._parent
-  }
-
   set parent(parent) {
     this._parent = parent
     this.document = parent.document
@@ -370,7 +366,7 @@ export class AbstractNode {
    * @returns {AbstractNode|undefined} the parent AbstractNode, or undefined for the root document.
    */
   getParent() {
-    return this.parent
+    return this._parent
   }
 
   /**

--- a/packages/core/src/converter/docbook5.js
+++ b/packages/core/src/converter/docbook5.js
@@ -363,14 +363,14 @@ export class DocBook5Converter extends ConverterBase {
     const reftext = node.reftext
     switch (node.style) {
       case 'abstract': {
-        if (node.parent === node.document && node.document.doctype === 'book') {
+        if (node.getParent() === node.document && node.document.doctype === 'book') {
           this.logger.warn(
             'abstract block cannot be used in a document without a doctitle when doctype is book. Excluding block content.'
           )
           return ''
         }
         let res = `<abstract>\n${this._titleTag(node)}${await this._encloseContent(node)}\n</abstract>`
-        const parent = node.parent
+        const parent = node.getParent()
         if (
           this.backend === 'docbook5' &&
           !node.hasOption('root') &&
@@ -387,7 +387,7 @@ export class DocBook5Converter extends ConverterBase {
       case 'partintro': {
         if (
           node.level === 0 &&
-          node.parent.context === 'section' &&
+          node.getParent().context === 'section' &&
           node.document.doctype === 'book'
         ) {
           return `<partintro${this._commonAttributes(id, role, reftext)}>\n${this._titleTag(node)}${await this._encloseContent(node)}\n</partintro>`
@@ -913,11 +913,11 @@ export class DocBook5Converter extends ConverterBase {
    * @private
    */
   _extractAbstract(document, abstract) {
-    let parent = abstract.parent
+    let parent = abstract.getParent()
     let toDelete = abstract
     while (parent !== document && parent.blocks.length === 1) {
       toDelete = parent
-      parent = parent.parent
+      parent = parent.getParent()
     }
     parent.blocks.splice(parent.blocks.indexOf(toDelete), 1)
     return abstract
@@ -928,7 +928,7 @@ export class DocBook5Converter extends ConverterBase {
    * @private
    */
   _restoreAbstract(abstract) {
-    abstract.parent.blocks.unshift(abstract)
+    abstract.getParent().blocks.unshift(abstract)
   }
 
   /**

--- a/packages/core/src/converter/docbook5.js
+++ b/packages/core/src/converter/docbook5.js
@@ -183,9 +183,9 @@ export class DocBook5Converter extends ConverterBase {
       `<calloutlist${this._commonAttributes(node.id, node.role, node.reftext)}>`
     )
     if (node.hasTitle()) result.push(`<title>${node.title}</title>`)
-    for (const item of node.items) {
+    for (const item of node.getItems()) {
       result.push(`<callout arearefs="${item.attr('coids')}">`)
-      result.push(`<para>${item.text}</para>`)
+      result.push(`<para>${item.getText()}</para>`)
       if (item.hasBlocks()) result.push(await item.content())
       result.push('</callout>')
     }
@@ -204,12 +204,12 @@ export class DocBook5Converter extends ConverterBase {
       result.push(`<colspec colwidth="${node.attr('labelwidth', 15)}*"/>`)
       result.push(`<colspec colwidth="${node.attr('itemwidth', 85)}*"/>`)
       result.push('<tbody valign="top">')
-      for (const [terms, dd] of node.items) {
+      for (const [terms, dd] of node.getItems()) {
         result.push('<row>\n<entry>')
-        for (const dt of terms) result.push(`<simpara>${dt.text}</simpara>`)
+        for (const dt of terms) result.push(`<simpara>${dt.getText()}</simpara>`)
         result.push('</entry>\n<entry>')
         if (dd) {
-          if (dd.hasText()) result.push(`<simpara>${dd.text}</simpara>`)
+          if (dd.hasText()) result.push(`<simpara>${dd.getText()}</simpara>`)
           if (dd.hasBlocks()) result.push(await dd.content())
         }
         result.push('</entry>\n</row>')
@@ -230,15 +230,15 @@ export class DocBook5Converter extends ConverterBase {
         )
         if (node.hasTitle()) result.push(`<title>${node.title}</title>`)
       }
-      for (const [terms, dd] of node.items) {
+      for (const [terms, dd] of node.getItems()) {
         result.push(`<${entryTag}>`)
         if (labelTag) result.push(`<${labelTag}>`)
         for (const dt of terms)
-          result.push(`<${termTag}>${dt.text}</${termTag}>`)
+          result.push(`<${termTag}>${dt.getText()}</${termTag}>`)
         if (labelTag) result.push(`</${labelTag}>`)
         result.push(`<${itemTag}>`)
         if (dd) {
-          if (dd.hasText()) result.push(`<simpara>${dd.text}</simpara>`)
+          if (dd.hasText()) result.push(`<simpara>${dd.getText()}</simpara>`)
           if (dd.hasBlocks()) result.push(await dd.content())
         }
         result.push(`</${itemTag}>`)
@@ -347,9 +347,9 @@ export class DocBook5Converter extends ConverterBase {
       `<orderedlist${this._commonAttributes(node.id, node.role, node.reftext)}${numAttribute}${startAttribute}>`
     )
     if (node.hasTitle()) result.push(`<title>${node.title}</title>`)
-    for (const item of node.items) {
+    for (const item of node.getItems()) {
       result.push(`<listitem${this._commonAttributes(item.id, item.role)}>`)
-      result.push(`<simpara>${item.text}</simpara>`)
+      result.push(`<simpara>${item.getText()}</simpara>`)
       if (item.hasBlocks()) result.push(await item.content())
       result.push('</listitem>')
     }
@@ -554,9 +554,9 @@ export class DocBook5Converter extends ConverterBase {
         `<bibliodiv${this._commonAttributes(node.id, node.role, node.reftext)}>`
       )
       if (node.hasTitle()) result.push(`<title>${node.title}</title>`)
-      for (const item of node.items) {
+      for (const item of node.getItems()) {
         result.push('<bibliomixed>')
-        result.push(`<bibliomisc>${item.text}</bibliomisc>`)
+        result.push(`<bibliomisc>${item.getText()}</bibliomisc>`)
         if (item.hasBlocks()) result.push(await item.content())
         result.push('</bibliomixed>')
       }
@@ -569,7 +569,7 @@ export class DocBook5Converter extends ConverterBase {
         `<itemizedlist${this._commonAttributes(node.id, node.role, node.reftext)}${markAttribute}>`
       )
       if (node.hasTitle()) result.push(`<title>${node.title}</title>`)
-      for (const item of node.items) {
+      for (const item of node.getItems()) {
         const textMarker =
           checklist && item.hasAttr('checkbox')
             ? item.hasAttr('checked')
@@ -577,7 +577,7 @@ export class DocBook5Converter extends ConverterBase {
               : '&#10063; '
             : ''
         result.push(`<listitem${this._commonAttributes(item.id, item.role)}>`)
-        result.push(`<simpara>${textMarker}${item.text}</simpara>`)
+        result.push(`<simpara>${textMarker}${item.getText()}</simpara>`)
         if (item.hasBlocks()) result.push(await item.content())
         result.push('</listitem>')
       }

--- a/packages/core/src/converter/html5.js
+++ b/packages/core/src/converter/html5.js
@@ -1005,7 +1005,7 @@ ${equation}
   async convert_open(node) {
     const style = node.style
     if (style === 'abstract') {
-      if (node.parent === node.document && node.document.doctype === 'book') {
+      if (node.getParent() === node.document && node.document.doctype === 'book') {
         this.logger.warn(
           'abstract block cannot be used in a document without a doctitle when doctype is book. Excluding block content.'
         )
@@ -1025,7 +1025,7 @@ ${await node.content()}
     if (
       style === 'partintro' &&
       (node.level > 0 ||
-        node.parent.context !== 'section' ||
+        node.getParent().context !== 'section' ||
         node.document.doctype !== 'book')
     ) {
       this.logger.error(

--- a/packages/core/src/converter/html5.js
+++ b/packages/core/src/converter/html5.js
@@ -663,7 +663,7 @@ Your browser does not support the audio tag.
       result.push('<table>')
       const fontIcons = node.document.hasAttr('icons', 'font')
       let num = 0
-      for (const item of node.items) {
+      for (const item of node.getItems()) {
         num++
         let numLabel
         if (fontIcons) {
@@ -673,15 +673,15 @@ Your browser does not support the audio tag.
         }
         result.push(`<tr>
 <td>${numLabel}</td>
-<td>${item.text}${item.hasBlocks() ? LF + (await item.content()) : ''}</td>
+<td>${item.getText()}${item.hasBlocks() ? LF + (await item.content()) : ''}</td>
 </tr>`)
       }
       result.push('</table>')
     } else {
       result.push('<ol>')
-      for (const item of node.items) {
+      for (const item of node.getItems()) {
         result.push(`<li>
-<p>${item.text}</p>${item.hasBlocks() ? LF + (await item.content()) : ''}
+<p>${item.getText()}</p>${item.hasBlocks() ? LF + (await item.content()) : ''}
 </li>`)
       }
       result.push('</ol>')
@@ -713,13 +713,13 @@ Your browser does not support the audio tag.
     switch (node.style) {
       case 'qanda':
         result.push('<ol>')
-        for (const [terms, dd] of node.items) {
+        for (const [terms, dd] of node.getItems()) {
           result.push('<li>')
           for (const dt of terms) {
-            result.push(`<p><em>${dt.text}</em></p>`)
+            result.push(`<p><em>${dt.getText()}</em></p>`)
           }
           if (dd) {
-            if (dd.hasText()) result.push(`<p>${dd.text}</p>`)
+            if (dd.hasText()) result.push(`<p>${dd.getText()}</p>`)
             if (dd.hasBlocks()) result.push(await dd.content())
           }
           result.push('</li>')
@@ -741,7 +741,7 @@ Your browser does not support the audio tag.
           result.push(`<col${itemWidthAttr}${slash}>`)
           result.push('</colgroup>')
         }
-        for (const [terms, dd] of node.items) {
+        for (const [terms, dd] of node.getItems()) {
           result.push('<tr>')
           result.push(
             `<td class="hdlist1${node.hasOption('strong') ? ' strong' : ''}">`
@@ -749,13 +749,13 @@ Your browser does not support the audio tag.
           let firstTerm = true
           for (const dt of terms) {
             if (!firstTerm) result.push(`<br${slash}>`)
-            result.push(dt.text)
+            result.push(dt.getText())
             firstTerm = false
           }
           result.push('</td>')
           result.push('<td class="hdlist2">')
           if (dd) {
-            if (dd.hasText()) result.push(`<p>${dd.text}</p>`)
+            if (dd.hasText()) result.push(`<p>${dd.getText()}</p>`)
             if (dd.hasBlocks()) result.push(await dd.content())
           }
           result.push('</td>')
@@ -767,13 +767,13 @@ Your browser does not support the audio tag.
       default: {
         result.push('<dl>')
         const dtStyleAttribute = node.style ? '' : ' class="hdlist1"'
-        for (const [terms, dd] of node.items) {
+        for (const [terms, dd] of node.getItems()) {
           for (const dt of terms) {
-            result.push(`<dt${dtStyleAttribute}>${dt.text}</dt>`)
+            result.push(`<dt${dtStyleAttribute}>${dt.getText()}</dt>`)
           }
           if (!dd) continue
           result.push('<dd>')
-          if (dd.hasText()) result.push(`<p>${dd.text}</p>`)
+          if (dd.hasText()) result.push(`<p>${dd.getText()}</p>`)
           if (dd.hasBlocks()) result.push(await dd.content())
           result.push('</dd>')
         }
@@ -982,7 +982,7 @@ ${equation}
       `<ol class="${node.style}"${typeAttribute}${startAttribute}${reversedAttribute}>`
     )
 
-    for (const item of node.items) {
+    for (const item of node.getItems()) {
       if (item.id) {
         result.push(
           `<li id="${item.id}"${item.role ? ` class="${item.role}"` : ''}>`
@@ -992,7 +992,7 @@ ${equation}
       } else {
         result.push('<li>')
       }
-      result.push(`<p>${item.text}</p>`)
+      result.push(`<p>${item.getText()}</p>`)
       if (item.hasBlocks()) result.push(await item.content())
       result.push('</li>')
     }
@@ -1308,7 +1308,7 @@ ${await doc.converter.convert(doc, 'outline', levels != null ? { toclevels: leve
     if (node.hasTitle()) result.push(`<div class="title">${node.title}</div>`)
     result.push(`<ul${ulClassAttribute}>`)
 
-    for (const item of node.items) {
+    for (const item of node.getItems()) {
       if (item.id) {
         result.push(
           `<li id="${item.id}"${item.role ? ` class="${item.role}"` : ''}>`
@@ -1320,10 +1320,10 @@ ${await doc.converter.convert(doc, 'outline', levels != null ? { toclevels: leve
       }
       if (checklist && item.hasAttr('checkbox')) {
         result.push(
-          `<p>${item.hasAttr('checked') ? markerChecked : markerUnchecked}${item.text}</p>`
+          `<p>${item.hasAttr('checked') ? markerChecked : markerUnchecked}${item.getText()}</p>`
         )
       } else {
-        result.push(`<p>${item.text}</p>`)
+        result.push(`<p>${item.getText()}</p>`)
       }
       if (item.hasBlocks()) result.push(await item.content())
       result.push('</li>')

--- a/packages/core/src/converter/manpage.js
+++ b/packages/core/src/converter/manpage.js
@@ -231,9 +231,9 @@ ${await this._encloseContent(node)}
     result.push('.TS\ntab(:);\nr lw(\\n(.lu*75u/100u).')
 
     let num = 0
-    for (const item of node.items) {
+    for (const item of node.getItems()) {
       result.push(`\\fB(${++num})\\fP\\h'-2n':T{`)
-      result.push(this.manify(item.text, { whitespace: 'normalize' }))
+      result.push(this.manify(item.getText(), { whitespace: 'normalize' }))
       if (item.hasBlocks()) result.push(await item.content())
       result.push('T}')
     }
@@ -248,21 +248,21 @@ ${await this._encloseContent(node)}
       result.push(`.sp\n.B ${this.manify(node.title)}\n.br`)
     }
     let counter = 0
-    for (const [terms, dd] of node.items) {
+    for (const [terms, dd] of node.getItems()) {
       counter++
       if (node.style === 'qanda') {
         result.push(
-          `.sp\n${counter}. ${this.manify(terms.map((dt) => dt.text).join(' '))}\n.RS 4`
+          `.sp\n${counter}. ${this.manify(terms.map((dt) => dt.getText()).join(' '))}\n.RS 4`
         )
       } else {
         result.push(
-          `.sp\n${this.manify(terms.map((dt) => dt.text).join(', '), { whitespace: 'normalize' })}\n.RS 4`
+          `.sp\n${this.manify(terms.map((dt) => dt.getText()).join(', '), { whitespace: 'normalize' })}\n.RS 4`
         )
       }
       if (dd) {
         let hasText = false
         if (dd.hasText()) {
-          result.push(this.manify(dd.text, { whitespace: 'normalize' }))
+          result.push(this.manify(dd.getText(), { whitespace: 'normalize' }))
           hasText = true
         }
         if (dd.hasBlocks()) {
@@ -343,9 +343,9 @@ ${this.manify(await node.content(), { whitespace: 'preserve' })}
 
     const start = parseInt(node.attr('start', 1), 10)
     let idx = 0
-    for (const item of node.items) {
+    for (const item of node.getItems()) {
       const numeral = idx + start
-      const listText = this.manify(item.text, { whitespace: 'normalize' })
+      const listText = this.manify(item.getText(), { whitespace: 'normalize' })
       result.push(`.sp
 .RS 4
 .ie n \\{\\
@@ -581,8 +581,8 @@ ${this.manify(await node.content(), { whitespace: 'preserve' })}
     if (node.hasTitle()) {
       result.push(`.sp\n.B ${this.manify(node.title)}\n.br`)
     }
-    for (const item of node.items) {
-      const listText = this.manify(item.text, { whitespace: 'normalize' })
+    for (const item of node.getItems()) {
+      const listText = this.manify(item.getText(), { whitespace: 'normalize' })
       result.push(`.sp
 .RS 4
 .ie n \\{\\

--- a/packages/core/src/list.js
+++ b/packages/core/src/list.js
@@ -20,22 +20,17 @@ export class List extends AbstractBlock {
     super(parent, context, opts)
   }
 
-  /** Alias for blocks — the list items. */
-  get items() {
-    return this.blocks
-  }
-
   /** Alias for blocks — the list content. */
   async content() {
     return this.blocks
   }
 
   /**
-   * Return the list items (alias for items / blocks).
+   * Return the list items.
    * @returns {ListItem[]}
    */
   getItems() {
-    return this.items
+    return this.blocks
   }
 
   /**
@@ -89,6 +84,15 @@ export class ListItem extends AbstractBlock {
    */
   marker
 
+  /** @internal @type {string|null} */
+  _text
+
+  /** @internal */
+  _convertedText
+
+  /** @internal @type {string[]} */
+  _subsSnapshot
+
   /**
    * @param {List} parent - The parent List block.
    * @param {string|null} [text=null] - The text of this item.
@@ -103,16 +107,41 @@ export class ListItem extends AbstractBlock {
 
   /** Contextual alias for parent. */
   get list() {
-    return this.parent
+    return this.getParent()
+  }
+
+  /**
+   * Return the parent List block (alias of getParent).
+   * @returns {List}
+   */
+  getList() {
+    return this.getParent()
   }
 
   /**
    * Return the text of this list item with substitutions applied.
-   * Synchronous because text is pre-computed during parse().
+   * The result is pre-computed during `Document.parse()` via {@link precomputeText}.
+   * Falls back to the raw text if {@link precomputeText} has not been called yet.
+   *
+   * In Ruby, text is lazy (`apply_subs` on first access), so API callers can modify
+   * subs before accessing text and get the result they expect. Here we replicate
+   * that by invalidating the pre-computed value when subs have changed since it
+   * was computed: returning raw text mirrors what Ruby would produce when subs are
+   * cleared or reduced to a no-op set (since `applySubs` is async and cannot be
+   * re-run synchronously).
    * @returns {string|null}
    */
   getText() {
-    return this.text
+    if (this._convertedText != null && this._subsSnapshot != null) {
+      const cur = this.subs
+      if (
+        cur.length !== this._subsSnapshot.length ||
+        cur.some((s, i) => s !== this._subsSnapshot[i])
+      ) {
+        return this._text ?? null
+      }
+    }
+    return this._convertedText ?? this._text ?? null
   }
 
   /**
@@ -132,32 +161,6 @@ export class ListItem extends AbstractBlock {
   }
 
   /**
-   * Get the string text with substitutions applied.
-   * The result is pre-computed during `Document.parse()` via {@link precomputeText}.
-   * Falls back to the raw text if {@link precomputeText} has not been called yet.
-   *
-   * In Ruby, text is lazy (`apply_subs` on first access), so API callers can modify
-   * subs before accessing text and get the result they expect. Here we replicate
-   * that by invalidating the pre-computed value when subs have changed since it
-   * was computed: returning raw text mirrors what Ruby would produce when subs are
-   * cleared or reduced to a no-op set (since `applySubs` is async and cannot be
-   * re-run synchronously).
-   * @returns {string|null}
-   */
-  get text() {
-    if (this._convertedText != null && this._subsSnapshot != null) {
-      const cur = this.subs
-      if (
-        cur.length !== this._subsSnapshot.length ||
-        cur.some((s, i) => s !== this._subsSnapshot[i])
-      ) {
-        return this._text ?? null
-      }
-    }
-    return this._convertedText ?? this._text ?? null
-  }
-
-  /**
    * Pre-compute the converted text asynchronously.
    * Called during `Document.parse()` so the synchronous getter works during conversion.
    * @returns {Promise<void>}
@@ -173,7 +176,7 @@ export class ListItem extends AbstractBlock {
    * Set the raw text of this list item.
    * @param {string|null} val
    */
-  set text(val) {
+  setText(val) {
     this._text = val
     this._convertedText = null
     this._subsSnapshot = null
@@ -208,6 +211,6 @@ export class ListItem extends AbstractBlock {
   }
 
   toString() {
-    return `#<ListItem {list_context: '${this.parent.context}', text: ${JSON.stringify(this._text)}, blocks: ${(this.blocks ?? []).length}}>`
+    return `#<ListItem {list_context: '${this.getParent().context}', text: ${JSON.stringify(this._text)}, blocks: ${(this.blocks ?? []).length}}>`
   }
 }

--- a/packages/core/src/parser.js
+++ b/packages/core/src/parser.js
@@ -1919,7 +1919,7 @@ export class Parser {
             listBlock.attributes['checklist-option'] = ''
             listItem.attributes.checkbox = ''
             if (!itemText.startsWith('[ ')) listItem.attributes.checked = ''
-            listItem.text = itemText.slice(4)
+            listItem.setText(itemText.slice(4))
           }
         }
       } else if (listType === 'olist') {

--- a/packages/core/src/section.js
+++ b/packages/core/src/section.js
@@ -78,8 +78,8 @@ export class Section extends AbstractBlock {
   sectnum(delimiter = '.', append = null) {
     const suffix =
       append !== null ? (append === false ? '' : append) : delimiter
-    if (this.level > 1 && this.parent instanceof Section) {
-      return `${this.parent.sectnum(delimiter, delimiter)}${this.numeral ?? ''}${suffix}`
+    if (this.level > 1 && this.getParent() instanceof Section) {
+      return `${this.getParent().sectnum(delimiter, delimiter)}${this.numeral ?? ''}${suffix}`
     }
     return `${this.numeral ?? ''}${suffix}`
   }

--- a/packages/core/src/section.js
+++ b/packages/core/src/section.js
@@ -183,11 +183,27 @@ export class Section extends AbstractBlock {
   }
 
   /**
+   * Set the section name (e.g. 'section', 'appendix').
+   * @param {string|null} val
+   */
+  setSectionName(val) {
+    this.sectname = val
+  }
+
+  /**
    * Get the 0-based index of this section within the parent block.
    * @returns {number}
    */
   getIndex() {
     return this.index
+  }
+
+  /**
+   * Set the 0-based index of this section within the parent block.
+   * @param {number} val
+   */
+  setIndex(val) {
+    this.index = val
   }
 
   /**
@@ -204,6 +220,14 @@ export class Section extends AbstractBlock {
    */
   isSpecial() {
     return this.special
+  }
+
+  /**
+   * Set whether this section is a special section.
+   * @param {boolean} val
+   */
+  setSpecial(val) {
+    this.special = val
   }
 
   /**

--- a/packages/core/src/substitutors.js
+++ b/packages/core/src/substitutors.js
@@ -1087,7 +1087,7 @@ export const Substitutors = {
     if (
       foundSquareBracket &&
       this.context === 'list_item' &&
-      this.parent.style === 'bibliography'
+      this.getParent().style === 'bibliography'
     ) {
       text = await asyncReplace(
         text,

--- a/packages/core/src/table.js
+++ b/packages/core/src/table.js
@@ -246,7 +246,7 @@ Table.Column = class Column extends AbstractNode {
 
   /** Alias for parent (always a Table). */
   get table() {
-    return this.parent
+    return this.getParent()
   }
 
   /**
@@ -266,7 +266,7 @@ Table.Column = class Column extends AbstractNode {
       if (Math.trunc(colPcwidth) === colPcwidth)
         colPcwidth = Math.trunc(colPcwidth)
     }
-    const tableAbswidth = this.parent.attributes.tableabswidth
+    const tableAbswidth = this.getParent().attributes.tableabswidth
     if (tableAbswidth != null) {
       const colAbswidth = truncate(
         (colPcwidth / 100.0) * tableAbswidth,
@@ -425,7 +425,7 @@ class Cell extends AbstractBlock {
 
   /** Alias for parent (always a Column). */
   get column() {
-    return this.parent
+    return this.getParent()
   }
 
   /**
@@ -530,7 +530,7 @@ class Cell extends AbstractBlock {
         const cs = this.style
         parts.push(
           cs && cs !== 'header'
-            ? await new Inline(this.parent, 'quoted', para, {
+            ? await new Inline(this.getParent(), 'quoted', para, {
                 type: cs,
               }).convert()
             : para
@@ -543,7 +543,7 @@ class Cell extends AbstractBlock {
     const cs = this.style
     if (cs && cs !== 'header') {
       return [
-        await new Inline(this.parent, 'quoted', subbedText, {
+        await new Inline(this.getParent(), 'quoted', subbedText, {
           type: cs,
         }).convert(),
       ]

--- a/packages/core/test/lists.test.js
+++ b/packages/core/test/lists.test.js
@@ -411,7 +411,7 @@ NOTE: This is a note.
 <1> a configuration value
 `
       const doc = await documentFromString(input)
-      const colist = doc.blocks[0].items[0].blocks[doc.blocks[0].items[0].blocks.length - 1]
+      const colist = doc.blocks[0].getItems()[0].blocks[doc.blocks[0].getItems()[0].blocks.length - 1]
       assert.equal(colist.context, 'colist')
       assert.notEqual(colist.style, 'source')
       const output = await doc.convert()
@@ -2742,8 +2742,8 @@ category b::
 paragraph
 `
       const doc = await documentFromString(input)
-      const dd = doc.blocks[0].items[0][1]
-      assert.equal(dd.text, null)
+      const dd = doc.blocks[0].getItems()[0][1]
+      assert.equal(dd.getText(), null)
     })
 
     test('should match trailing line separator in text of list item', async () => {
@@ -4968,11 +4968,11 @@ describe('Checklists', () => {
     const doc = await documentFromString(input)
     const checklist = doc.blocks[0]
     assert.ok(checklist.hasOption('checklist'), 'checklist should have checklist option')
-    assert.ok(checklist.items[0].hasAttribute('checkbox'), 'item 0 should have checkbox attr')
-    assert.ok(!checklist.items[0].hasAttribute('checked'), 'item 0 should not have checked attr')
-    assert.ok(checklist.items[1].hasAttribute('checkbox'), 'item 1 should have checkbox attr')
-    assert.ok(checklist.items[1].hasAttribute('checked'), 'item 1 should have checked attr')
-    assert.ok(!checklist.items[4].hasAttribute('checkbox'), 'item 4 should not have checkbox attr')
+    assert.ok(checklist.getItems()[0].hasAttribute('checkbox'), 'item 0 should have checkbox attr')
+    assert.ok(!checklist.getItems()[0].hasAttribute('checked'), 'item 0 should not have checked attr')
+    assert.ok(checklist.getItems()[1].hasAttribute('checkbox'), 'item 1 should have checkbox attr')
+    assert.ok(checklist.getItems()[1].hasAttribute('checked'), 'item 1 should have checked attr')
+    assert.ok(!checklist.getItems()[4].hasAttribute('checkbox'), 'item 4 should not have checkbox attr')
 
     const output = await doc.convert()
     assertCss(output, '.ulist.checklist', 1)
@@ -4992,12 +4992,12 @@ describe('Checklists', () => {
     const doc = await documentFromString(input)
     const checklist = doc.blocks[0]
     assert.ok(checklist.hasOption('checklist'), 'checklist should have checklist option')
-    assert.ok(checklist.items[0].hasAttribute('checkbox'), 'item 0 should have checkbox attr')
-    assert.ok(!checklist.items[0].hasAttribute('checked'), 'item 0 should not have checked attr')
-    assert.ok(checklist.items[1].hasAttribute('checkbox'), 'item 1 should have checkbox attr')
-    assert.ok(checklist.items[1].hasAttribute('checked'), 'item 1 should have checked attr')
-    assert.ok(!checklist.items[2].hasAttribute('checkbox'), 'item 2 should not have checkbox attr')
-    assert.ok(!checklist.items[3].hasAttribute('checkbox'), 'item 3 should not have checkbox attr')
+    assert.ok(checklist.getItems()[0].hasAttribute('checkbox'), 'item 0 should have checkbox attr')
+    assert.ok(!checklist.getItems()[0].hasAttribute('checked'), 'item 0 should not have checked attr')
+    assert.ok(checklist.getItems()[1].hasAttribute('checkbox'), 'item 1 should have checkbox attr')
+    assert.ok(checklist.getItems()[1].hasAttribute('checked'), 'item 1 should have checked attr')
+    assert.ok(!checklist.getItems()[2].hasAttribute('checkbox'), 'item 2 should not have checkbox attr')
+    assert.ok(!checklist.getItems()[3].hasAttribute('checkbox'), 'item 3 should not have checkbox attr')
   })
 
   test('should create checklist with font icons if at least one item has checkbox syntax and icons attribute is font', async () => {
@@ -5052,9 +5052,9 @@ describe('Lists model', () => {
 `
     const doc = await documentFromString(input)
     const list = doc.blocks[0]
-    const items = list.items
+    const items = list.getItems()
     assert.equal(items.length, 3)
-    assert.deepEqual(list.items, await list.content())
+    assert.deepEqual(list.getItems(), await list.content())
   })
 
   test('list item should be the parent of block attached to a list item', async () => {
@@ -5066,10 +5066,10 @@ listing block in list item 1
 `
     const doc = await documentFromString(input)
     const list = doc.blocks[0]
-    const list_item_1 = list.items[0]
+    const list_item_1 = list.getItems()[0]
     const listing_block = list_item_1.blocks[0]
     assert.equal(listing_block.context, 'listing')
-    assert.equal(listing_block.parent, list_item_1)
+    assert.equal(listing_block.getParent(), list_item_1)
   })
 
   test('outline? should return true for unordered list', async () => {
@@ -5105,8 +5105,8 @@ listing block in list item 1
 `
     const doc = await documentFromString(input)
     const list = doc.blocks[0]
-    assert.ok(list.items[0].simple())
-    assert.ok(!list.items[0].compound())
+    assert.ok(list.getItems()[0].simple())
+    assert.ok(!list.getItems()[0].compound())
   })
 
   test('simple? should return true for list item with nested outline list', async () => {
@@ -5118,8 +5118,8 @@ listing block in list item 1
 `
     const doc = await documentFromString(input)
     const list = doc.blocks[0]
-    assert.ok(list.items[0].simple())
-    assert.ok(!list.items[0].compound())
+    assert.ok(list.getItems()[0].simple())
+    assert.ok(!list.getItems()[0].compound())
   })
 
   test('simple? should return false for list item with block content', async () => {
@@ -5133,8 +5133,8 @@ listing block in list item 1
 `
     const doc = await documentFromString(input)
     const list = doc.blocks[0]
-    assert.ok(!list.items[0].simple())
-    assert.ok(list.items[0].compound())
+    assert.ok(!list.getItems()[0].simple())
+    assert.ok(list.getItems()[0].compound())
   })
 
   test('should allow text of ListItem to be assigned', async () => {
@@ -5144,10 +5144,10 @@ listing block in list item 1
 `
     const doc = await documentFromString(input)
     const list = doc.findBy({ context: 'ulist' })[0]
-    assert.equal(list.items.length, 3)
-    assert.equal(list.items[0].text, 'one')
-    list.items[0].text = 'un'
-    assert.equal(list.items[0].text, 'un')
+    assert.equal(list.getItems().length, 3)
+    assert.equal(list.getItems()[0].getText(), 'one')
+    list.getItems()[0].setText('un')
+    assert.equal(list.getItems()[0].getText(), 'un')
   })
 
   test('id and role assigned to ulist item in model are transmitted to output', async () => {
@@ -5156,7 +5156,7 @@ listing block in list item 1
 * three
 `
     const doc = await documentFromString(input)
-    const item_0 = doc.blocks[0].items[0]
+    const item_0 = doc.blocks[0].getItems()[0]
     item_0.id = 'one'
     item_0.addRole('item')
     const output = await doc.convert()
@@ -5169,7 +5169,7 @@ listing block in list item 1
 . three
 `
     const doc = await documentFromString(input)
-    const item_0 = doc.blocks[0].items[0]
+    const item_0 = doc.blocks[0].getItems()[0]
     item_0.id = 'one'
     item_0.addRole('item')
     const output = await doc.convert()
@@ -5184,17 +5184,17 @@ listing block in list item 1
 `
     const doc = await documentFromString(input)
     const list = doc.findBy({ context: 'ulist' })[0]
-    assert.equal(list.items.length, 4)
-    list.items[0].removeSub('quotes')
-    assert.equal(list.items[0].text, '*one*')
-    assert.ok(!list.items[0].subs.includes('quotes'))
-    list.items[1].subs.splice(0)
-    assert.equal(list.items[1].subs.length, 0)
-    assert.equal(list.items[1].text, '_two_')
-    list.items[2].subs.splice(0, list.items[2].subs.length, 'specialcharacters')
-    assert.deepEqual(list.items[2].subs, ['specialcharacters'])
-    assert.equal(list.items[2].text, '`three`')
-    assert.equal(list.items[3].text, '<mark>four</mark>')
+    assert.equal(list.getItems().length, 4)
+    list.getItems()[0].removeSub('quotes')
+    assert.equal(list.getItems()[0].getText(), '*one*')
+    assert.ok(!list.getItems()[0].subs.includes('quotes'))
+    list.getItems()[1].subs.splice(0)
+    assert.equal(list.getItems()[1].subs.length, 0)
+    assert.equal(list.getItems()[1].getText(), '_two_')
+    list.getItems()[2].subs.splice(0, list.getItems()[2].subs.length, 'specialcharacters')
+    assert.deepEqual(list.getItems()[2].subs, ['specialcharacters'])
+    assert.equal(list.getItems()[2].getText(), '`three`')
+    assert.equal(list.getItems()[3].getText(), '<mark>four</mark>')
   })
 
   test('should set lineno to line number in source where list starts', async () => {

--- a/packages/core/types/abstract_node.d.ts
+++ b/packages/core/types/abstract_node.d.ts
@@ -10,21 +10,18 @@ export abstract class AbstractNode {
      * @param {object} [opts={}]
      */
     constructor(parent: AbstractNode, context: string, opts?: object);
-    /** @type {AbstractNode} */
-    document: AbstractNode;
-    /** @type {AbstractNode} */
-    _parent: AbstractNode;
+    /** @type {Document} */
+    document: Document;
     context: string;
     nodeName: string;
     id: string;
     attributes: any;
     passthroughs: any[];
-    set parent(parent: AbstractNode);
     /**
-     * Get/Set the parent of this node.
-     * The setter also updates the document reference.
+     * Set the parent of this node.
+     * Also updates the document reference.
      */
-    get parent(): AbstractNode;
+    set parent(parent: any);
     set role(names: any);
     /**
      * Get the space-separated role string for this node.

--- a/packages/core/types/list.d.ts
+++ b/packages/core/types/list.d.ts
@@ -3,12 +3,10 @@
  */
 export class List extends AbstractBlock<any[]> {
     constructor(parent: any, context: any, opts?: {});
-    /** Alias for blocks — the list items. */
-    get items(): AbstractBlock<string>[];
     /** Alias for blocks — the list content. */
     content(): Promise<AbstractBlock<string>[]>;
     /**
-     * Return the list items (alias for items / blocks).
+     * Return the list items.
      * @returns {ListItem[]}
      */
     getItems(): ListItem[];
@@ -40,13 +38,25 @@ export class ListItem extends AbstractBlock<string> {
      * @type {string|null}
      */
     marker: string | null;
-    _text: string;
     subs: string[];
     /** Contextual alias for parent. */
     get list(): import("./abstract_node.js").AbstractNode;
     /**
+     * Return the parent List block (alias of getParent).
+     * @returns {List}
+     */
+    getList(): List;
+    /**
      * Return the text of this list item with substitutions applied.
-     * Synchronous because text is pre-computed during parse().
+     * The result is pre-computed during `Document.parse()` via {@link precomputeText}.
+     * Falls back to the raw text if {@link precomputeText} has not been called yet.
+     *
+     * In Ruby, text is lazy (`apply_subs` on first access), so API callers can modify
+     * subs before accessing text and get the result they expect. Here we replicate
+     * that by invalidating the pre-computed value when subs have changed since it
+     * was computed: returning raw text mirrors what Ruby would produce when subs are
+     * cleared or reduced to a no-op set (since `applySubs` is async and cannot be
+     * re-run synchronously).
      * @returns {string|null}
      */
     getText(): string | null;
@@ -61,32 +71,16 @@ export class ListItem extends AbstractBlock<string> {
      */
     hasText(): boolean;
     /**
-     * Set the raw text of this list item.
-     * @param {string|null} val
-     */
-    set text(val: string | null);
-    /**
-     * Get the string text with substitutions applied.
-     * The result is pre-computed during `Document.parse()` via {@link precomputeText}.
-     * Falls back to the raw text if {@link precomputeText} has not been called yet.
-     *
-     * In Ruby, text is lazy (`apply_subs` on first access), so API callers can modify
-     * subs before accessing text and get the result they expect. Here we replicate
-     * that by invalidating the pre-computed value when subs have changed since it
-     * was computed: returning raw text mirrors what Ruby would produce when subs are
-     * cleared or reduced to a no-op set (since `applySubs` is async and cannot be
-     * re-run synchronously).
-     * @returns {string|null}
-     */
-    get text(): string | null;
-    /**
      * Pre-compute the converted text asynchronously.
      * Called during `Document.parse()` so the synchronous getter works during conversion.
      * @returns {Promise<void>}
      */
     precomputeText(): Promise<void>;
-    _convertedText: any;
-    _subsSnapshot: string[];
+    /**
+     * Set the raw text of this list item.
+     * @param {string|null} val
+     */
+    setText(val: string | null): void;
     /**
      * Check whether this list item has simple content.
      * @returns {boolean} `true` if the item has no blocks or only a single nested outline list.

--- a/packages/core/types/section.d.ts
+++ b/packages/core/types/section.d.ts
@@ -29,7 +29,7 @@ export class Section extends AbstractBlock<string> {
     special: boolean;
     numbered: boolean;
     index: number;
-    sectname: any;
+    sectname: string;
     /**
      * The name of this section — alias for title.
      * @returns {string|null}
@@ -77,10 +77,20 @@ export class Section extends AbstractBlock<string> {
      */
     getSectionName(): string | null;
     /**
+     * Set the section name (e.g. 'section', 'appendix').
+     * @param {string|null} val
+     */
+    setSectionName(val: string | null): void;
+    /**
      * Get the 0-based index of this section within the parent block.
      * @returns {number}
      */
     getIndex(): number;
+    /**
+     * Set the 0-based index of this section within the parent block.
+     * @param {number} val
+     */
+    setIndex(val: number): void;
     /**
      * Get whether this section is numbered.
      * @returns {boolean}
@@ -91,6 +101,11 @@ export class Section extends AbstractBlock<string> {
      * @returns {boolean}
      */
     isSpecial(): boolean;
+    /**
+     * Set whether this section is a special section.
+     * @param {boolean} val
+     */
+    setSpecial(val: boolean): void;
     /**
      * Get the section numeral string.
      * @returns {string|null}

--- a/packages/core/types/table.d.ts
+++ b/packages/core/types/table.d.ts
@@ -80,22 +80,21 @@ declare class Cell extends AbstractBlock<string> {
         assignWidth(colPcwidth: number | null, widthBase: number | null, precision: number): number;
         isBlock(): boolean;
         isInline(): boolean;
-        document: AbstractNode;
+        document: Document;
         _parent: AbstractNode;
         context: string;
         nodeName: string;
         id: string;
         attributes: any;
         passthroughs: any[];
-        get parent(): AbstractNode;
-        set parent(parent: AbstractNode);
+        set parent(parent: any);
         get role(): any;
         set role(names: any);
         get roles(): any;
         getRole(): string | undefined;
         setRole(...names: (string | string[])[]): string;
         getRoles(): string[];
-        get converter(): any;
+        readonly converter: any;
         getNodeName(): string;
         getId(): string | undefined;
         setId(id: string): void;
@@ -142,7 +141,7 @@ declare class Cell extends AbstractBlock<string> {
         readAsset(path: string, opts?: any): Promise<string | null>;
         readContents(target: string, opts?: any): Promise<string | null>;
         isUri(str: string): boolean;
-        get logger(): any;
+        readonly logger: any;
     }, cellText: string, attributes?: any, opts?: any): Promise<typeof Cell>;
     constructor(column: any, cellText: any, attributes?: {}, opts?: {});
     _cursor: any;
@@ -151,13 +150,13 @@ declare class Cell extends AbstractBlock<string> {
     rowspan: number;
     _innerDocSetup: {
         lines: any;
-        parentDoc: AbstractNode;
+        parentDoc: Document;
         parentDoctitle: any;
         options: {
             safe: any;
             backend: any;
             header_footer: boolean;
-            parent: AbstractNode;
+            parent: Document;
             cursor: any;
         };
     };


### PR DESCRIPTION
- Replace get/set text accessors with getText()/setText()
- Add getList(), getMarker() and hasText() on ListItem
- Remove items getter from List in favour of getItems()
- Replace parent getter with getParent() and remove getter 
- Update tests and type declarations accordingly
- Add missing setter methods on Section
- Update install page to use named exports
- Fix migration guide