### PR TITLE
feat: add --extension CLI option and clarify --require contract

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,15 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 == Unreleased
 
+Improvements::
+
+* Add `--extension` CLI option to load and register Asciidoctor extension files — the option calls the `register(registry)` named export of the loaded module with a shared registry; can be repeated to load multiple extensions
+* Clarify `--require` CLI option — it now only loads the module as a side effect and no longer auto-calls any exported function; use `--extension` to register Asciidoctor extensions, and `--require` for libraries that configure themselves on load (syntax highlighters, polyfills, etc.)
+
+Breaking Changes::
+
+* `--require` no longer inspects or calls a `register` export from the loaded module — this auto-call was already broken (it passed the `Extensions` namespace instead of a registry instance); any extension that relied on this behaviour must be updated to either export a `register(registry)` function and be loaded via `--extension`, or self-register using `Extensions.register()` at the top level to remain loadable via `--require`
+
 == v4.0.0-alpha.6 (2026-06-03)
 
 Build::

--- a/docs/modules/cli/pages/options.adoc
+++ b/docs/modules/cli/pages/options.adoc
@@ -60,8 +60,16 @@ This option may be specified more than once.
   If _OUT_FILE_ is _-_ then the standard output is also used.
   If specified, the file is resolved relative to the working directory.
 
+*--extension*=_EXTENSION_::
+  Require the specified extension file and register it before executing the processor.
+  The file must export a `register(registry)` function.
+  See xref:extend:extensions/register.adoc#cli[Use extensions with the CLI] for details.
+  This option may be specified more than once.
+
 *-r, --require*=_LIBRARY_::
   Require the specified library before executing the processor, using the standard Node `require`.
+  Use this option to load libraries that configure themselves as a side effect (e.g., syntax highlighter plugins, polyfills).
+  For Asciidoctor extensions, prefer `--extension`, which handles registration automatically.
   This option may be specified more than once.
 
 *-s, --no-header-footer*::

