### PR TITLE
fix: correct dlist traversal in findBy by using flat(Infinity)

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,7 @@ Build::
 
 Bug Fixes::
 
+* Fix `findBy` throwing `TypeError: Receiver must be an instance of class AbstractBlock` when traversing a document that contains a description list (`dlist`) — `Array.flat()` (depth 1) was leaving the inner terms arrays unflattened, so iterating over them passed a plain array instead of a `ListItem` to the private `#findByInternal` method; changed to `flat(Infinity)` to match Ruby's `Array#flatten` behaviour
 * Fix named exports from `asciidoctor` package — remove the redundant `export { default } from '@asciidoctor/core'` line in `index.js` that was shadowing named exports and preventing `import { Document, ... } from 'asciidoctor'` from resolving correctly
 
 == v4.0.0-alpha.5 (2026-05-26)

--- a/packages/core/src/abstract_block.js
+++ b/packages/core/src/abstract_block.js
@@ -626,7 +626,7 @@ export class AbstractBlock extends AbstractNode {
       if (anyContext || contextSelector !== 'section') {
         // optimisation
         // NOTE dlist items can be null
-        for (const b of this.blocks.flat()) {
+        for (const b of this.blocks.flat(Infinity)) {
           if (b) b.#findByInternal(selector, result, filter)
         }
       }

--- a/packages/core/test/blocks.api.test.js
+++ b/packages/core/test/blocks.api.test.js
@@ -66,6 +66,24 @@ describe('Block', () => {
       )
       assert.equal(matches.length, 1)
     })
+
+    test('findBy traverses dlist items without throwing', async () => {
+      const doc = await documentFromString(
+        '[horizontal.contact]\ng+:: plus.google.com/1234567890\ntwitter:: @yourhandle'
+      )
+      // must not throw "Receiver must be an instance of class AbstractBlock"
+      const results = doc.findBy({ context: 'image', role: 'canvas' })
+      assert.equal(results.length, 0)
+    })
+
+    test('findBy traverses dlist and finds matching blocks inside descriptions', async () => {
+      const doc = await documentFromString(
+        'term1:: description one\nterm2:: description two'
+      )
+      const items = doc.findBy({ context: 'list_item' })
+      // 2 terms + 2 descriptions
+      assert.equal(items.length, 4)
+    })
   })
 
   describe('toString()', () => {


### PR DESCRIPTION
Array.flat() with default depth 1 left the inner terms arrays unflattened, causing #findByInternal to receive a plain Array instead of a ListItem and throw "Receiver must be an instance of class AbstractBlock". Using flat(Infinity) matches Ruby's Array#flatten behaviour.