### PR TITLE
docs: document registry reuse behaviour and add tests

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,6 +10,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 Improvements::
 
+* Document registry reuse behaviour — extensions registered via a group block (`Extensions.create(name, block)`) survive the internal reset and are safe to reuse across multiple conversions; extensions registered directly on a registry instance are cleared on every activation and will be silently lost after the first conversion
 * Add `--extension` CLI option to load and register Asciidoctor extension files — the option calls the `register(registry)` named export of the loaded module with a shared registry; can be repeated to load multiple extensions
 * Clarify `--require` CLI option — it now only loads the module as a side effect and no longer auto-calls any exported function; use `--extension` to register Asciidoctor extensions, and `--require` for libraries that configure themselves on load (syntax highlighters, polyfills, etc.)
 * Improve JSDoc for `IncludeProcessorDsl#handles` — add `@overload` signatures documenting the two setter forms (arity-1 `(target)` and arity-2 `(doc, target)`) and the invoker form; update `IncludeProcessorDslInterface` typedef to expose both setter overloads

--- a/docs/modules/extend/pages/extensions/register.adoc
+++ b/docs/modules/extend/pages/extensions/register.adoc
@@ -78,29 +78,30 @@ It can be useful when you want to convert the same text with different extension
 ----
 import { Extensions, convert } from '@asciidoctor/core'
 
