### PR TITLE
fix(core): await include processor's async process method

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,7 @@ jobs:
         shell: bash
         run: |
           npm test
+          npm run test:browser -w @asciidoctor/core
 
   native_images:
     needs: test

--- a/packages/core/src/reader.js
+++ b/packages/core/src/reader.js
@@ -1229,7 +1229,7 @@ export class PreprocessorReader extends Reader {
         const pa = attrlist
           ? await doc.parseAttributes(attrlist, [], { subInput: true })
           : {}
-        ext.processMethod(doc, this, expandedTarget, pa)
+        await ext.processMethod(doc, this, expandedTarget, pa)
         return true
       }
     }

--- a/packages/core/test/extensions.examples.test.js
+++ b/packages/core/test/extensions.examples.test.js
@@ -18,6 +18,8 @@ import smileyInlineMacro from './extensions/smiley-inline-macro.js'
 import emojiInlineMacro from './extensions/emoji-inline-macro.js'
 import loremBlockMacro from './extensions/lorem-block-macro.js'
 import fooInclude from './extensions/foo-include.js'
+import asyncFsInclude from './extensions/async-fs-include.js'
+import asyncTransformBlock from './extensions/async-transform-block.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const FIXTURES_DIR = join(__dirname, 'fixtures')
@@ -248,6 +250,28 @@ describe('Extensions (examples)', () => {
       assert.ok(!exts.hasBlocks())
       assert.ok(!exts.hasInlineMacros())
       assert.ok(!exts.hasIncludeProcessors())
+    })
+  })
+
+  describe('Include processor (async fs)', () => {
+    test('should read file content asynchronously using fs/promises', async () => {
+      const registry = Extensions.create()
+      asyncFsInclude(registry)
+      const result = await convert('include::hello.txt[]', {
+        safe: 'safe',
+        base_dir: FIXTURES_DIR,
+        extension_registry: registry,
+      })
+      assert.ok(result.includes('Hello from async include!'))
+    })
+  })
+
+  describe('Block processor (async transform)', () => {
+    test('should transform block content using an async function', async () => {
+      const registry = Extensions.create()
+      asyncTransformBlock(registry)
+      const result = await convert(fixture('async-block-ex.adoc'), { extension_registry: registry })
+      assert.ok(result.includes('Hello World From Async'))
     })
   })
 

--- a/packages/core/test/extensions/async-fs-include.js
+++ b/packages/core/test/extensions/async-fs-include.js
@@ -1,0 +1,12 @@
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export default function (registry) {
+  registry.includeProcessor(function () {
+    this.handles((target) => target.endsWith('.txt'))
+    this.process(async function (doc, reader, target, attrs) {
+      const content = await readFile(join(doc.getBaseDir(), target), 'utf8')
+      return reader.pushInclude(content.trimEnd().split('\n'), target, target, 1, attrs)
+    })
+  })
+}

--- a/packages/core/test/extensions/async-transform-block.js
+++ b/packages/core/test/extensions/async-transform-block.js
@@ -1,0 +1,15 @@
+// Simulates using an async library (e.g. a code formatter, a markdown converter, etc.)
+async function titleCase(text) {
+  return text.split(' ').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ')
+}
+
+export default function (registry) {
+  registry.block(function () {
+    this.named('titlecase')
+    this.onContext('paragraph')
+    this.process(async function (parent, reader) {
+      const lines = await Promise.all(reader.getLines().map(titleCase))
+      return this.createBlock(parent, 'paragraph', lines)
+    })
+  })
+}

--- a/packages/core/test/fixtures/async-block-ex.adoc
+++ b/packages/core/test/fixtures/async-block-ex.adoc
@@ -1,0 +1,4 @@
+= Async Block Example
+
+[titlecase]
+hello world from async

--- a/packages/core/test/fixtures/hello.txt
+++ b/packages/core/test/fixtures/hello.txt
@@ -1,0 +1,1 @@
+Hello from async include!

--- a/packages/core/test/shims/node-assert.js
+++ b/packages/core/test/shims/node-assert.js
@@ -16,11 +16,19 @@ async function rejects (fnOrPromise, errorOrMessage, message) {
   await expect(p).rejects.toThrow()
 }
 
-const assert = {
-  equal, deepEqual, strictEqual, deepStrictEqual,
-  notEqual, notDeepStrictEqual,
-  ok, fail, match, doesNotMatch, throws, rejects,
-}
+function assert (value, message) { ok(value, message) }
+assert.equal = equal
+assert.deepEqual = deepEqual
+assert.strictEqual = strictEqual
+assert.deepStrictEqual = deepStrictEqual
+assert.notEqual = notEqual
+assert.notDeepStrictEqual = notDeepStrictEqual
+assert.ok = ok
+assert.fail = fail
+assert.match = match
+assert.doesNotMatch = doesNotMatch
+assert.throws = throws
+assert.rejects = rejects
 
 export {
   equal, deepEqual, strictEqual, deepStrictEqual,


### PR DESCRIPTION
Without awaiting ext.processMethod(), include processors with async process functions would run fire-and-forget, producing empty output. Also adds example extensions (async fs include, async transform block) to validate that extensions can use async libraries in their processing pipeline.