### PR TITLE
feat(extensions): add getGroups() alias on Registry and Extensions

### DIFF
--- a/packages/core/src/extensions.js
+++ b/packages/core/src/extensions.js
@@ -1414,6 +1414,13 @@ export class Registry {
     return extension
   }
 
+  // ── JavaScript-style accessors ───────────────────────────────────────────────
+
+  /** @returns {object} the plain Object that maps names to groups for this registry. */
+  getGroups() {
+    return this.groups
+  }
+
   // ── Private helpers ──────────────────────────────────────────────────────────
 
   /** @internal */
@@ -1637,6 +1644,15 @@ export const Extensions = {
    */
   groups() {
     return _groups
+  },
+
+  /**
+   * Alias for {@link groups}.
+   *
+   * @returns {object}
+   */
+  getGroups() {
+    return this.groups()
   },
 
   /**

--- a/packages/core/test/extensions.test.js
+++ b/packages/core/test/extensions.test.js
@@ -174,6 +174,16 @@ describe('Extensions.Register', () => {
     assert.equal(Object.keys(Extensions.groups()).length, 0)
   })
 
+  test('registry.getGroups is an alias for registry.groups', () => {
+    const registry = Extensions.create('sample', function () {
+      this.block(function () {
+        this.named('whisper')
+        this.process((_parent, _reader, _attributes) => {})
+      })
+    })
+    assert.equal(registry.getGroups(), registry.groups)
+  })
+
   test('should auto-generate name when none given', () => {
     const _g1 = Extensions.register(SampleExtensionGroup)
     const _g2 = Extensions.register(SampleExtensionGroup)
@@ -188,6 +198,11 @@ describe('Extensions.Register', () => {
     assert.throws(() => Extensions.register(), {
       message: /Extension group to register not specified/,
     })
+  })
+
+  test('getGroups is an alias for groups', () => {
+    Extensions.register('sample', SampleExtensionGroup)
+    assert.equal(Extensions.getGroups(), Extensions.groups())
   })
 })
 

--- a/packages/core/types/extensions.d.ts
+++ b/packages/core/types/extensions.d.ts
@@ -700,6 +700,8 @@ export class Registry {
      * @returns {ProcessorExtension} the Extension stored in the registry.
      */
     prefer(...args: any[]): ProcessorExtension;
+    /** @returns {object} the plain Object that maps names to groups for this registry. */
+    getGroups(): object;
 }
 export namespace Extensions {
     /**
@@ -708,6 +710,12 @@ export namespace Extensions {
      * @returns {object}
      */
     function groups(): object;
+    /**
+     * Alias for {@link groups}.
+     *
+     * @returns {object}
+     */
+    function getGroups(): object;
     /**
      * Create a new Registry, optionally pre-populated with a named block.
      *


### PR DESCRIPTION
Adds Registry#getGroups() and Extensions.getGroups() as JavaScript-style accessor aliases for the existing groups property/method, following the dual accessor pattern established in the codebase.