### PR TITLE
fix: TypeDoc warnings, CLI docs in CI, and artifact action bumps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,10 @@ jobs:
         run: |
           npm ci
       - name: Generate API documentation
-        run: npm run docs -w @asciidoctor/core
+        run: |
+          npm run docs -w @asciidoctor/core
+          npm run docs -w asciidoctor
+          cp -r packages/asciidoctor/build/docs packages/core/build/docs/cli
       - name: Publish to gh-pages
         uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -35,7 +35,7 @@ jobs:
           npm run build:binary -w asciidoctor
 
       - name: Upload native image artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: "native-image-${{ matrix.platform }}"
           path: "packages/asciidoctor/dist/asciidoctor-${{ matrix.platform }}*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Generate release notes
         run: node tasks/changelog.js ${{ github.ref_name }}
       - name: Download native image artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: native-image-*
           path: packages/asciidoctor/dist

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,6 +10,8 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 Improvements::
 
+* Fix 8 TypeDoc warnings about DSL interface types referenced but not included in the documentation — `patch-jsdoc.js` now converts `export type X = import("./extensions.js").X` re-exports in `types/index.d.ts` to `export type { X } from './extensions.js'` so TypeDoc follows the re-export chain and documents the definitions inline
+* Add CLI doc generation and copy step to the `docs` job in `build.yml` so the main-branch docs push (under `/main/`) also includes the CLI API docs under `/main/cli/`, consistent with the release workflow
 * Restore CLI extensibility — `Options` and `Invoker` classes are now exported from `asciidoctor/cli`, allowing third-party tools to extend the CLI by subclassing: add custom options via `Options#addOption()` and override `Invoker#invoke()`, `Invoker#version()`, or `Invoker#convertFiles()` to customize behavior
 * Add JSDoc to the `Options` and `Invoker` classes and generate TypeScript declarations (`types/cli.d.ts`) via `tsc` — the `asciidoctor/cli` export now ships with types
 * Publish CLI API documentation to gh-pages under `/\{version}/cli/` alongside the core API docs, with cross-navigation links between the two sites

--- a/packages/asciidoctor/.gitignore
+++ b/packages/asciidoctor/.gitignore
@@ -1,3 +1,4 @@
 /node_modules/
 /dist/
 npm-debug.log
+/build/

--- a/packages/core/scripts/patch-jsdoc.js
+++ b/packages/core/scripts/patch-jsdoc.js
@@ -182,9 +182,26 @@ function walk(dir) {
 
 walk(typesDir)
 
+// Convert `export type X = import("./Y.js").X;` lines in index.d.ts to
+// `export type { X } from './Y.js';` so TypeDoc follows the re-export chain
+// and includes the definitions in the documentation instead of warning.
+const indexDtsPath = join(typesDir, 'index.d.ts')
+let indexDts = readFileSync(indexDtsPath, 'utf-8')
+const converted = indexDts.replace(
+  /^export type (\w+) = import\("([^"]+)"\)\.(\w+);$/gm,
+  (_, alias, modulePath, original) =>
+    alias === original
+      ? `export type { ${alias} } from '${modulePath}';`
+      : `export type { ${original} as ${alias} } from '${modulePath}';`
+)
+if (converted !== indexDts) {
+  writeFileSync(indexDtsPath, converted, 'utf-8')
+  indexDts = converted
+  console.log('converted import() re-exports to export { } from in index.d.ts')
+}
+
 // Generate index.d.cts for CJS consumers (moduleResolution: Node16 + module: commonjs).
 // Prepend a node reference directive so that Node.js globals (Buffer, etc.) are in scope
 // when TypeScript processes this file outside of a tsconfig that includes @types/node.
-const indexDts = readFileSync(join(typesDir, 'index.d.ts'), 'utf-8')
 writeFileSync(join(typesDir, 'index.d.cts'), '/// <reference types="node" />\n' + indexDts, 'utf-8')
 console.log('generated types/index.d.cts')

--- a/packages/core/types/index.d.cts
+++ b/packages/core/types/index.d.cts
@@ -27,14 +27,14 @@ export function load(input: string | string[] | Buffer, options?: any): Promise<
  * @returns {Promise<Document>} - the parsed Document
  */
 export function loadFile(filename: string, options?: any): Promise<Document>;
