### PR TITLE
chore(browser): sync exports with index.js entry point

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -16,6 +16,7 @@ Bug Fixes::
 Improvements::
 
 * Add pluggable HTTP cache system (`HttpCache`, `MemoryHttpCache`, `HttpCacheManager`) activated by the `cache-uri` document attribute, mirroring Ruby's `open-uri/cached` behaviour. When `cache-uri` is set, an ephemeral in-memory cache is used per conversion by default; register a custom `HttpCache` implementation via `HttpCacheManager.setCache()` for persistent or file-system-backed caching.
+* Export `HttpCache`, `MemoryHttpCache`, and `HttpCacheManager` from the browser entry point (`browser.js`), keeping it in sync with `index.js`
 * Align `readSvgContents` with the Ruby reference implementation by delegating entirely to `node.readContents`, removing the manual `isUriish`/`normalizeSystemPath` split
 * Fix `warnIfEmpty` in `AbstractNode#readContents` — the empty-string check now correctly uses `!= null` instead of a truthy guard, so a warning is emitted for empty local SVG assets
 

--- a/packages/core/src/browser.js
+++ b/packages/core/src/browser.js
@@ -10,6 +10,7 @@ import {
   RevisionInfo,
 } from './document.js'
 import { Logger, LoggerManager, MemoryLogger, NullLogger } from './logging.js'
+import { HttpCache, MemoryHttpCache, HttpCacheManager } from './http_cache.js'
 import { SafeMode, ContentModel } from './constants.js'
 import { Timings } from './timings.js'
 import { AbstractNode } from './abstract_node.js'
@@ -28,9 +29,23 @@ import {
   BlockMacroProcessor,
   Extensions,
 } from './extensions.js'
+// Re-export DSL interface types for TypeScript consumers.
+/**
+ * @typedef {import('./extensions.js').ProcessorDslInterface} ProcessorDslInterface
+ * @typedef {import('./extensions.js').DocumentProcessorDslInterface} DocumentProcessorDslInterface
+ * @typedef {import('./extensions.js').SyntaxProcessorDslInterface} SyntaxProcessorDslInterface
+ * @typedef {import('./extensions.js').IncludeProcessorDslInterface} IncludeProcessorDslInterface
+ * @typedef {import('./extensions.js').DocinfoProcessorDslInterface} DocinfoProcessorDslInterface
+ * @typedef {import('./extensions.js').BlockProcessorDslInterface} BlockProcessorDslInterface
+ * @typedef {import('./extensions.js').MacroProcessorDslInterface} MacroProcessorDslInterface
+ * @typedef {import('./extensions.js').InlineMacroProcessorDslInterface} InlineMacroProcessorDslInterface
+ */
 import {
   Converter,
+  ConverterBase,
+  CustomFactory,
   DefaultFactory as DefaultConverterFactory,
+  deriveBackendTraits,
 } from './converter.js'
 import { Inline } from './inline.js'
 import { Block } from './block.js'
@@ -97,6 +112,9 @@ export {
   LoggerManager,
   MemoryLogger,
   NullLogger,
+  HttpCache,
+  MemoryHttpCache,
+  HttpCacheManager,
   SafeMode,
   ContentModel,
   Timings,
@@ -114,7 +132,10 @@ export {
   Extensions,
   Cursor,
   Converter as ConverterFactory,
+  ConverterBase,
+  CustomFactory as ConverterCustomFactory,
   DefaultConverterFactory,
+  deriveBackendTraits,
   DefaultSyntaxHighlighterFactory,
   Html5Converter,
   SyntaxHighlighter,


### PR DESCRIPTION
Add ConverterBase, ConverterCustomFactory, deriveBackendTraits and DSL interface typedefs that were present in index.js but missing from browser.js.