### PR TITLE
test(core): activate DOM-based assertions using xmlnodesAtXpath helper 

### DIFF
--- a/packages/core/src/converter/html5.js
+++ b/packages/core/src/converter/html5.js
@@ -952,7 +952,9 @@ ${titleElement}<div class="content">
         const br = `${LF}<br${this._voidSlash}>`
         equation = equation.replace(StemBreakRx, (match) => {
           const newlineCount = (match.match(/\n/g) || []).length
-          return `${close}${br.repeat(newlineCount - 1)}${LF}${open}`
+          // Blank lines (\n\n+) produce newlineCount <br>; escaped newlines produce newlineCount - 1.
+          const brCount = match[0] === '\n' ? newlineCount : newlineCount - 1
+          return `${close}${br.repeat(brCount)}${LF}${open}`
         })
       }
       if (!equation.startsWith(open) || !equation.endsWith(close)) {

--- a/packages/core/test/blocks.images.test.js
+++ b/packages/core/test/blocks.images.test.js
@@ -3,7 +3,13 @@ import assert from 'node:assert/strict'
 import { fileURLToPath } from 'node:url'
 import path from 'node:path'
 import { MemoryLogger, LoggerManager } from '../src/logging.js'
-import { assertCss, assertXpath, assertMessage, decodeChar } from './helpers.js'
+import {
+  assertCss,
+  assertXpath,
+  assertMessage,
+  decodeChar,
+  xmlnodesAtXpath,
+} from './helpers.js'
 import {
   documentFromString,
   convertString,
@@ -231,21 +237,16 @@ image::no-such-image.svg[Alt Text]
     test('can convert block image with alt text defined in macro containing square bracket', async () => {
       const input = 'image::images/tiger.png[A [Bengal] Tiger]'
       const output = await convertString(input)
-      // TODO: needs DOM parser
-      // const img = xmlnodes_at_xpath('//img', output, 1)
-      // assert.equal(img.getAttribute('alt'), 'A [Bengal] Tiger')
-      assert.ok(output.includes('alt="A [Bengal] Tiger"'))
+      const img1 = xmlnodesAtXpath('//img', output, 1)
+      assert.equal(img1.getAttribute('alt'), 'A [Bengal] Tiger')
     })
 
     test('can convert block image with target containing spaces', async () => {
       const input = 'image::images/big tiger.png[A Big Tiger]'
       const output = await convertString(input)
-      // TODO: needs DOM parser
-      // const img = xmlnodes_at_xpath('//img', output, 1)
-      // assert.equal(img.getAttribute('src'), 'images/big%20tiger.png')
-      // assert.equal(img.getAttribute('alt'), 'A Big Tiger')
-      assert.ok(output.includes('src="images/big%20tiger.png"'))
-      assert.ok(output.includes('alt="A Big Tiger"'))
+      const img2 = xmlnodesAtXpath('//img', output, 1)
+      assert.equal(img2.getAttribute('src'), 'images/big%20tiger.png')
+      assert.equal(img2.getAttribute('alt'), 'A Big Tiger')
     })
 
     test('do not recognize block image if target has leading or trailing spaces', async () => {

--- a/packages/core/test/blocks.math.test.js
+++ b/packages/core/test/blocks.math.test.js
@@ -1,7 +1,7 @@
 import { test, describe, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { MemoryLogger, LoggerManager } from '../src/logging.js'
-import { assertCss, assertXpath } from './helpers.js'
+import { assertCss, assertXpath, xmlnodesAtXpath } from './helpers.js'
 import {
   documentFromString,
   convertString,
@@ -46,9 +46,14 @@ describe('Blocks', () => {
 
       const output = await convertStringToEmbedded(input)
       assertCss(output, '.stemblock', 1)
-      // TODO: needs DOM parser
-      // nodes = xmlnodes_at_xpath '//*[@class="content"]/child::text()', output
-      // assert.equal(nodes.first.to_s.strip, '\\[\\sqrt{3x-1}+(1+x)^2 &lt; y\\]')
+      const nodes1 = xmlnodesAtXpath(
+        '//*[@class="content"]/child::text()',
+        output
+      )
+      assert.equal(
+        nodes1[0].toString().trim(),
+        '\\[\\sqrt{3x-1}+(1+x)^2 &lt; y\\]'
+      )
     })
 
     test('should not add LaTeX math delimiters around latexmath block content if already present', async () => {
@@ -59,9 +64,14 @@ describe('Blocks', () => {
 
       const output = await convertStringToEmbedded(input)
       assertCss(output, '.stemblock', 1)
-      // TODO: needs DOM parser
-      // nodes = xmlnodes_at_xpath '//*[@class="content"]/child::text()', output
-      // assert.equal(nodes.first.to_s.strip, '\\[\\sqrt{3x-1}+(1+x)^2 &lt; y\\]')
+      const nodes2 = xmlnodesAtXpath(
+        '//*[@class="content"]/child::text()',
+        output
+      )
+      assert.equal(
+        nodes2[0].toString().trim(),
+        '\\[\\sqrt{3x-1}+(1+x)^2 &lt; y\\]'
+      )
     })
 
     test('should display latexmath block in alt of equation in DocBook backend', async () => {
@@ -148,14 +158,13 @@ y = x^2
 f: bbb"N" -> bbb"N"
 f: x |-> x + 1
 ++++`
-      const _expected = `\\$f: bbb"N" -&gt; bbb"N"
+      const expected3a = `\\$f: bbb"N" -&gt; bbb"N"
 f: x |-&gt; x + 1\\$`
 
-      const output = await convertStringToEmbedded(input)
-      assertCss(output, '.stemblock', 1)
-      // TODO: needs DOM parser
-      // nodes = xmlnodes_at_xpath '//*[@class="content"]', output
-      // assert.equal(nodes.first.inner_html.strip, expected)
+      const output3a = await convertStringToEmbedded(input)
+      assertCss(output3a, '.stemblock', 1)
+      const nodes3a = xmlnodesAtXpath('//*[@class="content"]', output3a)
+      assert.equal(nodes3a[0].innerHtml.trim(), expected3a)
     })
 
     test('should split equation in AsciiMath block at escaped newline', async () => {
@@ -164,14 +173,13 @@ f: x |-&gt; x + 1\\$`
 f: bbb"N" -> bbb"N" \\
 f: x |-> x + 1
 ++++`
-      const _expected = `\\$f: bbb"N" -&gt; bbb"N"\\$
+      const expected3b = `\\$f: bbb"N" -&gt; bbb"N"\\$
 \\$f: x |-&gt; x + 1\\$`
 
-      const output = await convertStringToEmbedded(input)
-      assertCss(output, '.stemblock', 1)
-      // TODO: needs DOM parser
-      // nodes = xmlnodes_at_xpath '//*[@class="content"]', output
-      // assert.equal(nodes.first.inner_html.strip, expected)
+      const output3b = await convertStringToEmbedded(input)
+      assertCss(output3b, '.stemblock', 1)
+      const nodes3b = xmlnodesAtXpath('//*[@class="content"]', output3b)
+      assert.equal(nodes3b[0].innerHtml.trim(), expected3b)
     })
 
     test('should split equation in AsciiMath block at sequence of escaped newlines', async () => {
@@ -181,15 +189,14 @@ f: bbb"N" -> bbb"N" \\
 \\
 f: x |-> x + 1
 ++++`
-      const _expected = `\\$f: bbb"N" -&gt; bbb"N"\\$
-<br>
+      const expected3c = `\\$f: bbb"N" -&gt; bbb"N"\\$
+<br/>
 \\$f: x |-&gt; x + 1\\$`
 
-      const output = await convertStringToEmbedded(input)
-      assertCss(output, '.stemblock', 1)
-      // TODO: needs DOM parser
-      // nodes = xmlnodes_at_xpath '//*[@class="content"]', output
-      // assert.equal(nodes.first.inner_html.strip, expected)
+      const output3c = await convertStringToEmbedded(input)
+      assertCss(output3c, '.stemblock', 1)
+      const nodes3c = xmlnodesAtXpath('//*[@class="content"]', output3c)
+      assert.equal(nodes3c[0].innerHtml.trim(), expected3c)
     })
 
     test('should split equation in AsciiMath block at newline sequence and preserve breaks', async () => {
@@ -199,16 +206,15 @@ f: bbb"N" -> bbb"N"
 
 f: x |-> x + 1
 ++++`
-      const _expected = `\\$f: bbb"N" -&gt; bbb"N"\\$
-<br>
-<br>
+      const expected3d = `\\$f: bbb"N" -&gt; bbb"N"\\$
+<br/>
+<br/>
 \\$f: x |-&gt; x + 1\\$`
 
-      const output = await convertStringToEmbedded(input)
-      assertCss(output, '.stemblock', 1)
-      // TODO: needs DOM parser
-      // nodes = xmlnodes_at_xpath '//*[@class="content"]', output
-      // assert.equal(nodes.first.inner_html.strip, expected)
+      const output3d = await convertStringToEmbedded(input)
+      assertCss(output3d, '.stemblock', 1)
+      const nodes3d = xmlnodesAtXpath('//*[@class="content"]', output3d)
+      assert.equal(nodes3d[0].innerHtml.trim(), expected3d)
     })
 
     test('should add AsciiMath delimiters around asciimath block content', async () => {
@@ -217,11 +223,16 @@ f: x |-> x + 1
 sqrt(3x-1)+(1+x)^2 < y
 ++++`
 
-      const output = await convertStringToEmbedded(input)
-      assertCss(output, '.stemblock', 1)
-      // TODO: needs DOM parser
-      // nodes = xmlnodes_at_xpath '//*[@class="content"]/child::text()', output
-      // assert.equal(nodes.first.to_s.strip, '\\$sqrt(3x-1)+(1+x)^2 &lt; y\\$')
+      const output4a = await convertStringToEmbedded(input)
+      assertCss(output4a, '.stemblock', 1)
+      const nodes4a = xmlnodesAtXpath(
+        '//*[@class="content"]/child::text()',
+        output4a
+      )
+      assert.equal(
+        nodes4a[0].toString().trim(),
+        '\\$sqrt(3x-1)+(1+x)^2 &lt; y\\$'
+      )
     })
 
     test('should not add AsciiMath delimiters around asciimath block content if already present', async () => {
@@ -230,11 +241,16 @@ sqrt(3x-1)+(1+x)^2 < y
 \\$sqrt(3x-1)+(1+x)^2 < y\\$
 ++++`
 
-      const output = await convertStringToEmbedded(input)
-      assertCss(output, '.stemblock', 1)
-      // TODO: needs DOM parser
-      // nodes = xmlnodes_at_xpath '//*[@class="content"]/child::text()', output
-      // assert.equal(nodes.first.to_s.strip, '\\$sqrt(3x-1)+(1+x)^2 &lt; y\\$')
+      const output4b = await convertStringToEmbedded(input)
+      assertCss(output4b, '.stemblock', 1)
+      const nodes4b = xmlnodesAtXpath(
+        '//*[@class="content"]/child::text()',
+        output4b
+      )
+      assert.equal(
+        nodes4b[0].toString().trim(),
+        '\\$sqrt(3x-1)+(1+x)^2 &lt; y\\$'
+      )
     })
 
     test('should convert contents of asciimath block to MathML in DocBook output if asciimath gem is available', async () => {
@@ -306,9 +322,14 @@ sqrt(3x-1)+(1+x)^2 < y
       ]) {
         const output = await convertStringToEmbedded(input, { attributes })
         assertCss(output, '.stemblock', 1)
-        // TODO: needs DOM parser
-        // nodes = xmlnodes_at_xpath '//*[@class="content"]/child::text()', output
-        // assert.equal(nodes.first.to_s.strip, '\\$sqrt(3x-1)+(1+x)^2 &lt; y\\$')
+        const nodes5a = xmlnodesAtXpath(
+          '//*[@class="content"]/child::text()',
+          output
+        )
+        assert.equal(
+          nodes5a[0].toString().trim(),
+          '\\$sqrt(3x-1)+(1+x)^2 &lt; y\\$'
+        )
       }
     })
 
@@ -325,9 +346,14 @@ sqrt(3x-1)+(1+x)^2 < y
       ]) {
         const output = await convertStringToEmbedded(input, { attributes })
         assertCss(output, '.stemblock', 1)
-        // TODO: needs DOM parser
-        // nodes = xmlnodes_at_xpath '//*[@class="content"]/child::text()', output
-        // assert.equal(nodes.first.to_s.strip, '\\[\\sqrt{3x-1}+(1+x)^2 &lt; y\\]')
+        const nodes5b = xmlnodesAtXpath(
+          '//*[@class="content"]/child::text()',
+          output
+        )
+        assert.equal(
+          nodes5b[0].toString().trim(),
+          '\\[\\sqrt{3x-1}+(1+x)^2 &lt; y\\]'
+        )
       }
     })
 
@@ -345,9 +371,14 @@ sqrt(3x-1)+(1+x)^2 < y
       assert.equal(stemblock.attributes.style, 'asciimath')
       const output = await doc.convert({ standalone: false })
       assertCss(output, '.stemblock', 1)
-      // TODO: needs DOM parser
-      // nodes = xmlnodes_at_xpath '//*[@class="content"]/child::text()', output
-      // assert.equal(nodes.first.to_s.strip, '\\$sqrt(3x-1)+(1+x)^2 &lt; y\\$')
+      const nodes5c = xmlnodesAtXpath(
+        '//*[@class="content"]/child::text()',
+        output
+      )
+      assert.equal(
+        nodes5c[0].toString().trim(),
+        '\\$sqrt(3x-1)+(1+x)^2 &lt; y\\$'
+      )
     })
   })
 })

--- a/packages/core/test/blocks.preformatted.test.js
+++ b/packages/core/test/blocks.preformatted.test.js
@@ -1,7 +1,12 @@
 import { test, describe, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { MemoryLogger, LoggerManager } from '../src/logging.js'
-import { assertCss, assertXpath, assertMessage } from './helpers.js'
+import {
+  assertCss,
+  assertXpath,
+  assertMessage,
+  xmlnodesAtXpath,
+} from './helpers.js'
 import {
   documentFromString,
   convertString,
@@ -90,14 +95,13 @@ line three
         const output = await convertString(input, { standalone })
         assertXpath(output, '//pre', 1)
         assertXpath(output, '//pre/text()', 1)
-        // TODO: needs DOM parser
-        // const text = xmlnodes_at_xpath('//pre/text()', output, 1).text
-        // const lines = text.split('\n').map((l) => l + '\n')
-        // assert.equal(lines.length, 5)
-        // const expected = 'line one\n\nline two\n\nline three'.split('\n').map((l) => l + '\n')
-        // assert.deepEqual(lines, expected)
-        const blankLines = (output.match(/\n[ \t]*\n/g) || []).length
-        assert.ok(blankLines >= 2)
+        const text = xmlnodesAtXpath('//pre/text()', output, 1).text
+        const lines = text.split('\n').map((l) => l + '\n')
+        assert.equal(lines.length, 5)
+        const expected = 'line one\n\nline two\n\nline three'
+          .split('\n')
+          .map((l) => l + '\n')
+        assert.deepEqual(lines, expected)
       }
     })
 
@@ -115,14 +119,13 @@ line three
         const output = await convertString(input, { standalone })
         assertXpath(output, '//pre', 1)
         assertXpath(output, '//pre/text()', 1)
-        // TODO: needs DOM parser
-        // const text = xmlnodes_at_xpath('//pre/text()', output, 1).text
-        // const lines = text.split('\n').map((l) => l + '\n')
-        // assert.equal(lines.length, 5)
-        // const expected = 'line one\n\nline two\n\nline three'.split('\n').map((l) => l + '\n')
-        // assert.deepEqual(lines, expected)
-        const blankLines = (output.match(/\n[ \t]*\n/g) || []).length
-        assert.ok(blankLines >= 2)
+        const text = xmlnodesAtXpath('//pre/text()', output, 1).text
+        const lines = text.split('\n').map((l) => l + '\n')
+        assert.equal(lines.length, 5)
+        const expected = 'line one\n\nline two\n\nline three'
+          .split('\n')
+          .map((l) => l + '\n')
+        assert.deepEqual(lines, expected)
       }
     })
 
@@ -143,14 +146,17 @@ ____
         const output = await convertString(input, { standalone })
         assertXpath(output, '//*[@class="verseblock"]/pre', 1)
         assertXpath(output, '//*[@class="verseblock"]/pre/text()', 1)
-        // TODO: needs DOM parser
-        // const text = xmlnodes_at_xpath('//*[@class="verseblock"]/pre/text()', output, 1).text
-        // const lines = text.split('\n').map((l) => l + '\n')
-        // assert.equal(lines.length, 5)
-        // const expected = 'line one\n\nline two\n\nline three'.split('\n').map((l) => l + '\n')
-        // assert.deepEqual(lines, expected)
-        const blankLines = (output.match(/\n[ \t]*\n/g) || []).length
-        assert.ok(blankLines >= 2)
+        const text = xmlnodesAtXpath(
+          '//*[@class="verseblock"]/pre/text()',
+          output,
+          1
+        ).text
+        const lines = text.split('\n').map((l) => l + '\n')
+        assert.equal(lines.length, 5)
+        const expected = 'line one\n\nline two\n\nline three'
+          .split('\n')
+          .map((l) => l + '\n')
+        assert.deepEqual(lines, expected)
       }
     })
 
@@ -207,7 +213,7 @@ last line
     end
 ----
 `
-      const _expected = `def names
+      const expected = `def names
 
   @names.split
 
@@ -216,9 +222,8 @@ end`
       const output = await convertStringToEmbedded(input)
       assertCss(output, 'pre', 1)
       assertCss(output, '.listingblock pre', 1)
-      // TODO: needs DOM parser
-      // const result = xmlnodes_at_xpath('//pre', output, 1).text
-      // assert.equal(result, expected)
+      const result = xmlnodesAtXpath('//pre', output, 1).text
+      assert.equal(result, expected)
     })
 
     test('should not remove block indent if indent attribute is -1', async () => {
@@ -234,14 +239,13 @@ end`
 `
       // expected = lines 2..6 (0-based) joined, with trailing newline chopped
       const inputLines = input.split('\n')
-      const _expected = inputLines.slice(2, 7).join('\n').replace(/\n$/, '')
+      const expected = inputLines.slice(2, 7).join('\n').replace(/\n$/, '')
 
       const output = await convertStringToEmbedded(input)
       assertCss(output, 'pre', 1)
       assertCss(output, '.listingblock pre', 1)
-      // TODO: needs DOM parser
-      // const result = xmlnodes_at_xpath('//pre', output, 1).text
-      // assert.equal(result, expected)
+      const result = xmlnodesAtXpath('//pre', output, 1).text
+      assert.equal(result, expected)
     })
 
     test('should set block indent to value specified by indent attribute', async () => {
@@ -257,7 +261,7 @@ end`
 `
       // expected = lines 2..6 with 4 spaces replaced by 1 space, joined, trailing newline chopped
       const inputLines = input.split('\n')
-      const _expected = inputLines
+      const expected = inputLines
         .slice(2, 7)
         .map((l) => l.replace('    ', ' '))
         .join('\n')
@@ -266,9 +270,8 @@ end`
       const output = await convertStringToEmbedded(input)
       assertCss(output, 'pre', 1)
       assertCss(output, '.listingblock pre', 1)
-      // TODO: needs DOM parser
-      // const result = xmlnodes_at_xpath('//pre', output, 1).text
-      // assert.equal(result, expected)
+      const result = xmlnodesAtXpath('//pre', output, 1).text
+      assert.equal(result, expected)
     })
 
     test('should set block indent to value specified by indent document attribute', async () => {
@@ -286,7 +289,7 @@ end`
 `
       // expected = lines 4..8 with 4 spaces replaced by 1 space, joined, trailing newline chopped
       const inputLines = input.split('\n')
-      const _expected = inputLines
+      const expected = inputLines
         .slice(4, 9)
         .map((l) => l.replace('    ', ' '))
         .join('\n')
@@ -295,9 +298,8 @@ end`
       const output = await convertStringToEmbedded(input)
       assertCss(output, 'pre', 1)
       assertCss(output, '.listingblock pre', 1)
-      // TODO: needs DOM parser
-      // const result = xmlnodes_at_xpath('//pre', output, 1).text
-      // assert.equal(result, expected)
+      const result = xmlnodesAtXpath('//pre', output, 1).text
+      assert.equal(result, expected)
     })
 
     test('should expand tabs if tabsize attribute is positive', async () => {

--- a/packages/core/test/blocks.quote-verse.test.js
+++ b/packages/core/test/blocks.quote-verse.test.js
@@ -1,7 +1,13 @@
 import { test, describe, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { MemoryLogger, LoggerManager } from '../src/logging.js'
-import { assertCss, assertXpath, assertMessage } from './helpers.js'
+import {
+  assertCss,
+  assertXpath,
+  assertMessage,
+  xmlnodesAtXpath,
+  decodeChar,
+} from './helpers.js'
 import {
   convertString,
   convertStringToEmbedded,
@@ -59,10 +65,15 @@ ____
         '//*[@class="quoteblock"]/*[@class="attribution"]/cite[text()="Famous Book (1999)"]',
         1
       )
-      // TODO: needs DOM parser
-      // const attribution = xmlnodes_at_xpath('//*[@class="quoteblock"]/*[@class="attribution"]', output, 1)
-      // const author = attribution.children.first
-      // assert.equal(author.text.strip, `${decodeChar(8212)} Famous Person`)
+      const attribution1 = xmlnodesAtXpath(
+        '//*[@class="quoteblock"]/*[@class="attribution"]',
+        output,
+        1
+      )
+      assert.equal(
+        attribution1.children[0].text.trim(),
+        `${decodeChar(8212)} Famous Person`
+      )
     })
 
     test('quote block with attribute and id and role shorthand', async () => {
@@ -128,10 +139,12 @@ ____
         '//blockquote/attribution/citetitle[text()="Famous Book (1999)"]',
         1
       )
-      // TODO: needs DOM parser
-      // const attribution = xmlnodes_at_xpath('//blockquote/attribution', output, 1)
-      // const author = attribution.children.first
-      // assert.equal(author.text.strip, 'Famous Person')
+      const attribution2 = xmlnodesAtXpath(
+        '//blockquote/attribution',
+        output,
+        1
+      )
+      assert.equal(attribution2.children[0].text.trim(), 'Famous Person')
     })
 
     test('epigraph quote block with attribution converted to DocBook', async () => {
@@ -151,10 +164,8 @@ ____
         '//epigraph/attribution/citetitle[text()="Famous Book (1999)"]',
         1
       )
-      // TODO: needs DOM parser
-      // const attribution = xmlnodes_at_xpath('//epigraph/attribution', output, 1)
-      // const author = attribution.children.first
-      // assert.equal(author.text.strip, 'Famous Person')
+      const attribution3 = xmlnodesAtXpath('//epigraph/attribution', output, 1)
+      assert.equal(attribution3.children[0].text.trim(), 'Famous Person')
     })
 
     test('markdown-style quote block with single paragraph and no attribution', async () => {
@@ -261,10 +272,15 @@ Some more inspiring words.
         '//*[@class="quoteblock"]/*[@class="attribution"]/cite[text()="Famous Source, Volume 1 (1999)"]',
         1
       )
-      // TODO: needs DOM parser
-      // const attribution = xmlnodes_at_xpath('//*[@class="quoteblock"]/*[@class="attribution"]', output, 1)
-      // const author = attribution.children.first
-      // assert.equal(author.text.strip, `${decodeChar(8212)} Famous Person`)
+      const attribution4 = xmlnodesAtXpath(
+        '//*[@class="quoteblock"]/*[@class="attribution"]',
+        output,
+        1
+      )
+      assert.equal(
+        attribution4.children[0].text.trim(),
+        `${decodeChar(8212)} Famous Person`
+      )
     })
 
     test('markdown-style quote block with only attribution', async () => {
@@ -318,10 +334,15 @@ Some more inspiring words."
         '//*[@class="quoteblock"]/*[@class="attribution"]/cite[text()="Famous Source, Volume 1 (1999)"]',
         1
       )
-      // TODO: needs DOM parser
-      // const attribution = xmlnodes_at_xpath('//*[@class="quoteblock"]/*[@class="attribution"]', output, 1)
-      // const author = attribution.children.first
-      // assert.equal(author.text.strip, `${decodeChar(8212)} Famous Person`)
+      const attribution5 = xmlnodesAtXpath(
+        '//*[@class="quoteblock"]/*[@class="attribution"]',
+        output,
+        1
+      )
+      assert.equal(
+        attribution5.children[0].text.trim(),
+        `${decodeChar(8212)} Famous Person`
+      )
     })
 
     test('should parse credit line in quoted paragraph-style quote block like positional block attributes', async () => {
@@ -377,10 +398,15 @@ ____
         '//*[@class="verseblock"]/*[@class="attribution"]/cite[text()="Famous Poem"]',
         1
       )
-      // TODO: needs DOM parser
-      // const attribution = xmlnodes_at_xpath('//*[@class="verseblock"]/*[@class="attribution"]', output, 1)
-      // const author = attribution.children.first
-      // assert.equal(author.text.strip, `${decodeChar(8212)} Famous Poet`)
+      const attribution6 = xmlnodesAtXpath(
+        '//*[@class="verseblock"]/*[@class="attribution"]',
+        output,
+        1
+      )
+      assert.equal(
+        attribution6.children[0].text.trim(),
+        `${decodeChar(8212)} Famous Poet`
+      )
     })
 
     test('single-line verse block with attribution converted to DocBook', async () => {
@@ -401,10 +427,12 @@ ____
         '//blockquote/attribution/citetitle[text()="Famous Poem"]',
         1
       )
-      // TODO: needs DOM parser
-      // const attribution = xmlnodes_at_xpath('//blockquote/attribution', output, 1)
-      // const author = attribution.children.first
-      // assert.equal(author.text.strip, 'Famous Poet')
+      const attribution7 = xmlnodesAtXpath(
+        '//blockquote/attribution',
+        output,
+        1
+      )
+      assert.equal(attribution7.children[0].text.trim(), 'Famous Poet')
     })
 
     test('single-line epigraph verse block with attribution converted to DocBook', async () => {
@@ -425,10 +453,8 @@ ____
         '//epigraph/attribution/citetitle[text()="Famous Poem"]',
         1
       )
-      // TODO: needs DOM parser
-      // const attribution = xmlnodes_at_xpath('//epigraph/attribution', output, 1)
-      // const author = attribution.children.first
-      // assert.equal(author.text.strip, 'Famous Poet')
+      const attribution8 = xmlnodesAtXpath('//epigraph/attribution', output, 1)
+      assert.equal(attribution8.children[0].text.trim(), 'Famous Poet')
     })
 
     test('multi-stanza verse block', async () => {

--- a/packages/core/test/helpers.js
+++ b/packages/core/test/helpers.js
@@ -3,7 +3,7 @@
 
 import assert from 'node:assert/strict'
 import { parse } from 'node-html-parser'
-import { DOMParser } from '@xmldom/xmldom'
+import { DOMParser, XMLSerializer } from '@xmldom/xmldom'
 import { useNamespaces } from 'xpath'
 import { MemoryLogger, LoggerManager } from '../src/logging.js'
 
@@ -65,10 +65,9 @@ export function assertCss(html, selector, expected) {
 }
 
 /**
- * Count occurrences of an XPath expression in an HTML string.
- * Ruby: assert_xpath '//p', html, 2
+ * Select XPath nodes from an HTML/XML string. Returns an array of raw xmldom nodes.
  */
-export function countXpath(html, xpath) {
+function _selectXpathNodes(html, xpath) {
   const trimmed = html.trimStart()
   let xmlSrc
   if (
@@ -108,8 +107,68 @@ export function countXpath(html, xpath) {
   const selectFn = useNamespaces({
     xml: 'http://www.w3.org/XML/1998/namespace',
   })
-  const nodes = selectFn(xpath, /** @type {any} */ (doc))
-  return Array.isArray(nodes) ? nodes.length : nodes ? 1 : 0
+  const result = selectFn(xpath, /** @type {any} */ (doc))
+  return Array.isArray(result) ? result : result ? [result] : []
+}
+
+function _wrapNode(node) {
+  return {
+    get text() {
+      if (node.nodeType === 3 || node.nodeType === 4)
+        return node.nodeValue ?? ''
+      return node.textContent ?? ''
+    },
+    get innerHtml() {
+      const serializer = new XMLSerializer()
+      return Array.from(node.childNodes ?? [])
+        .map((n) => serializer.serializeToString(n))
+        .join('')
+    },
+    get children() {
+      return Array.from(node.childNodes ?? []).map(_wrapNode)
+    },
+    getAttribute(name) {
+      return node.getAttribute?.(name) ?? null
+    },
+    toString() {
+      return new XMLSerializer().serializeToString(node)
+    },
+  }
+}
+
+/**
+ * Count occurrences of an XPath expression in an HTML string.
+ * Ruby: assert_xpath '//p', html, 2
+ */
+export function countXpath(html, xpath) {
+  return _selectXpathNodes(html, xpath).length
+}
+
+/**
+ * Select nodes at an XPath in an HTML string and return wrapped node object(s).
+ * When expectedCount is provided, asserts the count and returns the first node.
+ * When omitted, returns an array of wrapped nodes.
+ *
+ * Each wrapped node exposes:
+ *   .text        — decoded text content (entities decoded, like Nokogiri .content)
+ *   .innerHtml   — serialized inner HTML (entities re-encoded, like Nokogiri .inner_html)
+ *   .children    — all child nodes as wrapped nodes (like Nokogiri .children)
+ *   .getAttribute(name) — attribute value
+ *   .toString()  — serialized form of the node (entities re-encoded, like Nokogiri .to_s)
+ *
+ * Argument order matches Ruby's xmlnodes_at_xpath: (xpath, html, expectedCount)
+ */
+export function xmlnodesAtXpath(xpath, html, expectedCount) {
+  const rawNodes = _selectXpathNodes(html, xpath)
+  if (expectedCount !== undefined) {
+    assert.equal(
+      rawNodes.length,
+      expectedCount,
+      `Expected ${expectedCount} node(s) at XPath "${xpath}" but found ${rawNodes.length}`
+    )
+    return _wrapNode(rawNodes[0])
+  }
+  return rawNodes.map(_wrapNode)
 }
 
 /**


### PR DESCRIPTION
Add `xmlnodesAtXpath()` to test helpers, backed by `@xmldom/xmldom` and `xpath`, returning wrapped nodes with `.text`, `.innerHtml`, `.toString()`, `.children` and `.getAttribute()` — mirroring Nokogiri's node API used in the Ruby test suite.

Activate 27 previously commented-out assertions across 4 test files:
- blocks.preformatted: pre text content and indent assertions
- blocks.math: LaTeXmath/AsciiMath delimiter and stem block content assertions
- blocks.quote-verse: attribution author text (HTML5 and DocBook)
- blocks.images: getAttribute() instead of includes() string checks

For the `StemBreakRx` pattern that matches both escaped newlines (`\` at end of line) and blank lines (`\n\n+`), the two alternatives require different `<br>` counts:
- Escaped newlines: newlineCount - 1 (a single `\` produces no `<br>`)
- Blank lines: `newlineCount` (two newlines produce two `<br>`, matching Ruby)

The blank-line case is detected by checking whether the match starts with `\n`.