### PR TITLE
fix(attributes): hide attribute_entries from public attributes using a Symbol key

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,7 @@ Improvements::
 
 Bug Fixes::
 
+* `AbstractBlock#getAttributes()` no longer exposes the internal `attribute_entries` bookkeeping key — attribute entries are now stored under a private Symbol key invisible to `Object.keys()`, `for…in`, and `JSON.stringify()`
 * `doc.doctitle()` and `doc.xreftext()` now apply typographic substitutions (e.g., `'` → `&#8217;`) to the document title and reftext, matching the Ruby reference implementation
 * `NullLogger` now properly extends `Logger` — `instanceof Logger` checks on a `NullLogger` instance now return `true`
 * Strip UTF-8 BOM when it appears as three raw Latin-1 characters (ï»¿ / `\xEF\xBB\xBF`) rather than the decoded U+FEFF codepoint — fixes loading of BOM-prefixed content passed through a binary/Latin-1 decoder

--- a/packages/core/src/attribute_entry.js
+++ b/packages/core/src/attribute_entry.js
@@ -1,3 +1,19 @@
+// Symbol key used to store attribute entries on a block-attributes object without
+// polluting the public attributes (invisible to Object.keys / for-in / JSON.stringify).
+// Spread ({ ...attrs }) copies Symbol-keyed properties, so the entry survives the
+// shallow clone made in AbstractNode's constructor.
+export const ATTR_ENTRIES_KEY = Symbol('attribute_entries')
+
+/**
+ * Return the attribute entries stored for the given block attributes object,
+ * or undefined if none have been saved.
+ * @param {Object} blockAttributes
+ * @returns {AttributeEntry[]|undefined}
+ */
+export function getAttributeEntries(blockAttributes) {
+  return blockAttributes[ATTR_ENTRIES_KEY]
+}
+
 export class AttributeEntry {
   constructor(name, value, negate = null) {
     this.name = name
@@ -6,7 +22,7 @@ export class AttributeEntry {
   }
 
   saveTo(blockAttributes) {
-    ;(blockAttributes.attribute_entries ??= []).push(this)
+    ;(blockAttributes[ATTR_ENTRIES_KEY] ??= []).push(this)
     return this
   }
 }

--- a/packages/core/src/document.js
+++ b/packages/core/src/document.js
@@ -68,7 +68,11 @@ export class ImageReference {
 import { Footnote } from './footnote.js'
 export { Footnote }
 
-import { AttributeEntry } from './attribute_entry.js'
+import {
+  AttributeEntry,
+  getAttributeEntries,
+  ATTR_ENTRIES_KEY,
+} from './attribute_entry.js'
 export { AttributeEntry }
 
 /**
@@ -927,8 +931,9 @@ export class Document extends AbstractBlock {
    * @param {Object} blockAttributes
    */
   playbackAttributes(blockAttributes) {
-    if (!('attribute_entries' in blockAttributes)) return
-    for (const entry of blockAttributes.attribute_entries) {
+    const entries = getAttributeEntries(blockAttributes)
+    if (!entries) return
+    for (const entry of entries) {
       if (entry.negate) {
         delete this.attributes[entry.name]
         if (entry.name === 'compat-mode') this.compatMode = false
@@ -1746,7 +1751,7 @@ export class Document extends AbstractBlock {
    * @internal
    */
   _clearPlaybackAttributes(attributes) {
-    delete attributes.attribute_entries
+    delete attributes[ATTR_ENTRIES_KEY]
   }
 
   /**

--- a/packages/core/test/parser.test.js
+++ b/packages/core/test/parser.test.js
@@ -8,6 +8,7 @@ import { load } from '../src/load.js'
 import { Parser } from '../src/parser.js'
 import { Reader } from '../src/reader.js'
 import { MemoryLogger, LoggerManager } from '../src/logging.js'
+import { getAttributeEntries } from '../src/attribute_entry.js'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -75,10 +76,11 @@ describe('Parser', () => {
     assert.equal(attrName, 'foo')
     assert.equal(attrValue, 'bar')
     assert.equal(doc.getAttribute('foo'), 'bar')
-    assert.ok('attribute_entries' in attrs)
-    assert.equal(attrs.attribute_entries.length, 1)
-    assert.equal(attrs.attribute_entries[0].name, 'foo')
-    assert.equal(attrs.attribute_entries[0].value, 'bar')
+    assert.ok(getAttributeEntries(attrs) != null)
+    assert.equal(getAttributeEntries(attrs).length, 1)
+    assert.equal(getAttributeEntries(attrs)[0].name, 'foo')
+    assert.equal(getAttributeEntries(attrs)[0].value, 'bar')
+    assert.ok(!('attribute_entries' in attrs))
   })
 
   test('store accessible attribute on document with value that contains attribute reference', async () => {
@@ -95,10 +97,11 @@ describe('Parser', () => {
     assert.equal(attrName, 'foo')
     assert.equal(attrValue, 'ultramega')
     assert.equal(doc.getAttribute('foo'), 'ultramega')
-    assert.ok('attribute_entries' in attrs)
-    assert.equal(attrs.attribute_entries.length, 1)
-    assert.equal(attrs.attribute_entries[0].name, 'foo')
-    assert.equal(attrs.attribute_entries[0].value, 'ultramega')
+    assert.ok(getAttributeEntries(attrs) != null)
+    assert.equal(getAttributeEntries(attrs).length, 1)
+    assert.equal(getAttributeEntries(attrs)[0].name, 'foo')
+    assert.equal(getAttributeEntries(attrs)[0].value, 'ultramega')
+    assert.ok(!('attribute_entries' in attrs))
   })
 
   test('store inaccessible attribute on document with value', async () => {
@@ -113,6 +116,7 @@ describe('Parser', () => {
     assert.equal(attrName, 'foo')
     assert.equal(attrValue, 'bar')
     assert.equal(doc.getAttribute('foo'), 'baz')
+    assert.ok(getAttributeEntries(attrs) == null)
     assert.ok(!('attribute_entries' in attrs))
   })
 
@@ -133,10 +137,11 @@ describe('Parser', () => {
       )
       assert.equal(attrName, name.replace('!', ''))
       assert.equal(attrValue, null)
-      assert.ok('attribute_entries' in attrs)
-      assert.equal(attrs.attribute_entries.length, 1)
-      assert.equal(attrs.attribute_entries[0].name, 'foo')
-      assert.equal(attrs.attribute_entries[0].value, null)
+      assert.ok(getAttributeEntries(attrs) != null)
+      assert.equal(getAttributeEntries(attrs).length, 1)
+      assert.equal(getAttributeEntries(attrs)[0].name, 'foo')
+      assert.equal(getAttributeEntries(attrs)[0].value, null)
+      assert.ok(!('attribute_entries' in attrs))
     }
   })
 
@@ -156,6 +161,7 @@ describe('Parser', () => {
       )
       assert.equal(attrName, name.replace('!', ''))
       assert.equal(attrValue, null)
+      assert.ok(getAttributeEntries(attrs) == null)
       assert.ok(!('attribute_entries' in attrs))
     }
   })

--- a/packages/core/types/attribute_entry.d.ts
+++ b/packages/core/types/attribute_entry.d.ts
@@ -1,3 +1,11 @@
+/**
+ * Return the attribute entries stored for the given block attributes object,
+ * or undefined if none have been saved.
+ * @param {Object} blockAttributes
+ * @returns {AttributeEntry[]|undefined}
+ */
+export function getAttributeEntries(blockAttributes: any): AttributeEntry[] | undefined;
+export const ATTR_ENTRIES_KEY: unique symbol;
 export class AttributeEntry {
     constructor(name: any, value: any, negate?: any);
     name: any;


### PR DESCRIPTION
Replace the string key 'attribute_entries' with a module-private Symbol so that the internal playback bookkeeping is invisible to `Object.keys()`, for-in loops, and `JSON.stringify()`. The Symbol survives the shallow clone (`{ ...attrs }`) made in AbstractNode's constructor, so `playbackAttributes()` still works correctly after the spread.

Resolves #742