### PR TITLE
fix(core): store caption text in textlabel for delimited admonition blocks

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -128,6 +128,10 @@ Improvements::
 * Browser bundle is ~700 kB (unminified), down from ~1.74 MB with version 3 (Opal runtime included)
 * `ContentModel` constants exported (`COMPOUND`, `SIMPLE`, `VERBATIM`, `RAW`, `EMPTY`) for discoverable access to block content model values
 
+Bug Fixes::
+
+* Fix `caption` attribute on a delimited admonition block being stored as `true` instead of the caption text (the `textlabel` attribute now receives the resolved caption, matching Asciidoctor Ruby)
+
 Infrastructure::
 
 * Replaced ESLint + Standard with https://biomejs.dev[Biome] for linting and formatting

--- a/packages/core/src/parser.js
+++ b/packages/core/src/parser.js
@@ -1284,8 +1284,8 @@ export class Parser {
           const admStyle = attributes.style ?? blockContext
           attributes.name = admStyle.toLowerCase()
           attributes.textlabel =
-            (attributes.caption && delete attributes.caption) ??
-            docAttrs[`${attributes.name}-caption`]
+            attributes.caption ?? docAttrs[`${attributes.name}-caption`]
+          delete attributes.caption
           block = await Parser.buildBlock(
             blockContext,
             'compound',

--- a/packages/core/test/blocks.example-admonition.test.js
+++ b/packages/core/test/blocks.example-admonition.test.js
@@ -383,6 +383,44 @@ TIP: Override the caption of an admonition block using an attribute entry
       )
     })
 
+    test('caption attribute on delimited admonition block should be used as textlabel', async () => {
+      const input = `\
+[TIP, caption='ProTip(TM)']
+====
+Use includes.
+====
+`
+
+      const doc = await documentFromString(input)
+      const block = doc.getBlocks()[0]
+      assert.equal(block.getAttribute('textlabel'), 'ProTip&#8482;')
+      assert.equal(block.getAttribute('caption'), null)
+      const output = await convertStringToEmbedded(input)
+      assertXpath(
+        output,
+        '/*[@class="admonitionblock tip"]//*[@class="icon"]/*[@class="title"][text()="ProTip™"]',
+        1
+      )
+    })
+
+    test('caption attribute on delimited admonition block should be used as icon title with font icons', async () => {
+      const input = `\
+[TIP, caption='ProTip(TM)']
+====
+Use includes.
+====
+`
+
+      const output = await convertStringToEmbedded(input, {
+        attributes: { icons: 'font' },
+      })
+      assertXpath(
+        output,
+        '/*[@class="admonitionblock tip"]//*[@class="icon"]/i[@title="ProTip™"]',
+        1
+      )
+    })
+
     test('can override caption of admonition block using document attribute', async () => {
       const input = `\
 :tip-caption: Pro Tip


### PR DESCRIPTION
On a delimited admonition block (e.g. `[TIP, caption='ProTip']` / `====`), the parser assigned `attributes.textlabel = (attributes.caption && delete attributes.caption) ?? ...`, which short-circuits to the boolean result of `delete` (`true`) instead of the caption string. The converter then emitted an empty `title` attribute.

Resolve the caption value first, then delete the attribute separately, matching the paragraph admonition code path and Asciidoctor Ruby.