### PR TITLE
fix(load): strip UTF-8 BOM encoded as raw Latin-1 bytes

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,6 +15,8 @@ Improvements::
 Bug Fixes::
 
 * `NullLogger` now properly extends `Logger` — `instanceof Logger` checks on a `NullLogger` instance now return `true`
+* Strip UTF-8 BOM when it appears as three raw Latin-1 characters (ï»¿ / `\xEF\xBB\xBF`) rather than the decoded U+FEFF codepoint — fixes loading of BOM-prefixed content passed through a binary/Latin-1 decoder
+* `load()` now accepts a `Uint8Array` (including browser shim instances returned by `Buffer.concat`) in addition to Node.js `Buffer` — fixes "unsupported input type: object" error in browser environments
 
 == v4.0.0-alpha.2 (2026-05-17)
 

--- a/packages/core/src/helpers.js
+++ b/packages/core/src/helpers.js
@@ -38,7 +38,16 @@ const rstrip = (line) => line.replace(/[ \t\r\n\f\v]+$/, '')
  */
 export function prepareSourceArray(data, trimEnd = true) {
   if (!data.length) return []
-  if (data[0].startsWith(BOM)) data[0] = data[0].slice(1)
+  if (data[0].startsWith(BOM)) {
+    data[0] = data[0].slice(1)
+  } else if (
+    data[0].charCodeAt(0) === 0xef &&
+    data[0].charCodeAt(1) === 0xbb &&
+    data[0].charCodeAt(2) === 0xbf
+  ) {
+    // Strip UTF-8 BOM encoded as three raw characters (ï»¿ / \xEF\xBB\xBF) if not already decoded to U+FEFF
+    data[0] = data[0].slice(3)
+  }
   // Strip trailing \r to normalize Windows CRLF line endings (lines were split on \n, leaving \r).
   return trimEnd
     ? data.map(rstrip)
@@ -58,7 +67,16 @@ export function prepareSourceArray(data, trimEnd = true) {
  */
 export function prepareSourceString(data, trimEnd = true) {
   if (!data) return []
-  if (data.startsWith(BOM)) data = data.slice(1)
+  if (data.startsWith(BOM)) {
+    data = data.slice(1)
+  } else if (
+    data.charCodeAt(0) === 0xef &&
+    data.charCodeAt(1) === 0xbb &&
+    data.charCodeAt(2) === 0xbf
+  ) {
+    // Strip UTF-8 BOM encoded as three raw characters (ï»¿ / \xEF\xBB\xBF) if not already decoded to U+FEFF
+    data = data.slice(3)
+  }
   // Normalize Windows CRLF to LF so that split('\n') does not leave trailing \r on each line.
   if (data.includes('\r'))
     data = data.replace(/\r\n/g, '\n').replace(/\r/g, '\n')

--- a/packages/core/src/load.js
+++ b/packages/core/src/load.js
@@ -100,11 +100,9 @@ export async function load(input, options = {}) {
       attrs.docname = basename(inputPath, docfilesuffix)
     }
     source = await _readStream(input)
-  } else if (
-    typeof input === 'object' &&
-    input?.constructor?.name === 'Buffer'
-  ) {
-    source = input.toString('utf8')
+  } else if (input instanceof Uint8Array) {
+    // Covers both Node.js Buffer (a Uint8Array subclass) and browser Uint8Array shims.
+    source = new TextDecoder('utf-8').decode(input)
   } else if (typeof input === 'string') {
     source = input
   } else if (Array.isArray(input)) {

--- a/packages/core/test/load.test.js
+++ b/packages/core/test/load.test.js
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url'
 import { dirname, join, resolve } from 'node:path'
 
 import { load, loadFile } from '../src/load.js'
+import { convert } from '../src/convert.js'
 
 const FIXTURES_DIR = join(dirname(fileURLToPath(import.meta.url)), './fixtures')
 
@@ -46,6 +47,32 @@ test('load with attributes as key=value string', async () => {
   assert.equal(doc.getAttribute('source-highlighter'), 'highlight.js')
 })
 
+test('load source with BOM from Buffer', async () => {
+  const content = '= Document Title\n\nPreamble'
+  const buffer = Buffer.concat([
+    Buffer.from([0xef, 0xbb, 0xbf]),
+    Buffer.from(content, 'utf8'),
+  ])
+  const doc = await load(buffer, { safe: 'safe' })
+  assert.equal(doc.doctitle(), 'Document Title')
+  assert.equal(doc.blocks.length, 1)
+  const output = await convert(buffer, { safe: 'safe', standalone: false })
+  assert.match(output, /<p>Preamble<\/p>/)
+  assert.doesNotMatch(output, /﻿|ï»¿/)
+})
+
+test('load source with UTF-8 BOM bytes as raw Latin-1 characters', async () => {
+  // When content is decoded with Latin-1 / binary encoding, the UTF-8 BOM bytes
+  // (0xEF 0xBB 0xBF) appear as three separate characters (ï»¿) rather than U+FEFF.
+  const content = '\xEF\xBB\xBF= Document Title\n\nPreamble'
+  const doc = await load(content, { safe: 'safe' })
+  assert.equal(doc.doctitle(), 'Document Title')
+  assert.equal(doc.blocks.length, 1)
+  const output = await convert(content, { safe: 'safe', standalone: false })
+  assert.match(output, /<p>Preamble<\/p>/)
+  assert.doesNotMatch(output, /﻿|ï»¿/)
+})
+
 test('load input file via loadFile', async () => {
   const samplePath = join(FIXTURES_DIR, 'sample.adoc')
   const doc = await loadFile(samplePath, { safe: 'safe' })
@@ -53,4 +80,11 @@ test('load input file via loadFile', async () => {
   assert.equal(doc.getAttribute('docfile'), resolve(samplePath))
   assert.equal(doc.getAttribute('docdir'), dirname(resolve(samplePath)))
   assert.equal(doc.getAttribute('docfilesuffix'), '.adoc')
+})
+
+test('load file with UTF-8 BOM via loadFile', async () => {
+  const bomPath = join(FIXTURES_DIR, 'file-with-utf8-bom.adoc')
+  const doc = await loadFile(bomPath, { safe: 'safe' })
+  assert.equal(doc.doctitle(), '人')
+  assert.doesNotMatch(doc.doctitle(), /﻿|ï»¿/)
 })


### PR DESCRIPTION
When content is decoded with Latin-1/binary encoding, the UTF-8 BOM bytes (`0xEF 0xBB 0xBF`) appear as three separate characters (`ï»¿`) rather than the decoded `U+FEFF` codepoint. `prepareSourceString` and `prepareSourceArray` now handle both representations.