### PR TITLE
feat(types): export DSL interfaces and type process methods in extensions

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -15,6 +15,8 @@ Documentation::
 
 Improvements::
 
+* Export named TypeScript DSL interface types (`ProcessorDslInterface`, `DocumentProcessorDslInterface`, `SyntaxProcessorDslInterface`, `IncludeProcessorDslInterface`, `DocinfoProcessorDslInterface`, `BlockProcessorDslInterface`, `MacroProcessorDslInterface`, `InlineMacroProcessorDslInterface`) from `@asciidoctor/core` — TypeScript consumers can now use these as `this` context types in block-style extension registrations
+* Type the `process` method precisely on each processor class: `Preprocessor`, `TreeProcessor`, `Postprocessor`, `IncludeProcessor`, `DocinfoProcessor`, `BlockProcessor`, `MacroProcessor`, `BlockMacroProcessor`, and `InlineMacroProcessor` now have fully typed parameter and return types instead of `any`
 * Add `Registry#getGroups()` and `Extensions#getGroups()` as JavaScript-style accessor aliases for the `groups` property, following the dual accessor pattern
 
 Bug Fixes::

--- a/packages/core/src/extensions.js
+++ b/packages/core/src/extensions.js
@@ -27,6 +27,94 @@ import { basename } from './helpers.js'
 import { ATTR_REF_HEAD } from './constants.js'
 import { MacroNameRx, CC_ANY } from './rx.js'
 
