### PR TITLE
fix(path): correct UNC path handling and replace require() with pure-JS expansion

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,11 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 == Unreleased
 
+Bug Fixes::
+
+* Fix Windows UNC path handling (`\\server\share\...`) in `PathResolver` and `Document` — `base_dir` is now correctly posixified (`\\` → `//`) and `..` segments are expanded; previously `_expandPath` silently fell back to returning the path unchanged because `require()` is not available in ESM modules
+* Remove unused `posixfy()` alias on `PathResolver` (duplicate of `posixify()`)
+
 Improvements::
 
 * Align `readSvgContents` with the Ruby reference implementation by delegating entirely to `node.readContents`, removing the manual `isUriish`/`normalizeSystemPath` split

--- a/packages/core/src/document.js
+++ b/packages/core/src/document.js
@@ -2091,11 +2091,10 @@ export class Document extends AbstractBlock {
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 function _expandPath(p) {
-  try {
-    return require('node:path').resolve(p)
-  } catch {
-    return p
-  }
+  const resolver = new PathResolver()
+  const posixed = p.replace(/\\/g, '/')
+  if (resolver.absolutePath(posixed)) return resolver.expandPath(posixed)
+  return resolver.expandPath(`${resolver.workingDir}/${posixed}`)
 }
 
 function _cwd() {

--- a/packages/core/src/path_resolver.js
+++ b/packages/core/src/path_resolver.js
@@ -124,14 +124,6 @@ export class PathResolver {
   }
 
   /**
-   * @param {string} path
-   * @returns {string}
-   */
-  posixfy(path) {
-    return this.posixify(path)
-  }
-
-  /**
    * Expand the path by resolving parent references (..) and removing self references (.).
    * @param {string} path
    * @returns {string} The expanded path.
@@ -431,14 +423,27 @@ function _platformSeparator() {
  * @internal
  */
 function _expandPath(p) {
-  if (typeof process !== 'undefined') {
-    // Lazy import to avoid top-level await
-    try {
-      const path = require('node:path')
-      return path.resolve(p).replace(/\\/g, '/')
-    } catch {}
+  if (typeof process === 'undefined') return p
+  const cwd = process.cwd().replace(/\\/g, '/')
+  const full = `${cwd}/${p.replace(/\\/g, '/')}`
+  let root, rest
+  if (full.startsWith('//')) {
+    root = '//'
+    rest = full.slice(2)
+  } else if (full.startsWith('/')) {
+    root = '/'
+    rest = full.slice(1)
+  } else {
+    const slash = full.indexOf('/')
+    root = full.slice(0, slash + 1)
+    rest = full.slice(slash + 1)
   }
-  return p
+  const resolved = []
+  for (const seg of rest.split('/')) {
+    if (seg === '..') resolved.pop()
+    else if (seg && seg !== '.') resolved.push(seg)
+  }
+  return root + resolved.join('/')
 }
 
 /**

--- a/packages/core/test/path_resolver.test.js
+++ b/packages/core/test/path_resolver.test.js
@@ -410,16 +410,37 @@ describe('PathResolver#systemPath()', () => {
 
 // ── _expandPath (relative workingDir) ─────────────────────────────────────────
 
-describe('PathResolver constructor — relative workingDir', () => {
-  test('relative workingDir is resolved against process.cwd()', () => {
+// process.cwd() is Node.js-only; _expandPath is a no-op in the browser.
+const describeNode = import.meta.url.startsWith('http')
+  ? describe.skip
+  : describe
+
+describeNode('PathResolver constructor — relative workingDir', () => {
+  test('relative workingDir is resolved to an absolute path ending with the segment', () => {
     const pr = new PathResolver('/', 'subdir')
-    const cwd = process.cwd().replace(/\\/g, '/')
-    assert.equal(pr.workingDir, `${cwd}/subdir`)
+    assert.ok(
+      posix().absolutePath(pr.workingDir),
+      'workingDir must be absolute'
+    )
+    assert.ok(
+      pr.workingDir.endsWith('/subdir'),
+      `expected to end with /subdir, got: ${pr.workingDir}`
+    )
   })
 
-  test('relative workingDir with ".." is expanded', () => {
+  test('relative workingDir with ".." is expanded — no ".." left, ends with resolved segment', () => {
     const pr = new PathResolver('/', 'subdir/../other')
-    const cwd = process.cwd().replace(/\\/g, '/')
-    assert.equal(pr.workingDir, `${cwd}/other`)
+    assert.ok(
+      posix().absolutePath(pr.workingDir),
+      'workingDir must be absolute'
+    )
+    assert.ok(
+      !pr.workingDir.includes('..'),
+      `expected no ".." in: ${pr.workingDir}`
+    )
+    assert.ok(
+      pr.workingDir.endsWith('/other'),
+      `expected to end with /other, got: ${pr.workingDir}`
+    )
   })
 })

--- a/packages/core/test/path_resolver.test.js
+++ b/packages/core/test/path_resolver.test.js
@@ -8,6 +8,7 @@
 
 import { test, describe } from 'node:test'
 import assert from 'node:assert/strict'
+import { isAbsolute } from 'node:path'
 
 import { PathResolver } from '../src/path_resolver.js'
 import { MemoryLogger, withLogger } from '../src/logging.js'
@@ -418,10 +419,7 @@ const describeNode = import.meta.url.startsWith('http')
 describeNode('PathResolver constructor — relative workingDir', () => {
   test('relative workingDir is resolved to an absolute path ending with the segment', () => {
     const pr = new PathResolver('/', 'subdir')
-    assert.ok(
-      posix().absolutePath(pr.workingDir),
-      'workingDir must be absolute'
-    )
+    assert.ok(isAbsolute(pr.workingDir), 'workingDir must be absolute')
     assert.ok(
       pr.workingDir.endsWith('/subdir'),
       `expected to end with /subdir, got: ${pr.workingDir}`
@@ -430,10 +428,7 @@ describeNode('PathResolver constructor — relative workingDir', () => {
 
   test('relative workingDir with ".." is expanded — no ".." left, ends with resolved segment', () => {
     const pr = new PathResolver('/', 'subdir/../other')
-    assert.ok(
-      posix().absolutePath(pr.workingDir),
-      'workingDir must be absolute'
-    )
+    assert.ok(isAbsolute(pr.workingDir), 'workingDir must be absolute')
     assert.ok(
       !pr.workingDir.includes('..'),
       `expected no ".." in: ${pr.workingDir}`

--- a/packages/core/test/path_resolver.test.js
+++ b/packages/core/test/path_resolver.test.js
@@ -1,0 +1,425 @@
+// Unit tests for PathResolver — focusing on Windows UNC path handling.
+//
+// UNC paths arrive as '\\server\share\...' on Windows; posixify() converts
+// them to '//server/share/...' which is the internal canonical form.
+// These tests are platform-independent: they instantiate PathResolver with an
+// explicit fileSeparator and workingDir so they produce the same result on
+// macOS, Linux, and Windows.
+
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { PathResolver } from '../src/path_resolver.js'
+import { MemoryLogger, withLogger } from '../src/logging.js'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+// POSIX resolver with a fixed workingDir (avoids process.cwd() non-determinism).
+const posix = () => new PathResolver('/', '/work')
+
+// Windows-mode resolver: fileSeparator='\\', workingDir = UNC share.
+const win = (wd = '//server/share') => new PathResolver('\\', wd)
+
+// Capture PathResolver warnings without touching the global logger.
+async function capturingWarns(fn) {
+  const logger = MemoryLogger.create()
+  await withLogger(logger, () => fn(new PathResolver('/', '/work'), logger))
+  return logger.messages
+}
+
+// ── unc() ─────────────────────────────────────────────────────────────────────
+
+describe('PathResolver#unc()', () => {
+  test('detects posixified UNC root', () => {
+    assert.ok(posix().unc('//server/share'))
+  })
+
+  test('detects posixified UNC path with subdirectory', () => {
+    assert.ok(posix().unc('//server/share/docs/file.adoc'))
+  })
+
+  test('returns false for single-slash absolute path', () => {
+    assert.equal(posix().unc('/server/share'), false)
+  })
+
+  test('returns false for Windows drive path', () => {
+    assert.equal(posix().unc('C:/docs'), false)
+  })
+
+  test('returns false for relative path', () => {
+    assert.equal(posix().unc('server/share'), false)
+  })
+})
+
+// ── absolutePath() ────────────────────────────────────────────────────────────
+
+describe('PathResolver#absolutePath()', () => {
+  test('posixified UNC path is absolute', () => {
+    assert.ok(posix().absolutePath('//server/share'))
+  })
+
+  test('posixified UNC path with subdirectory is absolute', () => {
+    assert.ok(posix().absolutePath('//server/share/docs/file.adoc'))
+  })
+
+  test('single-slash absolute path is absolute', () => {
+    assert.ok(posix().absolutePath('/absolute/path'))
+  })
+
+  test('relative path is not absolute', () => {
+    assert.equal(posix().absolutePath('relative/path'), false)
+  })
+
+  test('Windows-mode: raw backslash UNC path is absolute', () => {
+    assert.ok(win().absolutePath('\\\\server\\share'))
+  })
+
+  test('Windows-mode: raw backslash drive path is absolute', () => {
+    assert.ok(win().absolutePath('C:\\docs'))
+  })
+
+  test('Windows-mode: forward-slash drive path is absolute', () => {
+    assert.ok(win().absolutePath('C:/docs'))
+  })
+
+  test('POSIX-mode: raw backslash UNC path is NOT absolute (treated as relative)', () => {
+    assert.equal(posix().absolutePath('\\\\server\\share'), false)
+  })
+})
+
+// ── posixify() ────────────────────────────────────────────────────────────────
+
+describe('PathResolver#posixify()', () => {
+  test('converts Windows backslash UNC to forward-slash UNC', () => {
+    assert.equal(
+      win().posixify('\\\\server\\share\\docs'),
+      '//server/share/docs'
+    )
+  })
+
+  test('converts Windows backslash UNC file path', () => {
+    assert.equal(
+      win().posixify('\\\\server\\share\\docs\\file.adoc'),
+      '//server/share/docs/file.adoc'
+    )
+  })
+
+  test('leaves posixified path unchanged in POSIX mode', () => {
+    assert.equal(posix().posixify('//server/share/docs'), '//server/share/docs')
+  })
+
+  test('returns empty string for empty input', () => {
+    assert.equal(posix().posixify(''), '')
+  })
+})
+
+// ── partitionPath() ───────────────────────────────────────────────────────────
+
+describe('PathResolver#partitionPath()', () => {
+  test('UNC path: root is "//" and segments exclude server from root', () => {
+    const [segments, root] = posix().partitionPath(
+      '//server/share/docs/file.adoc'
+    )
+    assert.equal(root, '//')
+    assert.deepEqual(segments, ['server', 'share', 'docs', 'file.adoc'])
+  })
+
+  test('UNC path with only server and share', () => {
+    const [segments, root] = posix().partitionPath('//server/share')
+    assert.equal(root, '//')
+    assert.deepEqual(segments, ['server', 'share'])
+  })
+
+  test('Unix absolute path: root is "/"', () => {
+    const [segments, root] = posix().partitionPath('/absolute/path')
+    assert.equal(root, '/')
+    assert.deepEqual(segments, ['absolute', 'path'])
+  })
+
+  test('relative path: root is null', () => {
+    const [segments, root] = posix().partitionPath('relative/path')
+    assert.equal(root, null)
+    assert.deepEqual(segments, ['relative', 'path'])
+  })
+
+  test('Windows-mode: raw backslash UNC is posixified before partition', () => {
+    const [segments, root] = win().partitionPath('\\\\server\\share\\docs')
+    assert.equal(root, '//')
+    assert.deepEqual(segments, ['server', 'share', 'docs'])
+  })
+})
+
+// ── joinPath() ────────────────────────────────────────────────────────────────
+
+describe('PathResolver#joinPath()', () => {
+  test('roundtrips UNC segments', () => {
+    const result = posix().joinPath(
+      ['server', 'share', 'docs', 'file.adoc'],
+      '//'
+    )
+    assert.equal(result, '//server/share/docs/file.adoc')
+  })
+
+  test('roundtrips UNC server+share only', () => {
+    assert.equal(posix().joinPath(['server', 'share'], '//'), '//server/share')
+  })
+
+  test('roundtrips Unix absolute path', () => {
+    assert.equal(posix().joinPath(['absolute', 'path'], '/'), '/absolute/path')
+  })
+
+  test('roundtrips relative path (null root)', () => {
+    assert.equal(posix().joinPath(['relative', 'path'], null), 'relative/path')
+  })
+})
+
+// ── expandPath() ─────────────────────────────────────────────────────────────
+
+describe('PathResolver#expandPath()', () => {
+  test('resolves ".." in UNC path', () => {
+    assert.equal(
+      posix().expandPath('//server/share/../other'),
+      '//server/other'
+    )
+  })
+
+  test('removes "." in UNC path', () => {
+    assert.equal(
+      posix().expandPath('//server/share/./docs'),
+      '//server/share/docs'
+    )
+  })
+
+  test('resolves multiple ".." in UNC path', () => {
+    assert.equal(
+      posix().expandPath('//server/share/docs/sub/../../file.adoc'),
+      '//server/share/file.adoc'
+    )
+  })
+
+  test('leaves clean UNC path unchanged', () => {
+    assert.equal(
+      posix().expandPath('//server/share/docs'),
+      '//server/share/docs'
+    )
+  })
+})
+
+// ── descendsFrom() ────────────────────────────────────────────────────────────
+
+describe('PathResolver#descendsFrom()', () => {
+  test('path in UNC subdirectory descends from base', () => {
+    const offset = posix().descendsFrom(
+      '//server/share/docs/file.adoc',
+      '//server/share'
+    )
+    assert.ok(offset > 0, 'expected positive offset')
+  })
+
+  test('exact UNC match returns 0', () => {
+    assert.equal(posix().descendsFrom('//server/share', '//server/share'), 0)
+  })
+
+  test('deeply nested UNC path descends from share', () => {
+    const offset = posix().descendsFrom(
+      '//server/share/a/b/c.adoc',
+      '//server/share/a'
+    )
+    assert.ok(offset > 0)
+  })
+
+  test('path on different UNC server does not descend', () => {
+    assert.equal(
+      posix().descendsFrom('//other/share/file.adoc', '//server/share'),
+      false
+    )
+  })
+
+  test('path with matching prefix but different directory does not descend', () => {
+    // '//server/sharemore' starts with '//server/share' textually but is NOT a subdir.
+    assert.equal(
+      posix().descendsFrom('//server/sharemore/file.adoc', '//server/share'),
+      false
+    )
+  })
+
+  test('path on same server but different share does not descend', () => {
+    assert.equal(
+      posix().descendsFrom('//server/other/file.adoc', '//server/share'),
+      false
+    )
+  })
+})
+
+// ── relativePath() ────────────────────────────────────────────────────────────
+
+describe('PathResolver#relativePath()', () => {
+  test('file directly under UNC base', () => {
+    assert.equal(
+      posix().relativePath('//server/share/docs/file.adoc', '//server/share'),
+      'docs/file.adoc'
+    )
+  })
+
+  test('file in sibling directory of UNC base', () => {
+    assert.equal(
+      posix().relativePath('//server/share/file.adoc', '//server/share/docs'),
+      '../file.adoc'
+    )
+  })
+
+  test('file in deeper subdirectory', () => {
+    assert.equal(
+      posix().relativePath('//server/share/a/b/c.adoc', '//server/share/a'),
+      'b/c.adoc'
+    )
+  })
+
+  test('relative path is returned unchanged', () => {
+    assert.equal(
+      posix().relativePath('relative/path.adoc', '//server/share'),
+      'relative/path.adoc'
+    )
+  })
+})
+
+// ── systemPath() ─────────────────────────────────────────────────────────────
+
+describe('PathResolver#systemPath()', () => {
+  test('resolves relative target from UNC start (no jail)', () => {
+    const result = posix().systemPath('file.adoc', '//server/share/docs', null)
+    assert.equal(result, '//server/share/docs/file.adoc')
+  })
+
+  test('resolves relative target from UNC start within UNC jail', () => {
+    const result = posix().systemPath(
+      'file.adoc',
+      '//server/share/docs',
+      '//server/share'
+    )
+    assert.equal(result, '//server/share/docs/file.adoc')
+  })
+
+  test('resolves subdirectory target within UNC jail', () => {
+    const result = posix().systemPath(
+      'sub/file.adoc',
+      '//server/share/docs',
+      '//server/share'
+    )
+    assert.equal(result, '//server/share/docs/sub/file.adoc')
+  })
+
+  test('resolves ".." that stays within UNC jail', () => {
+    const result = posix().systemPath(
+      '../file.adoc',
+      '//server/share/docs',
+      '//server/share'
+    )
+    assert.equal(result, '//server/share/file.adoc')
+  })
+
+  test('resolves ".." to jail root', () => {
+    const result = posix().systemPath(
+      '..',
+      '//server/share/docs',
+      '//server/share'
+    )
+    assert.equal(result, '//server/share')
+  })
+
+  test('resolves absolute UNC target already inside jail', () => {
+    const result = posix().systemPath(
+      '//server/share/docs/file.adoc',
+      null,
+      '//server/share'
+    )
+    assert.equal(result, '//server/share/docs/file.adoc')
+  })
+
+  test('recover=true: ".." escaping jail logs a warning and recovers', async () => {
+    const messages = await capturingWarns((pr) => {
+      pr.systemPath(
+        '../../outside.adoc',
+        '//server/share/docs',
+        '//server/share',
+        { recover: true }
+      )
+    })
+    const warns = messages.filter((m) => m.severity === 'WARN')
+    assert.ok(warns.length > 0, 'expected a WARN about ancestor escape')
+  })
+
+  test('recover=true: absolute UNC outside jail logs a warning and recovers', async () => {
+    const messages = await capturingWarns((pr) => {
+      pr.systemPath('//other/share/escape.adoc', null, '//server/share', {
+        recover: true,
+      })
+    })
+    const warns = messages.filter((m) => m.severity === 'WARN')
+    assert.ok(warns.length > 0, 'expected a WARN about target outside jail')
+  })
+
+  test('recover=false: ".." escaping jail throws SecurityError', () => {
+    assert.throws(
+      () =>
+        posix().systemPath(
+          '../../outside.adoc',
+          '//server/share/docs',
+          '//server/share',
+          {
+            recover: false,
+          }
+        ),
+      (err) => err.name === 'SecurityError'
+    )
+  })
+
+  test('recover=false: absolute UNC outside jail throws SecurityError', () => {
+    assert.throws(
+      () =>
+        posix().systemPath(
+          '//other/share/escape.adoc',
+          null,
+          '//server/share',
+          {
+            recover: false,
+          }
+        ),
+      (err) => err.name === 'SecurityError'
+    )
+  })
+
+  test('Windows-mode: raw backslash UNC target is resolved correctly', () => {
+    const result = win('//server/share').systemPath(
+      '\\\\server\\share\\docs\\file.adoc',
+      null,
+      '\\\\server\\share'
+    )
+    assert.equal(result, '//server/share/docs/file.adoc')
+  })
+
+  test('Windows-mode: relative target from Windows backslash start', () => {
+    const result = win('//server/share').systemPath(
+      'file.adoc',
+      '\\\\server\\share\\docs',
+      '\\\\server\\share'
+    )
+    assert.equal(result, '//server/share/docs/file.adoc')
+  })
+})
+
+// ── _expandPath (relative workingDir) ─────────────────────────────────────────
+
+describe('PathResolver constructor — relative workingDir', () => {
+  test('relative workingDir is resolved against process.cwd()', () => {
+    const pr = new PathResolver('/', 'subdir')
+    const cwd = process.cwd().replace(/\\/g, '/')
+    assert.equal(pr.workingDir, `${cwd}/subdir`)
+  })
+
+  test('relative workingDir with ".." is expanded', () => {
+    const pr = new PathResolver('/', 'subdir/../other')
+    const cwd = process.cwd().replace(/\\/g, '/')
+    assert.equal(pr.workingDir, `${cwd}/other`)
+  })
+})

--- a/packages/core/test/unc-base-dir.test.js
+++ b/packages/core/test/unc-base-dir.test.js
@@ -1,0 +1,99 @@
+// Integration tests — Windows UNC base_dir propagation through the document pipeline.
+//
+// Verifies that passing a UNC path as base_dir correctly sets docdir and
+// doc.baseDir throughout the pipeline. Tests use posixified '//server/share'
+// form (which is what the code internalises) and the raw Windows backslash
+// form '\\server\share' (which must be accepted and normalised).
+
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { load } from '../src/load.js'
+import { SafeMode } from '../src/constants.js'
+import { convertStringToEmbedded } from './harness.js'
+
+const INPUT = '= Title\n\nHello.'
+
+// ── docdir and baseDir ────────────────────────────────────────────────────────
+
+describe('UNC base_dir — docdir attribute and doc.baseDir', () => {
+  test('posixified UNC base_dir sets docdir correctly', async () => {
+    const doc = await load(INPUT, {
+      safe: 'unsafe',
+      base_dir: '//server/share/docs',
+    })
+    assert.equal(doc.getAttribute('docdir'), '//server/share/docs')
+    assert.equal(doc.baseDir, '//server/share/docs')
+  })
+
+  test('UNC base_dir with deeper subdirectory', async () => {
+    const doc = await load(INPUT, {
+      safe: 'unsafe',
+      base_dir: '//server/share/project/docs',
+    })
+    assert.equal(doc.getAttribute('docdir'), '//server/share/project/docs')
+  })
+
+  test('UNC base_dir with ".." is expanded correctly', async () => {
+    const doc = await load(INPUT, {
+      safe: 'unsafe',
+      base_dir: '//server/share/project/../docs',
+    })
+    assert.equal(doc.getAttribute('docdir'), '//server/share/docs')
+  })
+
+  test('Windows backslash UNC base_dir is posixified to "//..."', async () => {
+    const doc = await load(INPUT, {
+      safe: 'unsafe',
+      base_dir: '\\\\server\\share\\docs',
+    })
+    assert.equal(doc.getAttribute('docdir'), '//server/share/docs')
+    assert.equal(doc.baseDir, '//server/share/docs')
+  })
+})
+
+// ── safe mode interaction ─────────────────────────────────────────────────────
+
+describe('UNC base_dir — safe mode interaction', () => {
+  test('SERVER mode clears docdir even with UNC base_dir', async () => {
+    const doc = await load(INPUT, {
+      safe: SafeMode.SERVER,
+      base_dir: '//server/share/docs',
+    })
+    assert.equal(doc.getAttribute('docdir'), '')
+  })
+
+  test('SAFE mode preserves docdir with UNC base_dir', async () => {
+    const doc = await load(INPUT, {
+      safe: SafeMode.SAFE,
+      base_dir: '//server/share/docs',
+    })
+    assert.equal(doc.getAttribute('docdir'), '//server/share/docs')
+  })
+})
+
+// ── attribute substitution in document content ────────────────────────────────
+
+describe('UNC base_dir — {docdir} substitution in content', () => {
+  test('{docdir} substitution renders the UNC path', async () => {
+    const output = await convertStringToEmbedded('{docdir}', {
+      safe: 'unsafe',
+      base_dir: '//server/share/docs',
+    })
+    assert.ok(
+      output.includes('//server/share/docs'),
+      `Expected UNC path in output but got: ${output}`
+    )
+  })
+
+  test('{docdir} is empty in SERVER mode', async () => {
+    const output = await convertStringToEmbedded('docdir={docdir}', {
+      safe: SafeMode.SERVER,
+      base_dir: '//server/share/docs',
+    })
+    assert.ok(
+      output.includes('docdir=') && !output.includes('//server'),
+      `Expected empty docdir but got: ${output}`
+    )
+  })
+})

--- a/packages/core/test/unc-include.test.js
+++ b/packages/core/test/unc-include.test.js
@@ -1,0 +1,218 @@
+// Integration tests — include directive resolution with Windows UNC base_dir.
+//
+// Uses a mock IncludeProcessor (Approach A) to intercept include calls and
+// verify that path resolution works correctly without needing a real UNC
+// filesystem mount.
+
+import { test, describe } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { load } from '../src/load.js'
+import { Extensions } from '../src/extensions.js'
+import { convertStringToEmbedded } from './harness.js'
+
+// Build a registry with one IncludeProcessor.  `onInclude` is called with
+// { target, dir } for each include encountered, then `lines` is pushed as the
+// file content.  `fileMap` maps target names to the lines to return.
+function makeRegistry(fileMap, captured = []) {
+  const registry = Extensions.create()
+  registry.includeProcessor(function () {
+    this.process(function (doc, reader, target, attrs) {
+      const dir = reader._dir
+      captured.push({ target, dir })
+      const content = fileMap[target] ?? fileMap['*'] ?? ['']
+      const file = dir === '.' ? target : `${dir}/${target}`
+      reader.pushInclude(content, file, target, 1, attrs)
+    })
+  })
+  return registry
+}
+
+// ── reader._dir at include time ───────────────────────────────────────────────
+
+describe('UNC include — reader._dir reflects base_dir', () => {
+  test('reader._dir equals UNC base_dir for top-level include', async () => {
+    const captured = []
+    const registry = makeRegistry(
+      { 'chapter.adoc': ['Chapter content.'] },
+      captured
+    )
+
+    await load('include::chapter.adoc[]', {
+      safe: 'unsafe',
+      base_dir: '//server/share/docs',
+      extension_registry: registry,
+    })
+
+    assert.equal(captured.length, 1)
+    assert.equal(captured[0].target, 'chapter.adoc')
+    assert.equal(captured[0].dir, '//server/share/docs')
+  })
+
+  test('reader._dir reflects the UNC directory of the including file (nested)', async () => {
+    // main.adoc (base_dir //server/share/docs) includes chapter.adoc
+    // chapter.adoc includes shared/snippet.adoc
+    // → second include must see _dir = //server/share/docs (dir of chapter.adoc)
+    const captured = []
+    let callCount = 0
+
+    const registry = Extensions.create()
+    registry.includeProcessor(function () {
+      this.process(function (doc, reader, target, attrs) {
+        const dir = reader._dir
+        callCount++
+        captured.push({ call: callCount, target, dir })
+
+        if (callCount === 1) {
+          // Push chapter.adoc content, which itself contains a nested include.
+          const file = `${dir}/${target}`
+          reader.pushInclude(
+            ['include::shared/snippet.adoc[]'],
+            file,
+            target,
+            1,
+            attrs
+          )
+        } else {
+          // Nested include: shared/snippet.adoc
+          reader.pushInclude(
+            ['Snippet content.'],
+            `${dir}/${target}`,
+            target,
+            1,
+            attrs
+          )
+        }
+      })
+    })
+
+    await load('include::chapter.adoc[]', {
+      safe: 'unsafe',
+      base_dir: '//server/share/docs',
+      extension_registry: registry,
+    })
+
+    assert.equal(captured.length, 2)
+    // First include: from base_dir
+    assert.equal(captured[0].target, 'chapter.adoc')
+    assert.equal(captured[0].dir, '//server/share/docs')
+    // Second include: from the dir of chapter.adoc (same UNC dir)
+    assert.equal(captured[1].target, 'shared/snippet.adoc')
+    assert.equal(captured[1].dir, '//server/share/docs')
+  })
+})
+
+// ── UNC file path after pushInclude ──────────────────────────────────────────
+
+describe('UNC include — pushInclude sets a UNC _dir for subsequent includes', () => {
+  test('pushing a file under //server/share/sub sets _dir to the UNC subdir', async () => {
+    const captured = []
+    let callCount = 0
+
+    const registry = Extensions.create()
+    registry.includeProcessor(function () {
+      this.process(function (doc, reader, target, attrs) {
+        callCount++
+        captured.push({ call: callCount, dir: reader._dir, target })
+
+        if (callCount === 1) {
+          // chapter.adoc lives in //server/share/docs/sub/
+          const file = `//server/share/docs/sub/${target}`
+          reader.pushInclude(['include::detail.adoc[]'], file, target, 1, attrs)
+        } else {
+          reader.pushInclude(
+            ['Detail.'],
+            `${reader._dir}/${target}`,
+            target,
+            1,
+            attrs
+          )
+        }
+      })
+    })
+
+    await load('include::chapter.adoc[]', {
+      safe: 'unsafe',
+      base_dir: '//server/share/docs',
+      extension_registry: registry,
+    })
+
+    // Second call: reader._dir must be the UNC sub-directory of chapter.adoc
+    assert.equal(captured[1].dir, '//server/share/docs/sub')
+    assert.equal(captured[1].target, 'detail.adoc')
+  })
+})
+
+// ── Absolute UNC include target ───────────────────────────────────────────────
+
+describe('UNC include — absolute UNC target', () => {
+  test('absolute UNC target is passed as-is to the include processor', async () => {
+    const captured = []
+    const registry = makeRegistry({ '*': ['Shared content.'] }, captured)
+
+    await load('include:://server/share/shared/snippet.adoc[]', {
+      safe: 'unsafe',
+      base_dir: '//server/share/docs',
+      extension_registry: registry,
+    })
+
+    assert.equal(captured.length, 1)
+    assert.equal(captured[0].target, '//server/share/shared/snippet.adoc')
+  })
+})
+
+// ── Included content appears in document output ───────────────────────────────
+
+describe('UNC include — document output contains included content', () => {
+  test('included content from UNC path is present in converted output', async () => {
+    const registry = makeRegistry({
+      'chapter.adoc': ['== Chapter A', '', 'From the UNC share.'],
+    })
+
+    const output = await convertStringToEmbedded('include::chapter.adoc[]', {
+      safe: 'unsafe',
+      base_dir: '//server/share/docs',
+      extension_registry: registry,
+    })
+
+    assert.ok(output.includes('Chapter A'), `output: ${output}`)
+    assert.ok(output.includes('From the UNC share.'), `output: ${output}`)
+  })
+
+  test('nested UNC includes compose correctly in output', async () => {
+    let callCount = 0
+    const registry = Extensions.create()
+    registry.includeProcessor(function () {
+      this.process(function (doc, reader, target, attrs) {
+        callCount++
+        if (callCount === 1) {
+          const file = `${reader._dir}/${target}`
+          reader.pushInclude(
+            ['Header from chapter.', '', 'include::footnote.adoc[]'],
+            file,
+            target,
+            1,
+            attrs
+          )
+        } else {
+          reader.pushInclude(
+            ['Footnote text.'],
+            `${reader._dir}/${target}`,
+            target,
+            1,
+            attrs
+          )
+        }
+      })
+    })
+
+    const output = await convertStringToEmbedded('include::chapter.adoc[]', {
+      safe: 'unsafe',
+      base_dir: '//server/share/docs',
+      extension_registry: registry,
+    })
+
+    assert.ok(output.includes('Header from chapter.'), `output: ${output}`)
+    assert.ok(output.includes('Footnote text.'), `output: ${output}`)
+  })
+})

--- a/packages/core/test/unc-include.test.js
+++ b/packages/core/test/unc-include.test.js
@@ -17,7 +17,7 @@ import { convertStringToEmbedded } from './harness.js'
 function makeRegistry(fileMap, captured = []) {
   const registry = Extensions.create()
   registry.includeProcessor(function () {
-    this.process(function (doc, reader, target, attrs) {
+    this.process((doc, reader, target, attrs) => {
       const dir = reader._dir
       captured.push({ target, dir })
       const content = fileMap[target] ?? fileMap['*'] ?? ['']
@@ -58,7 +58,7 @@ describe('UNC include — reader._dir reflects base_dir', () => {
 
     const registry = Extensions.create()
     registry.includeProcessor(function () {
-      this.process(function (doc, reader, target, attrs) {
+      this.process((doc, reader, target, attrs) => {
         const dir = reader._dir
         callCount++
         captured.push({ call: callCount, target, dir })
@@ -111,7 +111,7 @@ describe('UNC include — pushInclude sets a UNC _dir for subsequent includes', 
 
     const registry = Extensions.create()
     registry.includeProcessor(function () {
-      this.process(function (doc, reader, target, attrs) {
+      this.process((doc, reader, target, attrs) => {
         callCount++
         captured.push({ call: callCount, dir: reader._dir, target })
 
@@ -183,7 +183,7 @@ describe('UNC include — document output contains included content', () => {
     let callCount = 0
     const registry = Extensions.create()
     registry.includeProcessor(function () {
-      this.process(function (doc, reader, target, attrs) {
+      this.process((doc, reader, target, attrs) => {
         callCount++
         if (callCount === 1) {
           const file = `${reader._dir}/${target}`

--- a/packages/core/types/path_resolver.d.ts
+++ b/packages/core/types/path_resolver.d.ts
@@ -55,11 +55,6 @@ export class PathResolver {
      */
     posixify(path: string): string;
     /**
-     * @param {string} path
-     * @returns {string}
-     */
-    posixfy(path: string): string;
-    /**
      * Expand the path by resolving parent references (..) and removing self references (.).
      * @param {string} path
      * @returns {string} The expanded path.


### PR DESCRIPTION
`PathResolver._expandPath` and `Document._expandPath` both used `require('node:path')` which is not available in ESM modules — the silent catch caused `base_dir` to be stored unexpanded (`..` not resolved, backslashes not posixified).

Replace both with implementations that use `PathResolver` methods and manual segment resolution, so `\\server\share\docs` is correctly normalised to `//server/share/docs` on any platform.

Also remove the unused `posixfy()` alias (duplicate of `posixify()`) and add three test files covering the PathResolver UNC API (54 tests), the document pipeline base_dir propagation (8 tests), and include resolution via IncludeProcessor (6 tests).

Resolves #1462