### PR TITLE
ci: test compatibility with Node.js 22

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 22
       - name: Install dependencies
         run: npm ci
       - name: Check and build
@@ -49,13 +49,19 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-15]
+        node-version: [22, 24]
+        exclude:
+          - os: windows-latest
+            node-version: 24
+          - os: macos-15
+            node-version: 24
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: ${{ matrix.node-version }}
       - name: Install dependencies
         run: |
           npm ci
@@ -74,7 +80,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 22
       - name: Set up Deno
         uses: denoland/setup-deno@v2
         with:
@@ -102,7 +108,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 22
       - name: Install dependencies
         run: |
           npm ci

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -20,6 +20,6 @@ Key highlights:
 * *No runtime dependencies* — no Opal, no Ruby, no generated bundle
 * *Fast* — native JavaScript execution with no interpreter overhead
 * *Browser and Node.js* — one library, two environments
-* *Node.js >= 24* — requires Node.js 24 (current LTS) or later
+* *Node.js >= 22* — requires Node.js 22 (LTS) or later
 
 Head to the xref:setup:install.adoc[Install guide] to get started.

--- a/docs/modules/setup/pages/migration-guide.adoc
+++ b/docs/modules/setup/pages/migration-guide.adoc
@@ -10,7 +10,7 @@ For compatibility, a CommonJS bundle is also provided and the `package.json` exp
 
 == Requirements
 
-* *Node.js >= 24* (current LTS)
+* *Node.js >= 22* (LTS)
 
 == Breaking changes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "sinon": "~21.1"
       },
       "engines": {
-        "node": ">=24"
+        "node": ">=22"
       }
     },
     "node_modules/@asciidoctor/core": {
@@ -1567,9 +1567,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3602,9 +3602,9 @@
       "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3650,10 +3650,10 @@
       }
     },
     "packages/asciidoctor": {
-      "version": "4.0.0-alpha.1",
+      "version": "4.0.0-alpha.4",
       "license": "MIT",
       "dependencies": {
-        "@asciidoctor/core": "4.0.0-alpha.1"
+        "@asciidoctor/core": "4.0.0-alpha.4"
       },
       "bin": {
         "asciidoctor": "bin/asciidoctor",
@@ -3670,7 +3670,7 @@
         "pug": "^3.0.3"
       },
       "engines": {
-        "node": ">=24"
+        "node": ">=22"
       }
     },
     "packages/asciidoctor/node_modules/ejs": {
@@ -3689,7 +3689,7 @@
     },
     "packages/core": {
       "name": "@asciidoctor/core",
-      "version": "4.0.0-alpha.1",
+      "version": "4.0.0-alpha.4",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.4.13",
@@ -3714,7 +3714,7 @@
         "xpath": "^0.0.34"
       },
       "engines": {
-        "node": ">=24"
+        "node": ">=22"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "packages/asciidoctor"
   ],
   "engines": {
-    "node": ">=24"
+    "node": ">=22"
   },
   "scripts": {
     "test": "npm run test:root && npm run test --workspaces",

--- a/packages/asciidoctor/package.json
+++ b/packages/asciidoctor/package.json
@@ -21,7 +21,7 @@
     "build:binary": "node tasks/build-sea.js"
   },
   "engines": {
-    "node": ">=24"
+    "node": ">=22"
   },
   "files": [
     "bin",

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This package is a **native JavaScript implementation of Asciidoctor**, converted from the original [Ruby source](https://github.com/asciidoctor/asciidoctor) by Claude. It is a pure ESM library targeting Node.js ≥ 24 with no Opal/Ruby compilation step.
+This package is a **native JavaScript implementation of Asciidoctor**, converted from the original [Ruby source](https://github.com/asciidoctor/asciidoctor) by Claude. It is a pure ESM library targeting Node.js ≥ 22 with no Opal/Ruby compilation step.
 
 This `@asciidoctor/core` package replaces the previous version that relied on Opal (a Ruby-to-JavaScript transpiler) to produce a JS bundle. It is now implemented with handwritten/AI-translated JavaScript modules that follow the same public API.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
     }
   },
   "engines": {
-    "node": ">=24"
+    "node": ">=22"
   },
   "scripts": {
     "build": "npm run build:data && rollup -c && npm run build:types",


### PR DESCRIPTION
Lower the minimum required Node.js version from 24 to 22 and update the CI matrix to run tests on Node 22 across all platforms, plus Node 24 on Linux to ensure both versions remain supported.