### PR TITLE
refactor(html5): align readSvgContents with Ruby reference implementation

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,11 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 == Unreleased
 
+Improvements::
+
+* Align `readSvgContents` with the Ruby reference implementation by delegating entirely to `node.readContents`, removing the manual `isUriish`/`normalizeSystemPath` split
+* Fix `warnIfEmpty` in `AbstractNode#readContents` — the empty-string check now correctly uses `!= null` instead of a truthy guard, so a warning is emitted for empty local SVG assets
+
 == v4.0.0-alpha.3 (2026-05-20)
 
 Documentation::

--- a/packages/core/src/abstract_node.js
+++ b/packages/core/src/abstract_node.js
@@ -765,7 +765,7 @@ export class AbstractNode {
       })
     }
 
-    if (contents && opts.warnIfEmpty && contents.length === 0) {
+    if (contents != null && opts.warnIfEmpty && contents.length === 0) {
       this.logger.warn(`contents of ${label} is empty: ${resolvedTarget}`)
     }
     return contents

--- a/packages/core/src/converter/html5.js
+++ b/packages/core/src/converter/html5.js
@@ -29,7 +29,7 @@ import {
   INLINE_MATH_DELIMITERS,
 } from '../constants.js'
 import { XmlSanitizeRx } from '../rx.js'
-import { extname, isUriish } from '../helpers.js'
+import { extname } from '../helpers.js'
 import { Stylesheets } from '../stylesheets.js'
 
 // ── Local regex constants ─────────────────────────────────────────────────────
@@ -1767,32 +1767,13 @@ Your browser does not support the video tag.
 
   // NOTE expose readSvgContents for Bespoke converter
   async readSvgContents(node, target) {
-    const imagesdir = node.document.getAttribute('imagesdir')
-    let resolvedPath
-    let svg
-    if (isUriish(target) || (imagesdir && isUriish(imagesdir))) {
-      svg = await node.readContents(target, {
-        start: imagesdir,
-        normalize: true,
-        warnOnFailure: true,
-        label: 'SVG',
-      })
-      resolvedPath = target
-    } else {
-      resolvedPath = node.normalizeSystemPath(target, imagesdir, null, {
-        targetName: 'image',
-      })
-      svg = await node.readAsset(resolvedPath, {
-        normalize: true,
-        warnOnFailure: true,
-        label: 'SVG',
-      })
-    }
-    if (svg == null) return null // file not found/readable; warning already emitted
-    if (!svg) {
-      node.logger.warn(`contents of SVG is empty: ${resolvedPath}`)
-      return null
-    }
+    let svg = await node.readContents(target, {
+      start: node.document.getAttribute('imagesdir'),
+      normalize: true,
+      label: 'SVG',
+      warnIfEmpty: true,
+    })
+    if (!svg) return null
     if (!svg.startsWith('<svg')) svg = svg.replace(SvgPreambleRx, '')
     // Fix incomplete SVG start tag (missing closing >) by inserting > before the first child element.
     // This handles cases like: <svg width="500"\n<circle .../> where the > is missing.


### PR DESCRIPTION
Delegate URI/path resolution entirely to node.readContents instead of manually branching on isUriish/normalizeSystemPath. Also fix a bug in AbstractNode#readContents where the warnIfEmpty guard used a truthy check that silently skipped empty strings.