### PR TITLE
chore: lower minimum Node.js version from 22 to 20

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -13,7 +13,7 @@ Improvements::
 * Restore CLI extensibility — `Options` and `Invoker` classes are now exported from `asciidoctor/cli`, allowing third-party tools to extend the CLI by subclassing: add custom options via `Options#addOption()` and override `Invoker#invoke()`, `Invoker#version()`, or `Invoker#convertFiles()` to customize behavior
 * Add JSDoc to the `Options` and `Invoker` classes and generate TypeScript declarations (`types/cli.d.ts`) via `tsc` — the `asciidoctor/cli` export now ships with types
 * Publish CLI API documentation to gh-pages under `/\{version}/cli/` alongside the core API docs, with cross-navigation links between the two sites
-* Lower the minimum required Node.js version from 24 to 22 — the CI matrix now runs tests on Node 22 (all platforms) and Node 24 (Linux) to ensure both versions remain supported
+* Lower the minimum required Node.js version from 24 to 20 — the `engines.node` field in all packages is now `>=20`; Node.js 22 remains the recommended version (current LTS/maintenance); Node.js 20 is EOL but the library has no runtime dependency on any API introduced after Node.js 20
 
 == v4.0.0-alpha.4 (2026-05-21)
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "packages/asciidoctor"
   ],
   "engines": {
-    "node": ">=22"
+    "node": ">=20"
   },
   "scripts": {
     "test": "npm run test:root && npm run test --workspaces",

--- a/packages/asciidoctor/package.json
+++ b/packages/asciidoctor/package.json
@@ -27,7 +27,7 @@
     "build:binary": "node tasks/build-sea.js"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=20"
   },
   "files": [
     "bin",

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This package is a **native JavaScript implementation of Asciidoctor**, converted from the original [Ruby source](https://github.com/asciidoctor/asciidoctor) by Claude. It is a pure ESM library targeting Node.js ≥ 22 with no Opal/Ruby compilation step.
+This package is a **native JavaScript implementation of Asciidoctor**, converted from the original [Ruby source](https://github.com/asciidoctor/asciidoctor) by Claude. It is a pure ESM library targeting Node.js ≥ 20 with no Opal/Ruby compilation step.
 
 This `@asciidoctor/core` package replaces the previous version that relied on Opal (a Ruby-to-JavaScript transpiler) to produce a JS bundle. It is now implemented with handwritten/AI-translated JavaScript modules that follow the same public API.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
     }
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=20"
   },
   "scripts": {
     "build": "npm run build:data && rollup -c && npm run build:types",


### PR DESCRIPTION
Node.js 20 is EOL but the library has no runtime dependency on any API introduced after Node.js 20 (import.meta.dirname, Array.fromAsync, Promise.withResolvers, etc. are not used). Node.js 22 remains the recommended version.