### PR TITLE
docs(extensions): add @overload signatures to IncludeProcessorDsl#handles

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,6 +12,7 @@ Improvements::
 
 * Add `--extension` CLI option to load and register Asciidoctor extension files — the option calls the `register(registry)` named export of the loaded module with a shared registry; can be repeated to load multiple extensions
 * Clarify `--require` CLI option — it now only loads the module as a side effect and no longer auto-calls any exported function; use `--extension` to register Asciidoctor extensions, and `--require` for libraries that configure themselves on load (syntax highlighters, polyfills, etc.)
+* Improve JSDoc for `IncludeProcessorDsl#handles` — add `@overload` signatures documenting the two setter forms (arity-1 `(target)` and arity-2 `(doc, target)`) and the invoker form; update `IncludeProcessorDslInterface` typedef to expose both setter overloads
 
 Breaking Changes::
 

--- a/packages/core/src/extensions.js
+++ b/packages/core/src/extensions.js
@@ -75,6 +75,7 @@ import { MacroNameRx, CC_ANY } from './rx.js'
  * DSL interface for include processors.
  *
  * @typedef {DocumentProcessorDslInterface & {
+ *   handles(fn: (target: string) => boolean): void;
  *   handles(fn: (doc: Document, target: string) => boolean): void;
  * }} IncludeProcessorDslInterface
  */
@@ -299,6 +300,35 @@ export const SyntaxProcessorDsl = {
 export const IncludeProcessorDsl = {
   ...DocumentProcessorDsl,
 
+  /**
+   * @overload
+   * @param {(target: string) => boolean} fn - Predicate that receives only the include target.
+   * @returns {void}
+   */
+  /**
+   * @overload
+   * @param {(doc: Document, target: string) => boolean} fn - Predicate that receives the document and the include target.
+   * @returns {void}
+   */
+  /**
+   * @overload
+   * @param {Document} doc - The document being parsed.
+   * @param {string} target - The include target.
+   * @returns {boolean}
+   */
+  /**
+   * Register a function that decides whether this include processor handles a given target,
+   * or invoke the registered handler.
+   *
+   * **Setter form** — register a predicate. The callback may accept either just the target
+   * string (arity 1) or both the document and the target string (arity 2).
+   *
+   * **Invoker form** — call the registered predicate with `(doc, target)` and return its
+   * result, or return `true` if no predicate has been registered.
+   *
+   * @param {...*} args
+   * @returns {boolean | void}
+   */
   handles(...args) {
     if (args.length === 1 && typeof args[0] === 'function') {
       const fn = args[0]

--- a/packages/core/types/extensions.d.ts
+++ b/packages/core/types/extensions.d.ts
@@ -38,7 +38,25 @@ export namespace SyntaxProcessorDsl {
     function resolvesAttributes(...args: any[]): void;
 }
 export namespace IncludeProcessorDsl {
-    function handles(...args: any[]): any;
+    /**
+     * @overload
+     * @param {(target: string) => boolean} fn - Predicate that receives only the include target.
+     * @returns {void}
+     */
+    function handles(fn: (target: string) => boolean): void;
+    /**
+     * @overload
+     * @param {(doc: Document, target: string) => boolean} fn - Predicate that receives the document and the include target.
+     * @returns {void}
+     */
+    function handles(fn: (doc: Document, target: string) => boolean): void;
+    /**
+     * @overload
+     * @param {Document} doc - The document being parsed.
+     * @param {string} target - The include target.
+     * @returns {boolean}
+     */
+    function handles(doc: Document, target: string): boolean;
 }
 export namespace DocinfoProcessorDsl {
     function atLocation(value: any): void;
@@ -1032,6 +1050,7 @@ export type SyntaxProcessorDslInterface = ProcessorDslInterface & {
  * DSL interface for include processors.
  */
 export type IncludeProcessorDslInterface = DocumentProcessorDslInterface & {
+    handles(fn: (target: string) => boolean): void;
     handles(fn: (doc: Document, target: string) => boolean): void;
 };
 /**


### PR DESCRIPTION
Document the dynamic first-argument behaviour: the setter form accepts either (target: string) or (doc: Document, target: string) as a callback, while the two-argument form is the internal invoker.