### PR TITLE
fix(convert): copy default stylesheet when stylesheet attr is empty string

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -32,6 +32,7 @@ Improvements::
 
 Bug Fixes::
 
+* `convert()` now copies `asciidoctor.css` to the output directory when `linkcss` and `copycss` are active and `stylesheet` is `''` (empty string, the default in standalone mode) — aligns with the Ruby reference implementation where an empty string is truthy; also implements `Stylesheets#writePrimaryStylesheet`, which was previously a no-op stub; in browser environments where the filesystem is unavailable the copy is skipped and an info message is logged
 * `AbstractBlock#getAttributes()` no longer exposes the internal `attribute_entries` bookkeeping key — attribute entries are now stored under a private Symbol key invisible to `Object.keys()`, `for…in`, and `JSON.stringify()`
 * `doc.doctitle()` and `doc.xreftext()` now apply typographic substitutions (e.g., `'` → `&#8217;`) to the document title and reftext, matching the Ruby reference implementation
 * `NullLogger` now properly extends `Logger` — `instanceof Logger` checks on a `NullLogger` instance now return `true`

--- a/packages/core/src/convert.js
+++ b/packages/core/src/convert.js
@@ -11,7 +11,7 @@
 //   - Ruby File.write → async writeFile() via node:fs/promises.
 //   - Ruby Helpers.mkdir_p → mkdirP() from helpers.js.
 //   - Ruby Helpers.uriish? → isUriish() from helpers.js.
-//   - Ruby Stylesheets.instance.write_primary_stylesheet → not yet ported to JS; skipped.
+//   - Ruby Stylesheets.instance.write_primary_stylesheet → Stylesheets.instance.writePrimaryStylesheet() in stylesheets.js; returns false in browser environments.
 //   - Ruby doc.syntax_highlighter → doc.syntaxHighlighter.
 //   - Ruby syntax_hl.write_stylesheet? doc → syntaxHl.writeStylesheet(doc).
 //   - Ruby syntax_hl.write_stylesheet doc, dir → syntaxHl.writeStylesheetToDisk(doc, dir).
@@ -24,6 +24,7 @@
 import { load } from './load.js'
 import { isUriish, mkdirP } from './helpers.js'
 import { SafeMode, DEFAULT_STYLESHEET_KEYS } from './constants.js'
+import { Stylesheets } from './stylesheets.js'
 
 // ── convert ───────────────────────────────────────────────────────────────────
 
