### PR TITLE
fix(core): make SyntaxHighlighterBase.format async and await node.content()

### DIFF
--- a/packages/core/src/syntaxHighlighter/highlightjs.js
+++ b/packages/core/src/syntaxHighlighter/highlightjs.js
@@ -27,9 +27,9 @@ export class HighlightJsAdapter extends SyntaxHighlighterBase {
    * @param {object} node - the source Block being processed
    * @param {string|null} lang - the source language string, or falsy if none
    * @param {object} opts - options passed to the base format()
-   * @returns {string}
+   * @returns {Promise<string>}
    */
-  format(node, lang, opts) {
+  async format(node, lang, opts) {
     const transform = (pre, code) => {
       if (node.hasAttribute('nohighlight-option')) {
         pre.class = pre.class.replace(' highlight', '')

--- a/packages/core/src/syntax_highlighter.js
+++ b/packages/core/src/syntax_highlighter.js
@@ -105,12 +105,13 @@ export class SyntaxHighlighterBase {
    * @param {Object} opts - options
    * @param {boolean} [opts.nowrap] - disable line wrapping
    * @param {Function} [opts.transform] - called with (pre, code) attribute objects before building tags
-   * @returns {string} the highlighted source wrapped in &lt;pre&gt;&lt;code&gt; tags
+   * @returns {Promise<string>} the highlighted source wrapped in &lt;pre&gt;&lt;code&gt; tags
    */
-  format(node, lang, opts) {
+  async format(node, lang, opts) {
     const classAttrVal = opts.nowrap
       ? `${this._preClass} highlight nowrap`
       : `${this._preClass} highlight`
+    const content = await node.content()
     const transform = opts.transform
     if (transform) {
       const pre = { class: classAttrVal }
@@ -126,9 +127,9 @@ export class SyntaxHighlighterBase {
       const codeAttrs = Object.entries(code)
         .map(([k, v]) => ` ${k}="${v}"`)
         .join('')
-      return `<pre${preAttrs}><code${codeAttrs}>${node.content}</code></pre>`
+      return `<pre${preAttrs}><code${codeAttrs}>${content}</code></pre>`
     }
-    return `<pre class="${classAttrVal}"><code${lang ? ` data-lang="${lang}"` : ''}>${node.content}</code></pre>`
+    return `<pre class="${classAttrVal}"><code${lang ? ` data-lang="${lang}"` : ''}>${content}</code></pre>`
   }
 
   /**

--- a/packages/core/test/syntax_highlighter.test.js
+++ b/packages/core/test/syntax_highlighter.test.js
@@ -1,0 +1,128 @@
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+import { assertCss, assertXpath } from './helpers.js'
+import { convertString, convertStringToEmbedded } from './harness.js'
+
+describe('SyntaxHighlighter', () => {
+  describe('highlightjs', () => {
+    describe('format', () => {
+      test('should render source block content inside pre>code tags', async () => {
+        const input = `\
+:source-highlighter: highlightjs
+
+[source,ruby]
+----
+puts "hello"
+----
+`
+        const output = await convertStringToEmbedded(input, { safe: 'safe' })
+        assertCss(output, '.listingblock pre.highlightjs.highlight', 1)
+        assertXpath(output, '//*[contains(@class,"listingblock")]//pre/code[contains(@class,"language-ruby")]', 1)
+        assert(output.includes('puts &quot;hello&quot;') || output.includes('puts "hello"'))
+      })
+
+      test('should set data-lang attribute on code element', async () => {
+        const input = `\
+:source-highlighter: highlightjs
+
+[source,javascript]
+----
+console.log('hi')
+----
+`
+        const output = await convertStringToEmbedded(input, { safe: 'safe' })
+        assertXpath(output, '//*[contains(@class,"listingblock")]//pre/code[@data-lang="javascript"]', 1)
+      })
+
+      test('should render source block without language', async () => {
+        const input = `\
+:source-highlighter: highlightjs
+
+[source]
+----
+some code
+----
+`
+        const output = await convertStringToEmbedded(input, { safe: 'safe' })
+        assertCss(output, '.listingblock pre.highlightjs.highlight', 1)
+        assertXpath(output, '//*[contains(@class,"listingblock")]//pre/code', 1)
+        assert(output.includes('some code'))
+      })
+
+      test('should add nowrap class to pre element when nowrap option is set', async () => {
+        const input = `\
+:source-highlighter: highlightjs
+
+[source%nowrap,ruby]
+----
+puts "hello"
+----
+`
+        const output = await convertStringToEmbedded(input, { safe: 'safe' })
+        assertCss(output, '.listingblock pre.highlightjs.highlight.nowrap', 1)
+      })
+
+      test('should add nowrap class to pre element when prewrap attribute is unset', async () => {
+        const input = `\
+:source-highlighter: highlightjs
+:prewrap!:
+
+[source,ruby]
+----
+puts "hello"
+----
+`
+        const output = await convertStringToEmbedded(input, { safe: 'safe' })
+        assertCss(output, '.listingblock pre.highlightjs.highlight.nowrap', 1)
+      })
+
+      test('should remove highlight class from pre when nohighlight-option is set', async () => {
+        const input = `\
+:source-highlighter: highlightjs
+
+[source%nohighlight,ruby]
+----
+puts "hello"
+----
+`
+        const output = await convertStringToEmbedded(input, { safe: 'safe' })
+        assertCss(output, '.listingblock pre.highlightjs:not(.highlight)', 1)
+        assertCss(output, '.listingblock pre.highlight', 0)
+      })
+
+      test('should preserve multiline content', async () => {
+        const input = `\
+:source-highlighter: highlightjs
+
+[source,ruby]
+----
+def greet(name)
+  puts "Hello, #{name}"
+end
+----
+`
+        const output = await convertStringToEmbedded(input, { safe: 'safe' })
+        assertCss(output, '.listingblock pre.highlightjs.highlight', 1)
+        assertXpath(output, '//*[contains(@class,"listingblock")]//pre/code[contains(@class,"language-ruby")]', 1)
+        assert(output.includes('def greet'))
+        assert(output.includes('end'))
+      })
+    })
+
+    describe('docinfo', () => {
+      test('should add highlight.js script and stylesheet to document', async () => {
+        const input = `\
+:source-highlighter: highlightjs
+
+[source,ruby]
+----
+puts "hello"
+----
+`
+        const output = await convertString(input, { safe: 'safe' })
+        assertCss(output, 'html > head > link[rel="stylesheet"][href*="github.min.css"]', 1)
+        assertCss(output, 'html > body > script[src*="highlight.min.js"]', 1)
+      })
+    })
+  })
+})

--- a/packages/core/types/syntaxHighlighter/highlightjs.d.ts
+++ b/packages/core/types/syntaxHighlighter/highlightjs.d.ts
@@ -8,9 +8,9 @@ export class HighlightJsAdapter extends SyntaxHighlighterBase {
      * @param {object} node - the source Block being processed
      * @param {string|null} lang - the source language string, or falsy if none
      * @param {object} opts - options passed to the base format()
-     * @returns {string}
+     * @returns {Promise<string>}
      */
-    format(node: object, lang: string | null, opts: object): string;
+    format(node: object, lang: string | null, opts: object): Promise<string>;
     /**
      * Always returns true — highlight.js injects markup into the document.
      * @param {string} location - 'head' or 'footer'

--- a/packages/core/types/syntaxHighlighter/html_pipeline.d.ts
+++ b/packages/core/types/syntaxHighlighter/html_pipeline.d.ts
@@ -1,0 +1,16 @@
+export class HtmlPipelineAdapter extends SyntaxHighlighterBase {
+    constructor(...args: any[]);
+    /**
+     * Wrap the source block in `<pre><code>` without highlight classes.
+     *
+     * The html-pipeline gem processes the markup downstream, so only a bare
+     * `<pre lang="<lang>"><code>` wrapper is emitted (no CSS classes, no data-lang).
+     * @param {object} node - the source Block being processed
+     * @param {string|null} lang - the source language string, or falsy if none
+     * @param {object} opts - options (unused by this adapter)
+     * @returns {Promise<string>} the wrapped source string
+     */
+    format(node: object, lang: string | null, opts: object): Promise<string>;
+}
+export default HtmlPipelineAdapter;
+import { SyntaxHighlighterBase } from '../syntax_highlighter.js';

--- a/packages/core/types/syntax_highlighter.d.ts
+++ b/packages/core/types/syntax_highlighter.d.ts
@@ -81,12 +81,12 @@ export class SyntaxHighlighterBase {
      * @param {Object} opts - options
      * @param {boolean} [opts.nowrap] - disable line wrapping
      * @param {Function} [opts.transform] - called with (pre, code) attribute objects before building tags
-     * @returns {string} the highlighted source wrapped in &lt;pre&gt;&lt;code&gt; tags
+     * @returns {Promise<string>} the highlighted source wrapped in &lt;pre&gt;&lt;code&gt; tags
      */
     format(node: Block, lang: string, opts: {
         nowrap?: boolean;
         transform?: Function;
-    }): string;
+    }): Promise<string>;
     /**
      * Indicates whether this highlighter wants to write a stylesheet to disk.
      *


### PR DESCRIPTION
- `node.content()` is an async method; calling it without await embedded its function reference in the template literal instead of the resolved string, producing empty source blocks.

- Add dedicated test suite for the highlightjs syntax highighter. Covers format() output (content, data-lang, nowrap, nohighlight-option, multiline) and docinfo CDN links, which were previously untested.