### PR TITLE
docs(browser): document Chrome --allow-file-access-from-files requirement for includes

### DIFF
--- a/docs/modules/setup/pages/install.adoc
+++ b/docs/modules/setup/pages/install.adoc
@@ -39,6 +39,19 @@ You need to do your testing through a server.
 Learn more about https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules[JavaScript modules].
 ====
 
+[NOTE]
+====
+If you're loading an AsciiDoc file from a `file://` URI and that document contains `include` directives, Chrome will block the `fetch` requests used to read the included files.
+To allow this, start Chrome with the following flag:
+
+[source,console]
+----
+--allow-file-access-from-files
+----
+
+This restriction does not apply when serving the page through a local HTTP server, which is the recommended approach.
+====
+
 == Node
 
 [source,js]

--- a/docs/modules/spec/pages/browser-include-spec.adoc
+++ b/docs/modules/spec/pages/browser-include-spec.adoc
@@ -1,8 +1,22 @@
 = Include directive processing in the browser
 
-This document describes how the include directive is processed in the browser environment (xmlhttprequest IO module).
+This document describes how the include directive is processed in the browser environment.
 This handling has slightly different rules than when a file-based document.
 The rules are listed in the order in which they are applied.
+
+[NOTE]
+====
+When converting a document loaded from a `file://` URI, `include` directives are resolved using `fetch`.
+Chrome blocks these requests by default.
+To allow local file access, start Chrome with:
+
+[source,console]
+----
+--allow-file-access-from-files
+----
+
+This restriction does not apply when serving files through a local HTTP server.
+====
 
 In these definitions, there are several commonly occurring terms that pertain to the include directive:
 
@@ -28,13 +42,13 @@ If both these tests fail, the include is replaced with a link.
 In this case, the base dir value has no impact.
 
 * If the target is relative and the base dir equals `.`, the target is used as both the include path and the relative path.
-The include path will be resolved relative to the window.location.href (per the behavior of XMLHttpRequest).
+The include path will be resolved relative to the window.location.href (per the behavior of fetch).
 
 * If the target is relative and the base dir begins with file://, the base dir is prepended to the target to create the include path.
 The target is used as the relative path.
 
 * If the target is relative and the base dir is relative, the base dir is prepended to the target to create the include path.
-The include path will be resolved relative to the window.location.href (per the behavior of XMLHttpRequest).
+The include path will be resolved relative to the window.location.href (per the behavior of fetch).
 The target is used as the relative path.
 
 * If the target is relative and the base dir is an absolute URL (i.e., starts with http:// or https:// scheme), the base dir is prepended to the target and used as the include path.
@@ -53,14 +67,14 @@ If either test succeeds, the target is used as both the include path and the rel
 In this case, the base dir value has no impact.
 
 * If the target is relative and the parent dir equals `.`, the target is used as both the include path and the relative path.
-The include path will be resolved relative to window.location.href (per the behavior of XMLHttpRequest).
+The include path will be resolved relative to window.location.href (per the behavior of fetch).
 
 * If the target is relative and the parent dir begins with file://, the parent dir is prepended to the target to create the include path.
 If the base dir equals `.`, or the include path does not descend from the base dir, the include path is used as the relative path.
 If the include path descends from the base dir, the relative path is the path difference.
 
 * If the target is relative and the parent dir is relative, the parent dir is prepended to the target to create the include path.
-The include path will be resolved relative to the window.location.href (per the behavior of XMLHttpRequest).
+The include path will be resolved relative to the window.location.href (per the behavior of fetch).
 If the base dir equals `.`, or the include path does not descend from the base dir, the include path is used as the relative path.
 If the include path descends from the base dir, the relative path is the path difference.
 

--- a/packages/core/src/browser/reader.js
+++ b/packages/core/src/browser/reader.js
@@ -5,7 +5,7 @@
 //
 // This logic is specific to Asciidoctor.js and has no equivalent in the upstream Ruby asciidoctor
 // implementation. It handles the case where the document is loaded in a browser environment
-// (XMLHttpRequest / Fetch IO module) where paths can be file:// or http(s):// URIs.
+// where paths can be file:// or http(s):// URIs.
 //
 // The key behavioural differences from the standard file-system resolver:
 //   - Relative targets are resolved by string concatenation against a URI context dir,
@@ -55,7 +55,7 @@ function _linkReplacement(reader, target, attrlist) {
  * 1. target starts with file:// → inc_path = relpath = target
  * 2. target is a URI → must descend from baseDir or allow-uri-read; else → link
  * 3. target is an absolute OS path → prepend file:// (or file:///)
- * 4. baseDir == '.' → inc_path = relpath = target  (resolved by XMLHttpRequest/fetch)
+ * 4. baseDir == '.' → inc_path = relpath = target  (resolved by fetch)
  * 5. baseDir starts with file:// OR baseDir is not a URI → inc_path = baseDir/target; relpath = target
  * 6. baseDir is an absolute URL → inc_path = baseDir/target; relpath = target
  *

--- a/packages/core/types/browser/reader.d.ts
+++ b/packages/core/types/browser/reader.d.ts
@@ -7,7 +7,7 @@
  * 1. target starts with file:// → inc_path = relpath = target
  * 2. target is a URI → must descend from baseDir or allow-uri-read; else → link
  * 3. target is an absolute OS path → prepend file:// (or file:///)
- * 4. baseDir == '.' → inc_path = relpath = target  (resolved by XMLHttpRequest/fetch)
+ * 4. baseDir == '.' → inc_path = relpath = target  (resolved by fetch)
  * 5. baseDir starts with file:// OR baseDir is not a URI → inc_path = baseDir/target; relpath = target
  * 6. baseDir is an absolute URL → inc_path = baseDir/target; relpath = target
  *


### PR DESCRIPTION
When loading an AsciiDoc document from a `file://` URI, Chrome blocks the fetch requests used to resolve include directives. Add a note to the install guide and the browser include spec, and update stale `XMLHttpRequest` references to `fetch`.

resolves #454 