@@ -214,7 +215,7 @@ export async function convert(input, options = {}) {
       let copyAsciidoctorStylesheet = false
       let copyUserStylesheet = false
       const stylesheet = doc.getAttribute('stylesheet')
-      if (stylesheet) {
+      if (stylesheet != null) {
         if (DEFAULT_STYLESHEET_KEYS.has(stylesheet)) {
           copyAsciidoctorStylesheet = true
         } else if (!isUriish(stylesheet)) {
@@ -246,7 +247,13 @@ export async function convert(input, options = {}) {
         }
 
         if (copyAsciidoctorStylesheet) {
-          // NOTE Stylesheets.instance.write_primary_stylesheet is not yet ported to JS
+          if (
+            !(await Stylesheets.instance.writePrimaryStylesheet(stylesoutdir))
+          ) {
+            doc.logger.info(
+              'skipping default stylesheet copy: filesystem writes are not supported in this environment'
+            )
+          }
         } else if (copyUserStylesheet) {
           let stylesheetSrc = doc.getAttribute('copycss')
           if (stylesheetSrc === '' || stylesheetSrc === true) {

--- a/packages/core/src/stylesheets.js
+++ b/packages/core/src/stylesheets.js
@@ -23,6 +23,21 @@ class StylesheetsClass {
   async embedPrimaryStylesheet() {
     return `<style>\n${defaultStylesheetData}\n</style>`
   }
+
+  async writePrimaryStylesheet(stylesoutdir) {
+    try {
+      const { writeFile } = await import('node:fs/promises')
+      const { join } = await import('node:path')
+      await writeFile(
+        join(stylesoutdir, StylesheetsClass.DEFAULT_STYLESHEET_NAME),
+        defaultStylesheetData,
+        'utf8'
+      )
+      return true
+    } catch {
+      return false
+    }
+  }
 }
 
 export const Stylesheets = {

--- a/packages/core/test/convert.test.js
+++ b/packages/core/test/convert.test.js
@@ -254,14 +254,14 @@ describe('stylesheet copying (linkcss + copycss)', () => {
   // Helper: file-like input object for a path whose content is already in memory
   const fileInput = (path, content) => ({ path, read: () => content })
 
-  test('default stylesheet (asciidoctor.css) is not written — feature not yet ported', async () => {
+  test('default stylesheet (asciidoctor.css) is copied when stylesheet="" (default)', async () => {
     await withTmpDir(async (dir) => {
       const inputPath = join(dir, 'doc.adoc')
       const content = '= Doc\n\nHello.'
       await writeFile(inputPath, content, 'utf8')
       const outDir = join(dir, 'out')
       await mkdir(outDir)
-      // stylesheet='' (default) → falsy → DEFAULT_STYLESHEET_KEYS block is skipped entirely
+      // stylesheet='' (default in standalone mode) → DEFAULT_STYLESHEET_KEYS.has('') → copy default stylesheet
       await convert(fileInput(inputPath, content), {
         safe: 'unsafe',
         to_dir: outDir,
@@ -269,20 +269,20 @@ describe('stylesheet copying (linkcss + copycss)', () => {
       })
       const files = await readdir(outDir)
       assert.ok(
-        !files.some((f) => f.endsWith('.css')),
-        'asciidoctor.css should not be written (not yet ported)'
+        files.includes('asciidoctor.css'),
+        'asciidoctor.css should be written to the output directory'
       )
     })
   })
 
-  test('stylesheet=DEFAULT (truthy key) triggers copyAsciidoctorStylesheet but writes no file', async () => {
+  test('stylesheet=DEFAULT copies default asciidoctor.css', async () => {
     await withTmpDir(async (dir) => {
       const inputPath = join(dir, 'doc.adoc')
       const content = '= Doc\n\nHello.'
       await writeFile(inputPath, content, 'utf8')
       const outDir = join(dir, 'out')
       await mkdir(outDir)
-      // 'DEFAULT' is in DEFAULT_STYLESHEET_KEYS → copyAsciidoctorStylesheet = true (not yet ported)
+      // 'DEFAULT' is in DEFAULT_STYLESHEET_KEYS → copy default stylesheet
       await convert(fileInput(inputPath, content), {
         safe: 'unsafe',
         to_dir: outDir,
@@ -290,8 +290,8 @@ describe('stylesheet copying (linkcss + copycss)', () => {
       })
       const files = await readdir(outDir)
       assert.ok(
-        !files.some((f) => f.endsWith('.css')),
-        'no CSS file written (not yet ported)'
+        files.includes('asciidoctor.css'),
+        'asciidoctor.css should be written to the output directory'
       )
     })
   })

--- a/packages/core/types/stylesheets.d.ts
+++ b/packages/core/types/stylesheets.d.ts
@@ -6,5 +6,6 @@ declare class StylesheetsClass {
     get primaryStylesheetName(): string;
     primaryStylesheetData(): Promise<string>;
     embedPrimaryStylesheet(): Promise<string>;
+    writePrimaryStylesheet(stylesoutdir: any): Promise<boolean>;
 }
 export {};


### PR DESCRIPTION
In Ruby, an empty string is truthy, so `if stylesheet` in convert.rb enters the block for stylesheet="" (the default in standalone mode), and DEFAULT_STYLESHEET_KEYS.include?("") is true → copyAsciidoctorStylesheet. In JavaScript, "" is falsy, so the block was skipped entirely.

Fix the guard to `if (stylesheet != null)` to distinguish "attribute not set" (null) from "attribute set to empty string" ("").

Also implement Stylesheets#writePrimaryStylesheet, which was previously a no-op stub. In browser environments where node:fs/promises is unavailable, the copy is skipped and an info message is logged.