-const registryA = Extensions.create()
-const registryB = Extensions.create()
-
-registryA.block(function () {
-  const self = this
-  self.named('callout')
-  self.onContext('paragraph')
-  self.process(function (parent, reader) {
-    // Render as a paragraph with a CSS role
-    const lines = reader.getLines()
-    return self.createBlock(parent, 'paragraph', lines, { role: 'callout' })
+const registryA = Extensions.create('callout-paragraph', function () {
+  this.block(function () {
+    const self = this
+    self.named('callout')
+    self.onContext('paragraph')
+    self.process(function (parent, reader) {
+      // Render as a paragraph with a CSS role
+      const lines = reader.getLines()
+      return self.createBlock(parent, 'paragraph', lines, { role: 'callout' })
+    })
   })
 })
 
-registryB.block(function () {
-  const self = this
-  self.named('callout')
-  self.onContext('paragraph')
-  self.process(function (parent, reader) {
-    // Render as a semantic <aside> element
-    const lines = reader.getLines()
-    const html = `<aside class="callout">${lines.join('\n')}</aside>`
-    return self.createBlock(parent, 'pass', html)
+const registryB = Extensions.create('callout-aside', function () {
+  this.block(function () {
+    const self = this
+    self.named('callout')
+    self.onContext('paragraph')
+    self.process(function (parent, reader) {
+      // Render as a semantic <aside> element
+      const lines = reader.getLines()
+      const html = `<aside class="callout">${lines.join('\n')}</aside>`
+      return self.createBlock(parent, 'pass', html)
+    })
   })
 })
 
@@ -127,6 +128,66 @@ Both registries have a `[callout]` block extension registered with a specific im
 
 The first block extension is registered in `registryA` and renders the content as a paragraph with a `callout` CSS role.
 The other is registered in `registryB` and wraps the content in a semantic `<aside>` element.
+
+[#registry-reuse]
+=== Reusing a registry across multiple conversions
+
+A registry can be reused across multiple conversions by passing it as the `extension_registry` option.
+However, the way you register extensions determines whether reuse is safe.
+
+When a block function is passed to `Extensions.create()`, that block is stored internally as a group.
+On each conversion, the registry resets its transient state and re-executes all groups, so extensions are correctly re-activated every time.
+
+When extensions are registered *directly* on a registry instance (e.g. `registry.preprocessor(fn)` called outside any block), they are stored in transient state that is cleared on every activation.
+*Those registrations will be silently lost from the second conversion onwards.*
+
+.Safe — block is stored as a group and re-executed on every conversion
+[source,js]
+----
+import { Extensions, convert } from '@asciidoctor/core'
+
+// The function passed to Extensions.create() is stored as a group.
+// It is re-executed on each conversion, so the preprocessor is always active.
+const registry = Extensions.create('my-ext', function () {
+  this.preprocessor(function () {
+    this.process(function (doc, reader) {
+      // ...
+      return reader
+    })
+  })
+})
+
+await convert('= First Doc',  { extension_registry: registry }) // <1>
+await convert('= Second Doc', { extension_registry: registry }) // <2>
+// The preprocessor is active for both conversions.
+----
+<1> First conversion — registry is activated, group block is executed, preprocessor is registered.
+<2> Second conversion — registry resets, group block is re-executed, preprocessor is registered again.
+
+.Unsafe — direct registration is lost after the first conversion
+[source,js]
+----
+import { Extensions, convert } from '@asciidoctor/core'
+
+const registry = Extensions.create()
+// Registering directly on the instance stores the preprocessor in transient state.
+registry.preprocessor(function () {
+  this.process(function (doc, reader) {
+    // ...
+    return reader
+  })
+})
+
+await convert('= First Doc',  { extension_registry: registry }) // <1>
+await convert('= Second Doc', { extension_registry: registry }) // <2>
+// The preprocessor is only active for the first conversion!
+----
+<1> First conversion — preprocessor is in transient state, it runs.
+<2> Second conversion — registry resets, transient state is cleared, preprocessor is gone.
+
+NOTE: This behaviour is identical to Ruby Asciidoctor.
+A registry is not designed to be reused with direct registrations.
+When in doubt, create a new registry per conversion, or use the block form of `Extensions.create()`.
 
 [#cli]
 == Use extensions with the CLI

--- a/packages/core/src/extensions.js
+++ b/packages/core/src/extensions.js
@@ -126,7 +126,7 @@ import { MacroNameRx, CC_ANY } from './rx.js'
  *   - Called with a single Function argument → stores it as the process block.
  *   - Called with non-Function arguments   → invokes the stored process block.
  *
- * The this context inside a stored process function is bound to the processor
+ * The `this` context inside a stored process function is bound to the processor
  * instance at definition time.
  */
 export const ProcessorDsl = {
@@ -1149,6 +1149,29 @@ const SYNTAX_PROCESSOR_CLASSES = {
  * Registry holds the extensions which have been registered and activated, has
  * methods for registering or defining a processor and looks up extensions
  * stored in the registry during parsing.
+ *
+ * **Registry reuse across conversions**
+ *
+ * A registry *can* be reused across multiple conversions, but only when extensions
+ * are registered via a group block (passed to {@link Extensions.create} or
+ * {@link Extensions.register}). Group blocks are stored in `groups` and survive
+ * the internal reset that happens on each activation.
+ *
+ * Extensions registered *directly* on the registry instance (e.g.
+ * `registry.preprocessor(fn)` called outside a group block) are stored in
+ * transient internal state that is cleared on every activation. They will be
+ * silently lost from the second conversion onwards.
+ *
+ * Use the group-block form for reusable registries:
+ * @example <caption>Safe — group block survives reset</caption>
+ * const registry = Extensions.create('my-ext', function () {
+ *   this.preprocessor(function () { ... })
+ * })
+ * // registry can be passed to multiple conversions safely
+ *
+ * @example <caption>Unsafe — direct registration is lost on reuse</caption>
+ * const registry = Extensions.create()
+ * registry.preprocessor(function () { ... }) // lost after 1st conversion!
  */
 export class Registry {
   constructor(groups = {}) {
@@ -1929,6 +1952,13 @@ export const Extensions = {
 
   /**
    * Create a new Registry, optionally pre-populated with a named block.
+   *
+   * When a `block` is provided it is stored as a group and re-executed on every
+   * activation, making the registry safe to reuse across multiple conversions.
+   * Without a `block`, any extensions registered directly on the returned registry
+   * (e.g. `registry.preprocessor(fn)`) are stored in transient state that is
+   * cleared on every activation — those registrations will be lost from the second
+   * conversion onwards. Prefer the block form when the registry may be reused.
    *
    * @param {string|null} [name=null] - Optional name for the group; auto-generated if omitted.
    * @param {Function|null} [block=null] - Optional function to register as the group.

--- a/packages/core/test/extensions.registry.test.js
+++ b/packages/core/test/extensions.registry.test.js
@@ -659,3 +659,77 @@ describe('Processor helper methods', () => {
     assert.ok(html.includes('world'))
   })
 })
+
+// ── Registry reuse across conversions ─────────────────────────────────────────
+
+describe('Registry reuse across conversions', () => {
+  test('group-block registry is active on every conversion', async () => {
+    // Extensions registered via the block passed to Extensions.create() are
+    // stored as a group and re-executed on each activation — safe to reuse.
+    const registry = Extensions.create('counter', function () {
+      this.preprocessor(function () {
+        this.process((doc, reader) => {
+          doc.setAttribute(
+            'ext-called',
+            String(parseInt(doc.getAttribute('ext-called', '0'), 10) + 1)
+          )
+          return reader
+        })
+      })
+    })
+
+    const doc1 = await load('= First', { extension_registry: registry })
+    assert.equal(
+      doc1.getAttribute('ext-called'),
+      '1',
+      'preprocessor should run on 1st conversion'
+    )
+    assert.equal(
+      registry.preprocessors().length,
+      1,
+      'should have exactly one preprocessor after 1st conversion'
+    )
+
+    const doc2 = await load('= Second', { extension_registry: registry })
+    assert.equal(
+      doc2.getAttribute('ext-called'),
+      '1',
+      'preprocessor should run on 2nd conversion'
+    )
+    assert.equal(
+      registry.preprocessors().length,
+      1,
+      'should have exactly one preprocessor after 2nd conversion'
+    )
+  })
+
+  test('directly-registered extensions are lost after the first conversion', async () => {
+    // Extensions registered directly on the registry instance (outside a group
+    // block) are stored in transient state that is cleared on every activation.
+    // This documents the known limitation: reuse is not safe with this pattern.
+    const registry = Extensions.create()
+    registry.preprocessor(function () {
+      this.process((doc, reader) => {
+        doc.setAttribute(
+          'ext-called',
+          String(parseInt(doc.getAttribute('ext-called', '0'), 10) + 1)
+        )
+        return reader
+      })
+    })
+
+    const doc1 = await load('= First', { extension_registry: registry })
+    assert.equal(
+      doc1.getAttribute('ext-called'),
+      '1',
+      'preprocessor should run on 1st conversion'
+    )
+
+    const doc2 = await load('= Second', { extension_registry: registry })
+    assert.equal(
+      doc2.getAttribute('ext-called'),
+      null,
+      'preprocessor is lost after reset — known limitation'
+    )
+  })
+})

--- a/packages/core/types/extensions.d.ts
+++ b/packages/core/types/extensions.d.ts
@@ -519,6 +519,29 @@ export class Group {
  * Registry holds the extensions which have been registered and activated, has
  * methods for registering or defining a processor and looks up extensions
  * stored in the registry during parsing.
+ *
+ * **Registry reuse across conversions**
+ *
+ * A registry *can* be reused across multiple conversions, but only when extensions
+ * are registered via a group block (passed to {@link Extensions.create} or
+ * {@link Extensions.register}). Group blocks are stored in `groups` and survive
+ * the internal reset that happens on each activation.
+ *
+ * Extensions registered *directly* on the registry instance (e.g.
+ * `registry.preprocessor(fn)` called outside a group block) are stored in
+ * transient internal state that is cleared on every activation. They will be
+ * silently lost from the second conversion onwards.
+ *
+ * Use the group-block form for reusable registries:
+ * @example <caption>Safe — group block survives reset</caption>
+ * const registry = Extensions.create('my-ext', function () {
+ *   this.preprocessor(function () { ... })
+ * })
+ * // registry can be passed to multiple conversions safely
+ *
+ * @example <caption>Unsafe — direct registration is lost on reuse</caption>
+ * const registry = Extensions.create()
+ * registry.preprocessor(function () { ... }) // lost after 1st conversion!
  */
 export class Registry {
     constructor(groups?: {});
@@ -843,6 +866,13 @@ export namespace Extensions {
     function getGroups(): object;
     /**
      * Create a new Registry, optionally pre-populated with a named block.
+     *
+     * When a `block` is provided it is stored as a group and re-executed on every
+     * activation, making the registry safe to reuse across multiple conversions.
+     * Without a `block`, any extensions registered directly on the returned registry
+     * (e.g. `registry.preprocessor(fn)`) are stored in transient state that is
+     * cleared on every activation — those registrations will be lost from the second
+     * conversion onwards. Prefer the block form when the registry may be reused.
      *
      * @param {string|null} [name=null] - Optional name for the group; auto-generated if omitted.
      * @param {Function|null} [block=null] - Optional function to register as the group.


### PR DESCRIPTION
A registry created via Extensions.create(name, block) can safely be reused across multiple conversions because the block is stored as a group and re-executed on every activation. Extensions registered directly on the registry instance (outside a group block) are cleared on every activation and silently lost after the first conversion.

This behaviour is identical in Ruby Asciidoctor.

- Add JSDoc warning on Registry class and Extensions.create()
- Fix the two-registry example in register.adoc (was using the unsafe direct-registration pattern) and add a dedicated #registry-reuse section with safe/unsafe examples and callout annotations
- Add two integration tests in extensions.registry.test.js covering both patterns across multiple load() calls

Closes #1709