### PR TITLE
docs(core): broaden ConverterBase.convert return type to Promise<unknown>

### DIFF
--- a/packages/core/src/converter.js
+++ b/packages/core/src/converter.js
@@ -412,7 +412,7 @@ export class ConverterBase {
    * @param {object} node - the AbstractNode to convert
    * @param {string|null} [transform=null] - hint for which method to call (default: node.nodeName)
    * @param {object|null} [opts=null] - optional hints
-   * @returns {Promise<string|null>} the converted string or null
+   * @returns {Promise<unknown>} the result of the `convert_<transform>` handler; the actual type depends on the implementation
    */
   async convert(node, transform = null, opts = null) {
     const method = `convert_${transform ?? node.nodeName}`

--- a/packages/core/types/converter.d.ts
+++ b/packages/core/types/converter.d.ts
@@ -127,9 +127,9 @@ export class ConverterBase {
      * @param {object} node - the AbstractNode to convert
      * @param {string|null} [transform=null] - hint for which method to call (default: node.nodeName)
      * @param {object|null} [opts=null] - optional hints
-     * @returns {Promise<string|null>} the converted string or null
+     * @returns {Promise<unknown>} the result of the `convert_<transform>` handler; the actual type depends on the implementation
      */
-    convert(node: object, transform?: string | null, opts?: object | null): Promise<string | null>;
+    convert(node: object, transform?: string | null, opts?: object | null): Promise<unknown>;
     /**
      * Report whether this converter can handle the given transform.
      *

--- a/packages/core/types/converter/template.d.ts
+++ b/packages/core/types/converter/template.d.ts
@@ -44,6 +44,18 @@ export class TemplateConverter extends ConverterBase {
     engineOptions: any;
     caches: any;
     /**
+     * Convert an AbstractNode to the backend format using the named template.
+     *
+     * Note: convert() is async because getContent() / applySubs() in the core package
+     * is async throughout. We pre-resolve content here and expose it synchronously to
+     * template engines (which are all synchronous) via a Proxy wrapper.
+     * @param {object} node - the AbstractNode to convert
+     * @param {string|null} [templateName=null] - the template name to use (default: node.nodeName)
+     * @param {object|null} [opts=null] - optional plain object passed as locals to the template
+     * @returns {Promise<string>}
+     */
+    convert(node: object, templateName?: string | null, opts?: object | null): Promise<string>;
+    /**
      * Retrieve a shallow copy of the templates map.
      * @returns {Object} plain object keyed by template name
      */


### PR DESCRIPTION
The actual return type depends on each converter implementation; the base class cannot declare it as Promise<string|null>.

resolves https://github.com/asciidoctor/asciidoctor.js/issues/1697