-export type ProcessorDslInterface = import("./extensions.js").ProcessorDslInterface;
-export type DocumentProcessorDslInterface = import("./extensions.js").DocumentProcessorDslInterface;
-export type SyntaxProcessorDslInterface = import("./extensions.js").SyntaxProcessorDslInterface;
-export type IncludeProcessorDslInterface = import("./extensions.js").IncludeProcessorDslInterface;
-export type DocinfoProcessorDslInterface = import("./extensions.js").DocinfoProcessorDslInterface;
-export type BlockProcessorDslInterface = import("./extensions.js").BlockProcessorDslInterface;
-export type MacroProcessorDslInterface = import("./extensions.js").MacroProcessorDslInterface;
-export type InlineMacroProcessorDslInterface = import("./extensions.js").InlineMacroProcessorDslInterface;
+export type { ProcessorDslInterface } from './extensions.js';
+export type { DocumentProcessorDslInterface } from './extensions.js';
+export type { SyntaxProcessorDslInterface } from './extensions.js';
+export type { IncludeProcessorDslInterface } from './extensions.js';
+export type { DocinfoProcessorDslInterface } from './extensions.js';
+export type { BlockProcessorDslInterface } from './extensions.js';
+export type { MacroProcessorDslInterface } from './extensions.js';
+export type { InlineMacroProcessorDslInterface } from './extensions.js';
 import { Document } from './document.js';
 import { convert } from './convert.js';
 import { convertFile } from './convert.js';

--- a/packages/core/types/index.d.ts
+++ b/packages/core/types/index.d.ts
@@ -26,14 +26,14 @@ export function load(input: string | string[] | Buffer, options?: any): Promise<
  * @returns {Promise<Document>} - the parsed Document
  */
 export function loadFile(filename: string, options?: any): Promise<Document>;
-export type ProcessorDslInterface = import("./extensions.js").ProcessorDslInterface;
-export type DocumentProcessorDslInterface = import("./extensions.js").DocumentProcessorDslInterface;
-export type SyntaxProcessorDslInterface = import("./extensions.js").SyntaxProcessorDslInterface;
-export type IncludeProcessorDslInterface = import("./extensions.js").IncludeProcessorDslInterface;
-export type DocinfoProcessorDslInterface = import("./extensions.js").DocinfoProcessorDslInterface;
-export type BlockProcessorDslInterface = import("./extensions.js").BlockProcessorDslInterface;
-export type MacroProcessorDslInterface = import("./extensions.js").MacroProcessorDslInterface;
-export type InlineMacroProcessorDslInterface = import("./extensions.js").InlineMacroProcessorDslInterface;
+export type { ProcessorDslInterface } from './extensions.js';
+export type { DocumentProcessorDslInterface } from './extensions.js';
+export type { SyntaxProcessorDslInterface } from './extensions.js';
+export type { IncludeProcessorDslInterface } from './extensions.js';
+export type { DocinfoProcessorDslInterface } from './extensions.js';
+export type { BlockProcessorDslInterface } from './extensions.js';
+export type { MacroProcessorDslInterface } from './extensions.js';
+export type { InlineMacroProcessorDslInterface } from './extensions.js';
 import { Document } from './document.js';
 import { convert } from './convert.js';
 import { convertFile } from './convert.js';


### PR DESCRIPTION
## Summary

- **Fix 8 TypeDoc warnings** — `patch-jsdoc.js` now converts `export type X = import("./extensions.js").X` to `export type { X } from './extensions.js'` so TypeDoc follows the re-export chain and documents the DSL interface types inline instead of warning
- **Include CLI docs in `build.yml` docs job** — the main-branch docs push (under `/main/`) now runs `npm run docs -w asciidoctor` and copies CLI docs into `core/build/docs/cli/`, consistent with `release.yml`; also ignores `packages/asciidoctor/build/` in git
- **Bump artifact action versions** — `upload-artifact@v4 → v7` in `native-image.yml`, `download-artifact@v4 → v8` in `release.yml`

## Test plan

- [ ] Run `npm run docs -w @asciidoctor/core` locally — verify 0 warnings
- [ ] Run `npm run build:types -w @asciidoctor/core` — verify `converted import() re-exports` message appears and `git diff --exit-code` passes
- [ ] Verify `build.yml` docs job generates CLI docs under `/main/cli/` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)