+// Type-only imports for JSDoc
+/**
+ * @typedef {import('./document.js').Document} Document
+ * @typedef {import('./abstract_block.js').AbstractBlock} AbstractBlock
+ */
+
+// ── DSL interface types ───────────────────────────────────────────────────────
+
+/**
+ * DSL interface for configuring a {@link Processor} instance.
+ * Applied to a processor instance via `Object.assign(instance, DslMixin)`.
+ *
+ * The `process` property behaves as a setter when called with a single Function
+ * argument (stores the process block), or as a passthrough caller otherwise.
+ *
+ * @typedef {object} ProcessorDslInterface
+ * @property {(key: string, value: unknown) => void} option - Set a config option.
+ * @property {(fn: (...args: unknown[]) => unknown) => void} process - Register the process function.
+ * @property {() => boolean} processBlockGiven - Returns true if a process function has been registered.
+ */
+
+/**
+ * DSL interface for document processors (Preprocessor, TreeProcessor, Postprocessor, DocinfoProcessor).
+ *
+ * @typedef {ProcessorDslInterface & { prefer(): void; prepend(): void }} DocumentProcessorDslInterface
+ */
+
+/**
+ * DSL interface for syntax processors (BlockProcessor, BlockMacroProcessor, InlineMacroProcessor).
+ *
+ * @typedef {ProcessorDslInterface & {
+ *   named(value: string): void;
+ *   contentModel(value: string): void;
+ *   parseContentAs(value: string): void;
+ *   positionalAttributes(...value: string[]): void;
+ *   namePositionalAttributes(...value: string[]): void;
+ *   positionalAttrs(...value: string[]): void;
+ *   defaultAttributes(value: Record<string, string>): void;
+ *   defaultAttrs(value: Record<string, string>): void;
+ *   resolveAttributes(...args: unknown[]): void;
+ *   resolvesAttributes(...args: unknown[]): void;
+ * }} SyntaxProcessorDslInterface
+ */
+
+/**
+ * DSL interface for include processors.
+ *
+ * @typedef {DocumentProcessorDslInterface & {
+ *   handles(fn: (doc: Document, target: string) => boolean): void;
+ * }} IncludeProcessorDslInterface
+ */
+
+/**
+ * DSL interface for docinfo processors.
+ *
+ * @typedef {DocumentProcessorDslInterface & {
+ *   atLocation(value: string): void;
+ * }} DocinfoProcessorDslInterface
+ */
+
+/**
+ * DSL interface for block processors.
+ *
+ * @typedef {SyntaxProcessorDslInterface & {
+ *   contexts(...value: (string | string[])[]): void;
+ *   onContexts(...value: (string | string[])[]): void;
+ *   onContext(...value: (string | string[])[]): void;
+ *   bindTo(...value: (string | string[])[]): void;
+ * }} BlockProcessorDslInterface
+ */
+
+/**
+ * DSL interface for macro processors (block and inline macros).
+ *
+ * @typedef {SyntaxProcessorDslInterface} MacroProcessorDslInterface
+ */
+
+/**
+ * DSL interface for inline macro processors.
+ *
+ * @typedef {MacroProcessorDslInterface & {
+ *   format(value: string): void;
+ *   matchFormat(value: string): void;
+ *   usingFormat(value: string): void;
+ *   match(value: RegExp): void;
+ * }} InlineMacroProcessorDslInterface
+ */
+
 // ── DSL Mixins ────────────────────────────────────────────────────────────────
 
 /**
@@ -625,7 +713,12 @@ export class Processor {
  * Extensions.register(function () { this.preprocessor(CommentStripPreprocessor) })
  */
 export class Preprocessor extends Processor {
-  process(_document, _reader) {
+  /**
+   * @param {Document} document - The document being parsed.
+   * @param {Reader} reader - The reader positioned at the beginning of the source.
+   * @returns {Reader|undefined} The same or a substitute Reader, or undefined to use the original.
+   */
+  process(document, reader) {
     throw new Error(
       `${this.constructor.name} must implement the process method`
     )
@@ -650,7 +743,11 @@ Preprocessor.DSL = DocumentProcessorDsl
  * Extensions.register(function () { this.treeProcessor(ShoutTreeProcessor) })
  */
 export class TreeProcessor extends Processor {
-  process(_document) {
+  /**
+   * @param {Document} document - The parsed document.
+   * @returns {void}
+   */
+  process(document) {
     throw new Error(
       `${this.constructor.name} must implement the process method`
     )
@@ -679,7 +776,12 @@ export const Treeprocessor = TreeProcessor
  * Extensions.register(function () { this.postprocessor(FooterPostprocessor) })
  */
 export class Postprocessor extends Processor {
-  process(_document, _output) {
+  /**
+   * @param {Document} document - The converted document.
+   * @param {string} output - The converted output string.
+   * @returns {string} The (possibly modified) output string.
+   */
+  process(document, output) {
     throw new Error(
       `${this.constructor.name} must implement the process method`
     )
@@ -693,13 +795,25 @@ Postprocessor.DSL = DocumentProcessorDsl
  * Implementations must extend IncludeProcessor.
  */
 export class IncludeProcessor extends Processor {
-  process(_document, _reader, _target, _attributes) {
+  /**
+   * @param {Document} document - The document being parsed.
+   * @param {Reader} reader - The reader for the including document.
+   * @param {string} target - The target of the include directive.
+   * @param {Record<string, string>} attributes - The parsed include attributes.
+   * @returns {void}
+   */
+  process(document, reader, target, attributes) {
     throw new Error(
       `${this.constructor.name} must implement the process method`
     )
   }
 
-  handles(_doc, _target) {
+  /**
+   * @param {Document} doc - The document being parsed.
+   * @param {string} target - The target of the include directive.
+   * @returns {boolean} true if this processor handles the given target.
+   */
+  handles(doc, target) {
     return true
   }
 }
@@ -717,7 +831,11 @@ export class DocinfoProcessor extends Processor {
     this.config.location ??= 'head'
   }
 
-  process(_document) {
+  /**
+   * @param {Document} document - The document being converted.
+   * @returns {string} The docinfo content to inject into the document.
+   */
+  process(document) {
     throw new Error(
       `${this.constructor.name} must implement the process method`
     )
@@ -773,7 +891,13 @@ export class BlockProcessor extends Processor {
     this.config.content_model ??= 'compound'
   }
 
-  process(_parent, _reader, _attributes) {
+  /**
+   * @param {AbstractBlock} parent - The enclosing block.
+   * @param {Reader} reader - The reader positioned at the block content.
+   * @param {Record<string, unknown>} attributes - The parsed block attributes.
+   * @returns {Block|void} A block node, or void to let the parser handle it.
+   */
+  process(parent, reader, attributes) {
     throw new Error(
       `${this.constructor.name} must implement the process method`
     )
@@ -791,7 +915,13 @@ export class MacroProcessor extends Processor {
     this.config.content_model ??= 'attributes'
   }
 
-  process(_parent, _target, _attributes) {
+  /**
+   * @param {AbstractBlock} parent - The enclosing block.
+   * @param {string} target - The macro target (text between `name:` and `[`).
+   * @param {Record<string, unknown>} attributes - The parsed macro attributes.
+   * @returns {Block|Inline|void}
+   */
+  process(parent, target, attributes) {
     throw new Error(
       `${this.constructor.name} must implement the process method`
     )
@@ -837,6 +967,16 @@ export class BlockMacroProcessor extends MacroProcessor {
   set name(value) {
     this._name = value
   }
+
+  /**
+   * @param {AbstractBlock} parent - The enclosing block.
+   * @param {string} target - The macro target.
+   * @param {Record<string, unknown>} attributes - The parsed macro attributes.
+   * @returns {Block} A block node created with one of the `createBlock` helpers.
+   */
+  process(parent, target, attributes) {
+    return super.process(parent, target, attributes)
+  }
 }
 BlockMacroProcessor.DSL = MacroProcessorDsl
 
@@ -878,6 +1018,16 @@ export class InlineMacroProcessor extends MacroProcessor {
       String(this.name),
       this.config.format
     ))
+  }
+
+  /**
+   * @param {AbstractBlock} parent - The enclosing block.
+   * @param {string} target - The macro target.
+   * @param {Record<string, unknown>} attributes - The parsed macro attributes.
+   * @returns {Inline} An Inline node created with `this.createInline(...)`.
+   */
+  process(parent, target, attributes) {
+    return super.process(parent, target, attributes)
   }
 
   resolveRegexp(name, format) {

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -28,6 +28,18 @@ import {
   BlockMacroProcessor,
   Extensions,
 } from './extensions.js'
+
+// Re-export DSL interface types for TypeScript consumers.
+/**
+ * @typedef {import('./extensions.js').ProcessorDslInterface} ProcessorDslInterface
+ * @typedef {import('./extensions.js').DocumentProcessorDslInterface} DocumentProcessorDslInterface
+ * @typedef {import('./extensions.js').SyntaxProcessorDslInterface} SyntaxProcessorDslInterface
+ * @typedef {import('./extensions.js').IncludeProcessorDslInterface} IncludeProcessorDslInterface
+ * @typedef {import('./extensions.js').DocinfoProcessorDslInterface} DocinfoProcessorDslInterface
+ * @typedef {import('./extensions.js').BlockProcessorDslInterface} BlockProcessorDslInterface
+ * @typedef {import('./extensions.js').MacroProcessorDslInterface} MacroProcessorDslInterface
+ * @typedef {import('./extensions.js').InlineMacroProcessorDslInterface} InlineMacroProcessorDslInterface
+ */
 import {
   Converter,
   ConverterBase,

--- a/packages/core/types/extensions.d.ts
+++ b/packages/core/types/extensions.d.ts
@@ -224,7 +224,12 @@ export class Processor {
  * Extensions.register(function () { this.preprocessor(CommentStripPreprocessor) })
  */
 export class Preprocessor extends Processor {
-    process(_document: any, _reader: any): void;
+    /**
+     * @param {Document} document - The document being parsed.
+     * @param {Reader} reader - The reader positioned at the beginning of the source.
+     * @returns {Reader|undefined} The same or a substitute Reader, or undefined to use the original.
+     */
+    process(document: Document, reader: Reader): Reader | undefined;
 }
 export namespace Preprocessor {
     export { DocumentProcessorDsl as DSL };
@@ -246,7 +251,11 @@ export namespace Preprocessor {
  * Extensions.register(function () { this.treeProcessor(ShoutTreeProcessor) })
  */
 export class TreeProcessor extends Processor {
-    process(_document: any): void;
+    /**
+     * @param {Document} document - The parsed document.
+     * @returns {void}
+     */
+    process(document: Document): void;
 }
 export namespace TreeProcessor {
     export { DocumentProcessorDsl as DSL };
@@ -271,7 +280,12 @@ export const Treeprocessor: typeof TreeProcessor;
  * Extensions.register(function () { this.postprocessor(FooterPostprocessor) })
  */
 export class Postprocessor extends Processor {
-    process(_document: any, _output: any): void;
+    /**
+     * @param {Document} document - The converted document.
+     * @param {string} output - The converted output string.
+     * @returns {string} The (possibly modified) output string.
+     */
+    process(document: Document, output: string): string;
 }
 export namespace Postprocessor {
     export { DocumentProcessorDsl as DSL };
@@ -282,8 +296,20 @@ export namespace Postprocessor {
  * Implementations must extend IncludeProcessor.
  */
 export class IncludeProcessor extends Processor {
-    process(_document: any, _reader: any, _target: any, _attributes: any): void;
-    handles(_doc: any, _target: any): boolean;
+    /**
+     * @param {Document} document - The document being parsed.
+     * @param {Reader} reader - The reader for the including document.
+     * @param {string} target - The target of the include directive.
+     * @param {Record<string, string>} attributes - The parsed include attributes.
+     * @returns {void}
+     */
+    process(document: Document, reader: Reader, target: string, attributes: Record<string, string>): void;
+    /**
+     * @param {Document} doc - The document being parsed.
+     * @param {string} target - The target of the include directive.
+     * @returns {boolean} true if this processor handles the given target.
+     */
+    handles(doc: Document, target: string): boolean;
 }
 export namespace IncludeProcessor {
     export { IncludeProcessorDsl as DSL };
@@ -295,7 +321,11 @@ export namespace IncludeProcessor {
  * Implementations must extend DocinfoProcessor.
  */
 export class DocinfoProcessor extends Processor {
-    process(_document: any): void;
+    /**
+     * @param {Document} document - The document being converted.
+     * @returns {string} The docinfo content to inject into the document.
+     */
+    process(document: Document): string;
 }
 export namespace DocinfoProcessor {
     export { DocinfoProcessorDsl as DSL };
@@ -331,7 +361,13 @@ export namespace DocinfoProcessor {
 export class BlockProcessor extends Processor {
     constructor(name?: any, config?: {});
     name: any;
-    process(_parent: any, _reader: any, _attributes: any): void;
+    /**
+     * @param {AbstractBlock} parent - The enclosing block.
+     * @param {Reader} reader - The reader positioned at the block content.
+     * @param {Record<string, unknown>} attributes - The parsed block attributes.
+     * @returns {Block|void} A block node, or void to let the parser handle it.
+     */
+    process(parent: AbstractBlock, reader: Reader, attributes: Record<string, unknown>): Block | void;
 }
 export namespace BlockProcessor {
     export { BlockProcessorDsl as DSL };
@@ -342,7 +378,13 @@ export namespace BlockProcessor {
 export class MacroProcessor extends Processor {
     constructor(name?: any, config?: {});
     name: any;
-    process(_parent: any, _target: any, _attributes: any): void;
+    /**
+     * @param {AbstractBlock} parent - The enclosing block.
+     * @param {string} target - The macro target (text between `name:` and `[`).
+     * @param {Record<string, unknown>} attributes - The parsed macro attributes.
+     * @returns {Block|Inline|void}
+     */
+    process(parent: AbstractBlock, target: string, attributes: Record<string, unknown>): Block | Inline | void;
 }
 /**
  * BlockMacroProcessors handle block macros with a custom name.
@@ -370,6 +412,13 @@ export class MacroProcessor extends Processor {
  */
 export class BlockMacroProcessor extends MacroProcessor {
     _name: any;
+    /**
+     * @param {AbstractBlock} parent - The enclosing block.
+     * @param {string} target - The macro target.
+     * @param {Record<string, unknown>} attributes - The parsed macro attributes.
+     * @returns {Block} A block node created with one of the `createBlock` helpers.
+     */
+    process(parent: AbstractBlock, target: string, attributes: Record<string, unknown>): Block;
 }
 export namespace BlockMacroProcessor {
     export { MacroProcessorDsl as DSL };
@@ -407,6 +456,13 @@ export class InlineMacroProcessor extends MacroProcessor {
      * @returns {RegExp}
      */
     get regexp(): RegExp;
+    /**
+     * @param {AbstractBlock} parent - The enclosing block.
+     * @param {string} target - The macro target.
+     * @param {Record<string, unknown>} attributes - The parsed macro attributes.
+     * @returns {Inline} An Inline node created with `this.createInline(...)`.
+     */
+    process(parent: AbstractBlock, target: string, attributes: Record<string, unknown>): Inline;
     resolveRegexp(name: any, format: any): any;
 }
 export namespace InlineMacroProcessor {
@@ -456,7 +512,7 @@ export class Registry {
      * @returns {Registry} this Registry.
      */
     activate(document: Document): Registry;
-    document: any;
+    document: import("./document.js").Document;
     /**
      * Register a Preprocessor with the extension registry.
      *
@@ -876,6 +932,85 @@ export namespace Extensions {
      */
     function newBlockMacroProcessor(name?: string, functions?: object, ...args: any[]): BlockMacroProcessor;
 }
+export type Document = import("./document.js").Document;
+export type AbstractBlock = import("./abstract_block.js").AbstractBlock;
+/**
+ * DSL interface for configuring a {@link Processor} instance.
+ * Applied to a processor instance via `Object.assign(instance, DslMixin)`.
+ *
+ * The `process` property behaves as a setter when called with a single Function
+ * argument (stores the process block), or as a passthrough caller otherwise.
+ */
+export type ProcessorDslInterface = {
+    /**
+     * - Set a config option.
+     */
+    option: (key: string, value: unknown) => void;
+    /**
+     * - Register the process function.
+     */
+    process: (fn: (...args: unknown[]) => unknown) => void;
+    /**
+     * - Returns true if a process function has been registered.
+     */
+    processBlockGiven: () => boolean;
+};
+/**
+ * DSL interface for document processors (Preprocessor, TreeProcessor, Postprocessor, DocinfoProcessor).
+ */
+export type DocumentProcessorDslInterface = ProcessorDslInterface & {
+    prefer(): void;
+    prepend(): void;
+};
+/**
+ * DSL interface for syntax processors (BlockProcessor, BlockMacroProcessor, InlineMacroProcessor).
+ */
+export type SyntaxProcessorDslInterface = ProcessorDslInterface & {
+    named(value: string): void;
+    contentModel(value: string): void;
+    parseContentAs(value: string): void;
+    positionalAttributes(...value: string[]): void;
+    namePositionalAttributes(...value: string[]): void;
+    positionalAttrs(...value: string[]): void;
+    defaultAttributes(value: Record<string, string>): void;
+    defaultAttrs(value: Record<string, string>): void;
+    resolveAttributes(...args: unknown[]): void;
+    resolvesAttributes(...args: unknown[]): void;
+};
+/**
+ * DSL interface for include processors.
+ */
+export type IncludeProcessorDslInterface = DocumentProcessorDslInterface & {
+    handles(fn: (doc: Document, target: string) => boolean): void;
+};
+/**
+ * DSL interface for docinfo processors.
+ */
+export type DocinfoProcessorDslInterface = DocumentProcessorDslInterface & {
+    atLocation(value: string): void;
+};
+/**
+ * DSL interface for block processors.
+ */
+export type BlockProcessorDslInterface = SyntaxProcessorDslInterface & {
+    contexts(...value: (string | string[])[]): void;
+    onContexts(...value: (string | string[])[]): void;
+    onContext(...value: (string | string[])[]): void;
+    bindTo(...value: (string | string[])[]): void;
+};
+/**
+ * DSL interface for macro processors (block and inline macros).
+ */
+export type MacroProcessorDslInterface = SyntaxProcessorDslInterface;
+/**
+ * DSL interface for inline macro processors.
+ */
+export type InlineMacroProcessorDslInterface = MacroProcessorDslInterface & {
+    format(value: string): void;
+    matchFormat(value: string): void;
+    usingFormat(value: string): void;
+    match(value: RegExp): void;
+};
 import { Section } from './section.js';
 import { Block } from './block.js';
 import { List } from './list.js';

--- a/packages/core/types/index.d.cts
+++ b/packages/core/types/index.d.cts
@@ -27,6 +27,14 @@ export function load(input: string | string[] | Buffer, options?: any): Promise<
  * @returns {Promise<Document>} - the parsed Document
  */
 export function loadFile(filename: string, options?: any): Promise<Document>;
+export type ProcessorDslInterface = import("./extensions.js").ProcessorDslInterface;
+export type DocumentProcessorDslInterface = import("./extensions.js").DocumentProcessorDslInterface;
+export type SyntaxProcessorDslInterface = import("./extensions.js").SyntaxProcessorDslInterface;
+export type IncludeProcessorDslInterface = import("./extensions.js").IncludeProcessorDslInterface;
+export type DocinfoProcessorDslInterface = import("./extensions.js").DocinfoProcessorDslInterface;
+export type BlockProcessorDslInterface = import("./extensions.js").BlockProcessorDslInterface;
+export type MacroProcessorDslInterface = import("./extensions.js").MacroProcessorDslInterface;
+export type InlineMacroProcessorDslInterface = import("./extensions.js").InlineMacroProcessorDslInterface;
 import { Document } from './document.js';
 import { convert } from './convert.js';
 import { convertFile } from './convert.js';

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -26,6 +26,14 @@ export function load(input: string | string[] | Buffer, options?: any): Promise<
  * @returns {Promise<Document>} - the parsed Document
  */
 export function loadFile(filename: string, options?: any): Promise<Document>;
+export type ProcessorDslInterface = import("./extensions.js").ProcessorDslInterface;
+export type DocumentProcessorDslInterface = import("./extensions.js").DocumentProcessorDslInterface;
+export type SyntaxProcessorDslInterface = import("./extensions.js").SyntaxProcessorDslInterface;
+export type IncludeProcessorDslInterface = import("./extensions.js").IncludeProcessorDslInterface;
+export type DocinfoProcessorDslInterface = import("./extensions.js").DocinfoProcessorDslInterface;
+export type BlockProcessorDslInterface = import("./extensions.js").BlockProcessorDslInterface;
+export type MacroProcessorDslInterface = import("./extensions.js").MacroProcessorDslInterface;
+export type InlineMacroProcessorDslInterface = import("./extensions.js").InlineMacroProcessorDslInterface;
 import { Document } from './document.js';
 import { convert } from './convert.js';
 import { convertFile } from './convert.js';


### PR DESCRIPTION
Add named TypeScript interface types for all DSL mixins (`ProcessorDslInterface`, `DocumentProcessorDslInterface`, `SyntaxProcessorDslInterface`, `IncludeProcessorDslInterface`, `DocinfoProcessorDslInterface`, `BlockProcessorDslInterface`, `MacroProcessorDslInterface`, `InlineMacroProcessorDslInterface`) and re-export them from the package entry point.

Replace the generic `process(..._args: any[])` stub on each processor base class with precise `@param/@returns` JSDoc so TypeScript generates fully typed signatures.