### PR TITLE
fix: nested documents use plain Reader to match Ruby behaviour

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -14,6 +14,7 @@ Build::
 
 Bug Fixes::
 
+* Fix escaped include directive (`\include::file.adoc[]`) inside a listing block in an AsciiDoc table cell logging a spurious "include file not found" error — nested documents now use a plain `Reader` (no include/conditional processing) matching Ruby Asciidoctor behaviour; the first-line preprocessor directive expansion is handled explicitly as Ruby does
 * Fix `findBy` throwing `TypeError: Receiver must be an instance of class AbstractBlock` when traversing a document that contains a description list (`dlist`) — `Array.flat()` (depth 1) was leaving the inner terms arrays unflattened, so iterating over them passed a plain array instead of a `ListItem` to the private `#findByInternal` method; changed to `flat(Infinity)` to match Ruby's `Array#flatten` behaviour
 * Fix named exports from `asciidoctor` package — remove the redundant `export { default } from '@asciidoctor/core'` line in `index.js` that was shadowing named exports and preventing `import { Document, ... } from 'asciidoctor'` from resolving correctly
 

--- a/packages/core/src/document.js
+++ b/packages/core/src/document.js
@@ -34,7 +34,7 @@ import { XmlSanitizeRx, AttributeEntryPassMacroRx } from './rx.js'
 import { LF } from './constants.js'
 import { applyLogging } from './logging.js'
 import { SyntaxHighlighter, DefaultFactoryProxy } from './syntax_highlighter.js'
-import { PreprocessorReader, Cursor } from './reader.js'
+import { Reader, PreprocessorReader, Cursor } from './reader.js'
 import { Parser } from './parser.js'
 import { Extensions, Registry } from './extensions.js'
 
@@ -483,8 +483,8 @@ export class Document extends AbstractBlock {
       if ((this.doctype = attrs.doctype = parentDoctype) !== DEFAULT_DOCTYPE) {
         this._updateDoctypeAttributes(DEFAULT_DOCTYPE)
       }
-      // Set up reader only — parsing is deferred to Document.create() / doc.parse().
-      this.reader = new PreprocessorReader(this, data, options.cursor)
+      // Nested documents use a plain Reader (no include/conditional processing), matching Ruby behaviour.
+      this.reader = new Reader(data, options.cursor, { document: this })
       if (this.sourcemap) this.sourceLocation = this.reader.cursor
     } else {
       this.backend = null

--- a/packages/core/src/table.js
+++ b/packages/core/src/table.js
@@ -14,6 +14,7 @@ import { Inline } from './inline.js'
 import { applyLogging } from './logging.js'
 import { LF, ATTR_REF_HEAD, BASIC_SUBS, NORMAL_SUBS } from './constants.js'
 import { BlankLineRx, LeadingInlineAnchorRx } from './rx.js'
+import { PreprocessorReader } from './reader.js'
 
 /**
  * Truncate a float to `precision` decimal places (like Ruby's Float#truncate).
@@ -474,6 +475,25 @@ class Cell extends AbstractBlock {
     if (cell._innerDocSetup) {
       const { lines, parentDoc, parentDoctitle, options } = cell._innerDocSetup
       cell._innerDocSetup = null
+      // If the first line may be a preprocessor directive (include, ifdef…), expand it using a
+      // temporary PreprocessorReader — matching the Ruby behaviour in table.rb.
+      if (lines.length > 0 && lines[0].includes('::')) {
+        const firstLine = lines[0]
+        const tmpReader = new PreprocessorReader(
+          parentDoc,
+          [firstLine],
+          options.cursor
+        )
+        const preprocessedLines = await tmpReader.readLines()
+        if (
+          !(
+            preprocessedLines.length === 1 && preprocessedLines[0] === firstLine
+          )
+        ) {
+          lines.shift()
+          if (preprocessedLines.length > 0) lines.unshift(...preprocessedLines)
+        }
+      }
       const innerDoc = await parentDoc.constructor.create(lines, options)
       if (parentDoctitle) parentDoc.attributes.doctitle = parentDoctitle
       cell._innerDocument = innerDoc

--- a/packages/core/test/tables.psv-asciidoc-cells.test.js
+++ b/packages/core/test/tables.psv-asciidoc-cells.test.js
@@ -395,6 +395,31 @@ a|include::fixtures/include-file.adoc[]
       )
     })
 
+    test('escaped include directive in a listing block inside an AsciiDoc table cell should not be processed', async () => {
+      const input = `|===
+a|
+[source,asciidoc]
+----
+\\include::intro.adoc[]
+----
+|===`
+      await usingMemoryLogger(async (logger) => {
+        const output = await convertStringToEmbedded(input, {
+          safe: 'unsafe',
+          base_dir: '/tmp',
+        })
+        assert.ok(
+          output.includes('include::intro.adoc[]'),
+          `Expected escaped include as literal text in output, got:\n${output}`
+        )
+        assert.strictEqual(
+          logger.messages.length,
+          0,
+          `Expected no log messages, got: ${JSON.stringify(logger.messages)}`
+        )
+      })
+    })
+
     test('cross reference link in an AsciiDoc table cell should resolve to reference in main document', async () => {
       const input = `== Some
 

--- a/packages/core/types/document.d.ts
+++ b/packages/core/types/document.d.ts
@@ -489,7 +489,7 @@ export namespace Document {
 import { Footnote } from './footnote.js';
 import { AttributeEntry } from './attribute_entry.js';
 import { AbstractBlock } from './abstract_block.js';
-import type { Reader } from './reader.js';
+import { Reader } from './reader.js';
 import { Section } from './section.js';
 import { Inline } from './inline.js';
 export { Footnote, AttributeEntry };


### PR DESCRIPTION
Escaped include directives (`\include::file.adoc[]`) inside listing blocks in AsciiDoc table cells were triggering a spurious "include file not found" error. The outer PreprocessorReader correctly stripped the backslash and returned `include::intro.adoc[]`, but because nested documents were also created with a PreprocessorReader, the inner document's reader processed the now-unescaped directive as a real include.

In Ruby Asciidoctor, nested documents (AsciiDoc cells) use a plain `Reader` that performs no include or conditional preprocessing. This patch aligns the JS implementation: nested documents now use `Reader` instead of `PreprocessorReader`. The first-line preprocessing special case (expanding a preprocessor directive on the very first line of a cell, e.g. `a|include::file.adoc[]`) is replicated explicitly in `Table.Cell.create()` via a temporary PreprocessorReader, matching the equivalent logic in table.rb.