### PR TITLE
fix(document): apply replacements subs to document header title

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,7 @@ Improvements::
 
 Bug Fixes::
 
+* `doc.doctitle()` and `doc.xreftext()` now apply typographic substitutions (e.g., `'` → `&#8217;`) to the document title and reftext, matching the Ruby reference implementation
 * `NullLogger` now properly extends `Logger` — `instanceof Logger` checks on a `NullLogger` instance now return `true`
 
 == v4.0.0-alpha.2 (2026-05-17)

--- a/packages/core/src/document.js
+++ b/packages/core/src/document.js
@@ -1657,6 +1657,12 @@ export class Document extends AbstractBlock {
    * Handles titles (AbstractBlock), list item text, table cell text, and reftexts.
    */
   async _resolveAllTexts(block) {
+    // The header section lives outside document.blocks; pre-compute its title here so
+    // that doc.doctitle() returns the fully-substituted title (with replacements applied,
+    // e.g. ' → &#8217;) rather than the header-subs-only fallback.
+    if (block === this && this.header) {
+      await this.header.precomputeTitle?.()
+    }
     // Skip title pre-computation for blocks with an explicit empty id ([id=]).
     // In Ruby, apply_title_subs is lazy: it is never called during parsing for such
     // blocks because section.title is never accessed.  An explicit empty id is

--- a/packages/core/test/document.test.js
+++ b/packages/core/test/document.test.js
@@ -185,6 +185,19 @@ describe('Structure', () => {
     assert.ok(doc.header != null)
   })
 
+  test('doctitle applies replacements substitution (apostrophe → &#8217;)', async () => {
+    const input = "= Let's Go!\n\npreamble"
+    const doc = await parse(input)
+    assert.equal(doc.doctitle(), 'Let&#8217;s Go!')
+  })
+
+  test('xreftext with reftext applies quotes and replacements substitutions', async () => {
+    const input = "[#go,reftext=\"Let's get goin`'!\"]\n= Let's Go!\n\npreamble"
+    const doc = await parse(input)
+    assert.equal(doc.doctitle(), 'Let&#8217;s Go!')
+    assert.equal(doc.xreftext(), 'Let&#8217;s get goin&#8217;!')
+  })
+
   test('document with legacy doctitle enables compat mode', async () => {
     const input = 'Document Title\n==============\n\n+content+'
     const doc = await parse(input)


### PR DESCRIPTION
The header section lived outside document.blocks so `precomputeTitle()` was never called on it. As a result, `doc.doctitle()` fell back to the synchronous `applyHeaderSubs()` path (`specialcharacters` + `attributes` only), leaving typographic substitutions like `' → &#8217;` unapplied.

Fix `_resolveAllTexts` to also precompute the header section title when processing the document root, matching Ruby's `apply_title_subs` behaviour.