--- a/docs/modules/extend/examples/extensions/callout-block.js
+++ b/docs/modules/extend/examples/extensions/callout-block.js
@@ -1,4 +1,4 @@
-export default function (registry) {
+export function register(registry) {
   registry.block(function () {
     this.named('callout')
     this.onContext('paragraph')

--- a/docs/modules/extend/examples/extensions/copy-button-postprocessor.js
+++ b/docs/modules/extend/examples/extensions/copy-button-postprocessor.js
@@ -1,4 +1,4 @@
-export default function (registry) {
+export function register(registry) {
   registry.postprocessor(function () {
     this.process(function (doc, output) {
       return output

--- a/docs/modules/extend/examples/extensions/draft-preprocessor.js
+++ b/docs/modules/extend/examples/extensions/draft-preprocessor.js
@@ -1,4 +1,4 @@
-export default function (registry) {
+export function register(registry) {
   registry.preprocessor(function () {
     this.process(function (doc, reader) {
       const isDraft = reader.lines.some(l => /^\/\/\s*draft:/i.test(l))

--- a/docs/modules/extend/examples/extensions/gist-block-macro.js
+++ b/docs/modules/extend/examples/extensions/gist-block-macro.js
@@ -1,4 +1,4 @@
-export default function (registry) {
+export function register(registry) {
   registry.blockMacro(function () {
     this.named('gist')
     this.process(function (parent, target, attrs) {

--- a/docs/modules/extend/examples/extensions/json-include-processor.js
+++ b/docs/modules/extend/examples/extensions/json-include-processor.js
@@ -1,4 +1,4 @@
-export default function (registry) {
+export function register(registry) {
   registry.includeProcessor(function () {
     this.handles(target => target.startsWith('https://') && target.endsWith('.json'))
     this.process(async function (doc, reader, target, attrs) {

--- a/docs/modules/extend/examples/extensions/npm-inline-macro-processor.js
+++ b/docs/modules/extend/examples/extensions/npm-inline-macro-processor.js
@@ -1,4 +1,4 @@
-export default function (registry) {
+export function register(registry) {
   registry.inlineMacro('npm', function () {
     this.process(function (parent, target, attrs) {
       const version = attrs.version ? `@${attrs.version}` : ''

--- a/docs/modules/extend/examples/extensions/open-graph-docinfo-processor.js
+++ b/docs/modules/extend/examples/extensions/open-graph-docinfo-processor.js
@@ -1,4 +1,4 @@
-export default function (registry) {
+export function register(registry) {
   registry.docinfoProcessor(function () {
     this.atLocation('head')
     this.process(function (doc) {

--- a/docs/modules/extend/examples/extensions/reading-time-tree-processor.js
+++ b/docs/modules/extend/examples/extensions/reading-time-tree-processor.js
@@ -1,4 +1,4 @@
-export default function (registry) {
+export function register(registry) {
   registry.treeProcessor(function () {
     this.process(function (doc) {
       const words = doc.findBy({ context: 'paragraph' })

--- a/docs/modules/extend/pages/extensions/block-macro-processor.adoc
+++ b/docs/modules/extend/pages/extensions/block-macro-processor.adoc
@@ -29,15 +29,21 @@ include::example$extensions/gist-block-macro.js[]
 
 == Usage
 
+=== API
+
 [source,js]
 ----
 import { Extensions, convert } from '@asciidoctor/core'
-import registerGistBlockMacro from './gist-block-macro.js'
+import { register } from './gist-block-macro.js'
 
 const registry = Extensions.create()
-registerGistBlockMacro(registry)
+register(registry)
 
 const html = await convert('gist::mojombo/4ae3f9bc20c6b67e06a7[]', { extension_registry: registry })
 console.log(html)
 // <script src="https://gist.github.com/mojombo/4ae3f9bc20c6b67e06a7.js"></script>
 ----
+
+=== CLI
+
+ $ asciidoctor --extension ./gist-block-macro.js sample-gist-doc.adoc

--- a/docs/modules/extend/pages/extensions/block-processor.adoc
+++ b/docs/modules/extend/pages/extensions/block-processor.adoc
@@ -25,16 +25,22 @@ include::example$extensions/callout-block.js[]
 
 == Usage
 
+=== API
+
 [source,js]
 ----
 import { Extensions, convertFile } from '@asciidoctor/core'
-import registerCalloutBlock from './callout-block.js'
+import { register } from './callout-block.js'
 
 const registry = Extensions.create()
-registerCalloutBlock(registry)
+register(registry)
 
 const html = await convertFile('sample-callout-doc.adoc', { to_file: false, extension_registry: registry })
 console.log(html)
 // <aside class="callout callout-warning">Make sure you have Node.js 18 or later installed before running the setup script.</aside>
 // <aside class="callout callout-tip">You can skip this step if you already have the dependencies installed.</aside>
 ----
+
+=== CLI
+
+ $ asciidoctor --extension ./callout-block.js sample-callout-doc.adoc

--- a/docs/modules/extend/pages/extensions/docinfo-processor.adoc
+++ b/docs/modules/extend/pages/extensions/docinfo-processor.adoc
@@ -27,13 +27,15 @@ include::example$extensions/open-graph-docinfo-processor.js[]
 
 == Usage
 
+=== API
+
 [source,js]
 ----
 import { Extensions, convertFile } from '@asciidoctor/core'
-import registerOpenGraphDocinfoProcessor from './open-graph-docinfo-processor.js'
+import { register } from './open-graph-docinfo-processor.js'
 
 const registry = Extensions.create()
-registerOpenGraphDocinfoProcessor(registry)
+register(registry)
 
 await convertFile('sample-article-doc.adoc', { to_file: false, extension_registry: registry })
 // The <head> now contains:
@@ -41,3 +43,7 @@ await convertFile('sample-article-doc.adoc', { to_file: false, extension_registr
 // <meta property="og:description" content="Learn how to convert AsciiDoc documents to HTML using Asciidoctor.js.">
 // <meta property="og:image" content="https://example.com/images/asciidoctorjs-preview.png">
 ----
+
+=== CLI
+
+ $ asciidoctor --extension ./open-graph-docinfo-processor.js sample-article-doc.adoc

--- a/docs/modules/extend/pages/extensions/include-processor.adoc
+++ b/docs/modules/extend/pages/extensions/include-processor.adoc
@@ -36,13 +36,15 @@ include::example$extensions/json-include-processor.js[]
 
 == Usage
 
+=== API
+
 [source,js]
 ----
 import { Extensions, convert } from '@asciidoctor/core'
-import registerJsonIncludeProcessor from './json-include-processor.js'
+import { register } from './json-include-processor.js'
 
 const registry = Extensions.create()
-registerJsonIncludeProcessor(registry)
+register(registry)
 
 const html = await convert(
   'include::https://raw.githubusercontent.com/org/repo/main/versions.json[as=attributes]',
@@ -52,3 +54,7 @@ const html = await convert(
 // :version: 3.1.0
 // :node-min: 18
 ----
+
+=== CLI
+
+ $ asciidoctor --extension ./json-include-processor.js sample-versions-doc.adoc

--- a/docs/modules/extend/pages/extensions/inline-macro-processor.adoc
+++ b/docs/modules/extend/pages/extensions/inline-macro-processor.adoc
@@ -24,16 +24,22 @@ include::example$extensions/npm-inline-macro-processor.js[]
 
 == Usage
 
+=== API
+
 [source,js]
 ----
 import { Extensions, convertFile } from '@asciidoctor/core'
-import registerNpmInlineMacro from './npm-inline-macro-processor.js'
+import { register } from './npm-inline-macro-processor.js'
 
 const registry = Extensions.create()
-registerNpmInlineMacro(registry)
+register(registry)
 
 const html = await convertFile('sample-npm-doc.adoc', { to_file: false, extension_registry: registry })
 console.log(html)
 // <p>Install <a href="https://www.npmjs.com/package/lodash">lodash@4.17.21</a> for utility functions
 // and <a href="https://www.npmjs.com/package/axios">axios</a> for HTTP requests.</p>
 ----
+
+=== CLI
+
+ $ asciidoctor --extension ./npm-inline-macro-processor.js sample-npm-doc.adoc

--- a/docs/modules/extend/pages/extensions/postprocessor.adoc
+++ b/docs/modules/extend/pages/extensions/postprocessor.adoc
@@ -29,13 +29,15 @@ include::example$extensions/copy-button-postprocessor.js[]
 
 == Usage
 
+=== API
+
 [source,js]
 ----
 import { Extensions, convertFile } from '@asciidoctor/core'
-import registerCopyButtonPostprocessor from './copy-button-postprocessor.js'
+import { register } from './copy-button-postprocessor.js'
 
 const registry = Extensions.create()
-registerCopyButtonPostprocessor(registry)
+register(registry)
 
 const html = await convertFile('sample-api-doc.adoc', { to_file: false, extension_registry: registry })
 // Every <pre> element is now wrapped with a copy button:
@@ -44,3 +46,7 @@ const html = await convertFile('sample-api-doc.adoc', { to_file: false, extensio
 // <pre class="highlight"><code ...>curl ...</code></pre>
 // </div>
 ----
+
+=== CLI
+
+ $ asciidoctor --extension ./copy-button-postprocessor.js sample-api-doc.adoc

--- a/docs/modules/extend/pages/extensions/preprocessor.adoc
+++ b/docs/modules/extend/pages/extensions/preprocessor.adoc
@@ -26,16 +26,22 @@ include::example$extensions/draft-preprocessor.js[]
 
 == Usage
 
+=== API
+
 [source,js]
 ----
 import { Extensions, loadFile } from '@asciidoctor/core'
-import registerDraftPreprocessor from './draft-preprocessor.js'
+import { register } from './draft-preprocessor.js'
 
 const registry = Extensions.create()
-registerDraftPreprocessor(registry)
+register(registry)
 
 const doc = await loadFile('sample-release-notes.adoc', { extension_registry: registry })
 console.log(doc.getAttribute('status')) // 'DRAFT'
 const html = await doc.convert()
 // The rendered document starts with a WARNING admonition block
 ----
+
+=== CLI
+
+ $ asciidoctor --extension ./draft-preprocessor.js sample-release-notes.adoc

--- a/docs/modules/extend/pages/extensions/register.adoc
+++ b/docs/modules/extend/pages/extensions/register.adoc
@@ -146,8 +146,10 @@ An extension can also be loaded this way if it self-registers as a side effect b
 
 === Extension file structure
 
-An extension loaded via `--extension` must export a named `register` function:
+An extension loaded via `--extension` must export a named `register` function.
+Both ES module and CommonJS formats are supported.
 
+.ES module (recommended)
 [source,js]
 ----
 export function register(registry) {
@@ -164,8 +166,18 @@ export function register(registry) {
 }
 ----
 
+.CommonJS
+[source,js]
+----
+module.exports.register = function (registry) {
+  registry.block(function () {
+    // ...
+  })
+}
+----
+
  $ asciidoctor --extension ./callout-block.js my-document.adoc
 
-The `--extension` option can be repeated to load several extensions, all sharing the same registry:
+The `--extension` option can be repeated to load several extensions:
 
  $ asciidoctor --extension ./callout-block.js --extension ./draft-preprocessor.js my-document.adoc

--- a/docs/modules/extend/pages/extensions/register.adoc
+++ b/docs/modules/extend/pages/extensions/register.adoc
@@ -127,3 +127,45 @@ Both registries have a `[callout]` block extension registered with a specific im
 
 The first block extension is registered in `registryA` and renders the content as a paragraph with a `callout` CSS role.
 The other is registered in `registryB` and wraps the content in a semantic `<aside>` element.
+
+[#cli]
+== Use extensions with the CLI
+
+The CLI provides two options for loading external files:
+
+`--extension`::
+Loads the file and registers it as an Asciidoctor extension.
+The file must export a `register(registry)` function, which the CLI calls with a shared registry before conversion.
+This is the recommended way to load extensions.
+
+`-r` / `--require`::
+Loads the file as a plain Node.js module, executing any top-level side effects.
+The CLI does *not* call any exported function.
+Use this for libraries that configure themselves on load (syntax highlighter plugins, polyfills, etc.).
+An extension can also be loaded this way if it self-registers as a side effect by calling `Extensions.register()` at the top level, but `--extension` is preferred when the file follows the `register(registry)` export convention.
+
+=== Extension file structure
+
+An extension loaded via `--extension` must export a named `register` function:
+
+[source,js]
+----
+export function register(registry) {
+  registry.block(function () {
+    this.named('callout')
+    this.onContext('paragraph')
+    this.process(function (parent, reader, attrs) {
+      const type = attrs.type || 'note'
+      const lines = reader.getLines()
+      const html = `<aside class="callout callout-${type}">${lines.join('\n')}</aside>`
+      return this.createBlock(parent, 'pass', html)
+    })
+  })
+}
+----
+
+ $ asciidoctor --extension ./callout-block.js my-document.adoc
+
+The `--extension` option can be repeated to load several extensions, all sharing the same registry:
+
+ $ asciidoctor --extension ./callout-block.js --extension ./draft-preprocessor.js my-document.adoc

--- a/docs/modules/extend/pages/extensions/tree-processor.adoc
+++ b/docs/modules/extend/pages/extensions/tree-processor.adoc
@@ -33,14 +33,20 @@ include::example$extensions/reading-time-tree-processor.js[]
 
 == Usage
 
+=== API
+
 [source,js]
 ----
 import { Extensions, convertFile } from '@asciidoctor/core'
-import registerReadingTimeTreeProcessor from './reading-time-tree-processor.js'
+import { register } from './reading-time-tree-processor.js'
 
 const registry = Extensions.create()
-registerReadingTimeTreeProcessor(registry)
+register(registry)
 
 const html = await convertFile('sample-guide-doc.adoc', { to_file: false, extension_registry: registry })
 // <p>Estimated reading time: 1 min</p>
 ----
+
+=== CLI
+
+ $ asciidoctor --extension ./reading-time-tree-processor.js sample-guide-doc.adoc

--- a/packages/asciidoctor/lib/cli.js
+++ b/packages/asciidoctor/lib/cli.js
@@ -459,13 +459,17 @@ CLI version ${pkg.version}`
   _prepareExtensions(values) {
     const extensionPaths = values.extension
     if (!extensionPaths || extensionPaths.length === 0) return
+    const logger = LoggerManager.getLogger()
     for (const extensionPath of extensionPaths) {
       const lib = requireLibrary(extensionPath)
-      const registerFn = lib?.register ?? lib?.default
-      if (typeof registerFn === 'function') {
+      if (typeof lib?.register === 'function') {
         Extensions.register(function () {
-          registerFn(this)
+          lib.register(this)
         })
+      } else {
+        logger.warn(
+          `Extension '${extensionPath}' does not export a register function and will be ignored.`
+        )
       }
     }
   }

--- a/packages/asciidoctor/lib/cli.js
+++ b/packages/asciidoctor/lib/cli.js
@@ -126,6 +126,13 @@ const BASE_OPTION_DEFINITIONS = {
       'require the specified library before executing the processor (repeatable)',
     metavar: '<library>',
   },
+  extension: {
+    type: 'string',
+    multiple: true,
+    describe:
+      'require the specified extension and register it before executing the processor (repeatable)',
+    metavar: '<extension>',
+  },
   version: {
     type: 'boolean',
     short: 'V',
@@ -351,6 +358,7 @@ export class Invoker {
     }
 
     this._prepareProcessor(values)
+    this._prepareExtensions(values)
     const { options, failureLevel } = this.options
 
     const logger = LoggerManager.getLogger()
@@ -443,9 +451,21 @@ CLI version ${pkg.version}`
     const requirePaths = values.require
     if (!requirePaths) return
     for (const requirePath of requirePaths) {
-      const lib = requireLibrary(requirePath)
-      if (lib && typeof lib.register === 'function') {
-        lib.register(Extensions)
+      requireLibrary(requirePath)
+    }
+  }
+
+  /** @internal */
+  _prepareExtensions(values) {
+    const extensionPaths = values.extension
+    if (!extensionPaths || extensionPaths.length === 0) return
+    for (const extensionPath of extensionPaths) {
+      const lib = requireLibrary(extensionPath)
+      const registerFn = lib?.register ?? lib?.default
+      if (typeof registerFn === 'function') {
+        Extensions.register(function () {
+          registerFn(this)
+        })
       }
     }
   }

--- a/packages/asciidoctor/test/cli.test.js
+++ b/packages/asciidoctor/test/cli.test.js
@@ -99,6 +99,7 @@ describe('CLI smoke tests', () => {
 
 const POSTPROCESSOR_EXTENSION = join(__dirname, 'fixtures', 'postprocessor-extension.js')
 const POSTPROCESSOR_EXTENSION_CJS = join(__dirname, 'fixtures', 'postprocessor-extension.cjs')
+const NO_REGISTER_EXTENSION = join(__dirname, 'fixtures', 'no-register-extension.js')
 
 describe('--extension option', () => {
   test('--extension loads and registers the extension', () => {
@@ -148,6 +149,14 @@ describe('--extension option', () => {
     )
     assert.equal(result.status, 0)
     assert.match(result.stdout, /<!-- postprocessor-extension -->/)
+  })
+
+  test('--extension logs a warning when the extension does not export a register function', () => {
+    const result = cli(['--extension', NO_REGISTER_EXTENSION, '-'], {
+      input: '= Hello\n\nParagraph.',
+    })
+    assert.equal(result.status, 0)
+    assert.match(result.stderr, /does not export a register function/)
   })
 })
 

--- a/packages/asciidoctor/test/cli.test.js
+++ b/packages/asciidoctor/test/cli.test.js
@@ -98,6 +98,7 @@ describe('CLI smoke tests', () => {
 })
 
 const POSTPROCESSOR_EXTENSION = join(__dirname, 'fixtures', 'postprocessor-extension.js')
+const POSTPROCESSOR_EXTENSION_CJS = join(__dirname, 'fixtures', 'postprocessor-extension.cjs')
 
 describe('--extension option', () => {
   test('--extension loads and registers the extension', () => {
@@ -130,6 +131,14 @@ describe('--extension option', () => {
     } finally {
       rmSync(tmpDir, { recursive: true })
     }
+  })
+
+  test('--extension works with a CommonJS extension (module.exports.register)', () => {
+    const result = cli(['--extension', POSTPROCESSOR_EXTENSION_CJS, '-'], {
+      input: '= Hello\n\nParagraph.',
+    })
+    assert.equal(result.status, 0)
+    assert.match(result.stdout, /<!-- cjs-postprocessor-extension -->/)
   })
 
   test('--extension can be repeated to load multiple extensions', () => {

--- a/packages/asciidoctor/test/cli.test.js
+++ b/packages/asciidoctor/test/cli.test.js
@@ -97,6 +97,51 @@ describe('CLI smoke tests', () => {
   })
 })
 
+const POSTPROCESSOR_EXTENSION = join(__dirname, 'fixtures', 'postprocessor-extension.js')
+
+describe('--extension option', () => {
+  test('--extension loads and registers the extension', () => {
+    const result = cli(['--extension', POSTPROCESSOR_EXTENSION, '-'], {
+      input: '= Hello\n\nParagraph.',
+    })
+    assert.equal(result.status, 0)
+    assert.match(result.stdout, /<!-- postprocessor-extension -->/)
+  })
+
+  test('--require does not call the register export', () => {
+    const result = cli(['--require', POSTPROCESSOR_EXTENSION, '-'], {
+      input: '= Hello\n\nParagraph.',
+    })
+    assert.equal(result.status, 0)
+    assert.doesNotMatch(result.stdout, /<!-- postprocessor-extension -->/)
+  })
+
+  test('--extension applies to all input files', () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'asciidoctor-test-'))
+    try {
+      const fileA = join(tmpDir, 'a.adoc')
+      const fileB = join(tmpDir, 'b.adoc')
+      writeFileSync(fileA, '= Doc A\n\nFirst.')
+      writeFileSync(fileB, '= Doc B\n\nSecond.')
+      const result = cli(['--extension', POSTPROCESSOR_EXTENSION, '-D', tmpDir, fileA, fileB])
+      assert.equal(result.status, 0)
+      assert.match(readFileSync(join(tmpDir, 'a.html'), 'utf8'), /<!-- postprocessor-extension -->/)
+      assert.match(readFileSync(join(tmpDir, 'b.html'), 'utf8'), /<!-- postprocessor-extension -->/)
+    } finally {
+      rmSync(tmpDir, { recursive: true })
+    }
+  })
+
+  test('--extension can be repeated to load multiple extensions', () => {
+    const result = cli(
+      ['--extension', POSTPROCESSOR_EXTENSION, '--extension', POSTPROCESSOR_EXTENSION, '-'],
+      { input: '= Hello\n\nParagraph.' }
+    )
+    assert.equal(result.status, 0)
+    assert.match(result.stdout, /<!-- postprocessor-extension -->/)
+  })
+})
+
 const EXTENDED_CLI = join(__dirname, 'fixtures', 'extended-cli.js')
 
 function extendedCli(args, opts = {}) {

--- a/packages/asciidoctor/test/fixtures/no-register-extension.js
+++ b/packages/asciidoctor/test/fixtures/no-register-extension.js
@@ -1,0 +1,3 @@
+export function setup() {
+  // intentionally does not export a register function
+}

--- a/packages/asciidoctor/test/fixtures/postprocessor-extension.cjs
+++ b/packages/asciidoctor/test/fixtures/postprocessor-extension.cjs
@@ -1,0 +1,7 @@
+module.exports.register = function (registry) {
+  registry.postprocessor(function () {
+    this.process(function (doc, output) {
+      return output + '<!-- cjs-postprocessor-extension -->'
+    })
+  })
+}

--- a/packages/asciidoctor/test/fixtures/postprocessor-extension.js
+++ b/packages/asciidoctor/test/fixtures/postprocessor-extension.js
@@ -1,0 +1,7 @@
+export function register(registry) {
+  registry.postprocessor(function () {
+    this.process(function (doc, output) {
+      return output + '<!-- postprocessor-extension -->'
+    })
+  })
+}


### PR DESCRIPTION
- Add `--extension` (repeatable) CLI option that loads an extension file and registers it via its exported `register(registry)` function — both ESM (`export function register`) and CommonJS (`module.exports.register`) are supported
- Fix `--require` to load-only: it no longer auto-calls any exported function.
- Update all eight extension examples to use `export function register(registry)` instead of a default export, and update every extension doc page to show both API and CLI usage
 - Add a `[#cli]` section to `register.adoc` explaining the `--extension` / `--require` distinction and showing ESM + CJS extension formats

### Motivation

Users trying to load an extension with `-r` from the CLI were surprised to find it had no effect. The extension examples exported a default function, but `--require` never called it. This PR introduces `--extension` as the dedicated option for extensions, with a clear contract (`register(registry)`), and documents the distinction.

See also: https://asciidoctor.zulipchat.com/#narrow/channel/279645-users.2Fasciidoctor.2Ejs/topic/Use.20extensions.20from.20command.20line.3F/with/599886016

### Breaking change

`--require` no longer calls `lib.register`. Any extension that relied on this must either switch to `--extension` or self-register using `Extensions.register()` at the top level.
