### PR TITLE
fix(extensions): preserve directly-registered extensions across registry reuse

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,10 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 == Unreleased
 
+Bug Fixes::
+
+* Fix registry reuse — extensions registered directly on a registry instance (e.g. `registry.preprocessor(fn)`) now survive the internal reset and are preserved across multiple conversions, matching the behaviour of group-block registrations (`Extensions.create(name, block)`); both patterns are now safe to reuse
+
 Improvements::
 
 * Document registry reuse behaviour — extensions registered via a group block (`Extensions.create(name, block)`) survive the internal reset and are safe to reuse across multiple conversions; extensions registered directly on a registry instance are cleared on every activation and will be silently lost after the first conversion

--- a/docs/modules/extend/pages/extensions/register.adoc
+++ b/docs/modules/extend/pages/extensions/register.adoc
@@ -133,15 +133,9 @@ The other is registered in `registryB` and wraps the content in a semantic `<asi
 === Reusing a registry across multiple conversions
 
 A registry can be reused across multiple conversions by passing it as the `extension_registry` option.
-However, the way you register extensions determines whether reuse is safe.
+Both registration styles are safe to reuse.
 
-When a block function is passed to `Extensions.create()`, that block is stored internally as a group.
-On each conversion, the registry resets its transient state and re-executes all groups, so extensions are correctly re-activated every time.
-
-When extensions are registered *directly* on a registry instance (e.g. `registry.preprocessor(fn)` called outside any block), they are stored in transient state that is cleared on every activation.
-*Those registrations will be silently lost from the second conversion onwards.*
-
-.Safe — block is stored as a group and re-executed on every conversion
+.Group block — stored as a group and re-executed on every conversion
 [source,js]
 ----
 import { Extensions, convert } from '@asciidoctor/core'
@@ -164,13 +158,13 @@ await convert('= Second Doc', { extension_registry: registry }) // <2>
 <1> First conversion — registry is activated, group block is executed, preprocessor is registered.
 <2> Second conversion — registry resets, group block is re-executed, preprocessor is registered again.
 
-.Unsafe — direct registration is lost after the first conversion
+.Direct registration — preserved across conversions
 [source,js]
 ----
 import { Extensions, convert } from '@asciidoctor/core'
 
 const registry = Extensions.create()
-// Registering directly on the instance stores the preprocessor in transient state.
+// Extensions registered directly on the instance are preserved across activations.
 registry.preprocessor(function () {
   this.process(function (doc, reader) {
     // ...
@@ -180,14 +174,10 @@ registry.preprocessor(function () {
 
 await convert('= First Doc',  { extension_registry: registry }) // <1>
 await convert('= Second Doc', { extension_registry: registry }) // <2>
-// The preprocessor is only active for the first conversion!
+// The preprocessor is active for both conversions.
 ----
-<1> First conversion — preprocessor is in transient state, it runs.
-<2> Second conversion — registry resets, transient state is cleared, preprocessor is gone.
-
-NOTE: This behaviour is identical to Ruby Asciidoctor.
-A registry is not designed to be reused with direct registrations.
-When in doubt, create a new registry per conversion, or use the block form of `Extensions.create()`.
+<1> First conversion — preprocessor runs.
+<2> Second conversion — preprocessor is preserved across the reset and runs again.
 
 [#cli]
 == Use extensions with the CLI

--- a/packages/core/src/extensions.js
+++ b/packages/core/src/extensions.js
@@ -1102,22 +1102,48 @@ export class ProcessorExtension extends Extension {
     super(kind, instance, instance.config)
     this.processMethod =
       processMethod || ((...args) => instance.process(...args))
+    /** @internal */
+    this._direct = false
   }
 }
 
 // ── Group ─────────────────────────────────────────────────────────────────────
 
 /**
- * A Group registers one or more extensions with a Registry.
+ * A Group bundles one or more extension registrations that are re-executed on
+ * every document conversion, making the registry safe to reuse.
  *
- * Subclass Group and pass the subclass to Extensions.register(), or call
- * the static register() method directly.
+ * Subclass Group, override {@link Group#activate}, and either call
+ * {@link Group.register} to add it globally or pass the subclass to
+ * {@link Extensions.create} / {@link Extensions.register}.
+ *
+ * @example
+ * class MyGroup extends Group {
+ *   activate (registry) {
+ *     registry.preprocessor(MyPreprocessor)
+ *   }
+ * }
+ * MyGroup.register()
  */
 export class Group {
+  /**
+   * Register this Group class globally under the given name.
+   *
+   * Equivalent to calling `Extensions.register(name, this)`.
+   *
+   * @param {string|null} [name] - Optional name for the group.
+   */
   static register(name = null) {
     Extensions.register(name, this)
   }
 
+  /**
+   * Called by {@link Registry#activate} on every document conversion.
+   *
+   * Override this method to register extensions with the provided registry.
+   *
+   * @param {Registry} _registry - The registry to register extensions with.
+   */
   activate(_registry) {
     throw new Error(
       `${this.constructor.name} must implement the activate method`
@@ -1150,32 +1176,23 @@ const SYNTAX_PROCESSOR_CLASSES = {
  * methods for registering or defining a processor and looks up extensions
  * stored in the registry during parsing.
  *
- * **Registry reuse across conversions**
+ * A registry can be reused across multiple conversions. Extensions registered
+ * via a group block (passed to {@link Extensions.create} or
+ * {@link Extensions.register}) are re-executed on every activation. Extensions
+ * registered directly on the registry instance (e.g. `registry.preprocessor(fn)`)
+ * are preserved across activations.
  *
- * A registry *can* be reused across multiple conversions, but only when extensions
- * are registered via a group block (passed to {@link Extensions.create} or
- * {@link Extensions.register}). Group blocks are stored in `groups` and survive
- * the internal reset that happens on each activation.
- *
- * Extensions registered *directly* on the registry instance (e.g.
- * `registry.preprocessor(fn)` called outside a group block) are stored in
- * transient internal state that is cleared on every activation. They will be
- * silently lost from the second conversion onwards.
- *
- * Use the group-block form for reusable registries:
- * @example <caption>Safe — group block survives reset</caption>
+ * @example
  * const registry = Extensions.create('my-ext', function () {
  *   this.preprocessor(function () { ... })
  * })
  * // registry can be passed to multiple conversions safely
- *
- * @example <caption>Unsafe — direct registration is lost on reuse</caption>
- * const registry = Extensions.create()
- * registry.preprocessor(function () { ... }) // lost after 1st conversion!
  */
 export class Registry {
   constructor(groups = {}) {
     this.groups = groups
+    /** @internal */
+    this._activating = false
     this._reset()
   }
 
@@ -1192,18 +1209,26 @@ export class Registry {
       ...Object.values(Extensions.groups()),
       ...Object.values(this.groups),
     ]
-    for (const group of extGroups) {
-      if (typeof group === 'function') {
-        // Check if it is a class (constructor) with an activate prototype method.
-        if (group.prototype && typeof group.prototype.activate === 'function') {
-          new group().activate(this)
-        } else {
-          // Plain function — call in the context of this registry (like instance_exec).
-          group.length === 0 ? group.call(this) : group(this)
+    this._activating = true
+    try {
+      for (const group of extGroups) {
+        if (typeof group === 'function') {
+          // Check if it is a class (constructor) with an activate prototype method.
+          if (
+            group.prototype &&
+            typeof group.prototype.activate === 'function'
+          ) {
+            new group().activate(this)
+          } else {
+            // Plain function — call in the context of this registry (like instance_exec).
+            group.length === 0 ? group.call(this) : group(this)
+          }
+        } else if (group && typeof group.activate === 'function') {
+          group.activate(this)
         }
-      } else if (group && typeof group.activate === 'function') {
-        group.activate(this)
       }
+    } finally {
+      this._activating = false
     }
     return this
   }
@@ -1779,6 +1804,7 @@ export class Registry {
     }
 
     const extension = new ProcessorExtension(kind, processorInstance)
+    extension._direct = !this._activating
     extension.config.position === '>>'
       ? store.unshift(extension)
       : store.push(extension)
@@ -1850,27 +1876,44 @@ export class Registry {
     }
 
     store[name] = new ProcessorExtension(kind, processorInstance)
+    store[name]._direct = !this._activating
     return store[name]
   }
 
   /** @internal */
   _reset() {
+    // Keep extensions registered directly (outside a group); only clear group-registered ones.
+    // Extensions tagged with _direct=true survive across activations.
+    const keepArr = (arr) => {
+      const kept = arr?.filter((e) => e._direct) ?? []
+      return kept.length ? kept : null
+    }
+    const keepMap = (map) => {
+      if (!map) return null
+      const kept = Object.create(null)
+      for (const [k, v] of Object.entries(map)) if (v._direct) kept[k] = v
+      return Object.keys(kept).length ? kept : null
+    }
     /** @internal */
-    this._preprocessor_extensions = null
+    this._preprocessor_extensions = keepArr(this._preprocessor_extensions)
     /** @internal */
-    this._tree_processor_extensions = null
+    this._tree_processor_extensions = keepArr(this._tree_processor_extensions)
     /** @internal */
-    this._postprocessor_extensions = null
+    this._postprocessor_extensions = keepArr(this._postprocessor_extensions)
     /** @internal */
-    this._include_processor_extensions = null
+    this._include_processor_extensions = keepArr(
+      this._include_processor_extensions
+    )
     /** @internal */
-    this._docinfo_processor_extensions = null
+    this._docinfo_processor_extensions = keepArr(
+      this._docinfo_processor_extensions
+    )
     /** @internal */
-    this._block_extensions = null
+    this._block_extensions = keepMap(this._block_extensions)
     /** @internal */
-    this._block_macro_extensions = null
+    this._block_macro_extensions = keepMap(this._block_macro_extensions)
     /** @internal */
-    this._inline_macro_extensions = null
+    this._inline_macro_extensions = keepMap(this._inline_macro_extensions)
     this.document = null
   }
 

--- a/packages/core/test/extensions.registry.test.js
+++ b/packages/core/test/extensions.registry.test.js
@@ -703,10 +703,7 @@ describe('Registry reuse across conversions', () => {
     )
   })
 
-  test('directly-registered extensions are lost after the first conversion', async () => {
-    // Extensions registered directly on the registry instance (outside a group
-    // block) are stored in transient state that is cleared on every activation.
-    // This documents the known limitation: reuse is not safe with this pattern.
+  test('directly-registered extensions survive reuse across conversions', async () => {
     const registry = Extensions.create()
     registry.preprocessor(function () {
       this.process((doc, reader) => {
@@ -722,14 +719,14 @@ describe('Registry reuse across conversions', () => {
     assert.equal(
       doc1.getAttribute('ext-called'),
       '1',
-      'preprocessor should run on 1st conversion'
+      'preprocessor runs on 1st conversion'
     )
 
     const doc2 = await load('= Second', { extension_registry: registry })
     assert.equal(
       doc2.getAttribute('ext-called'),
-      null,
-      'preprocessor is lost after reset — known limitation'
+      '1',
+      'preprocessor runs on 2nd conversion'
     )
   })
 })

--- a/packages/core/types/extensions.d.ts
+++ b/packages/core/types/extensions.d.ts
@@ -504,14 +504,38 @@ export class ProcessorExtension extends Extension {
     processMethod: any;
 }
 /**
- * A Group registers one or more extensions with a Registry.
+ * A Group bundles one or more extension registrations that are re-executed on
+ * every document conversion, making the registry safe to reuse.
  *
- * Subclass Group and pass the subclass to Extensions.register(), or call
- * the static register() method directly.
+ * Subclass Group, override {@link Group#activate}, and either call
+ * {@link Group.register} to add it globally or pass the subclass to
+ * {@link Extensions.create} / {@link Extensions.register}.
+ *
+ * @example
+ * class MyGroup extends Group {
+ *   activate (registry) {
+ *     registry.preprocessor(MyPreprocessor)
+ *   }
+ * }
+ * MyGroup.register()
  */
 export class Group {
-    static register(name?: any): void;
-    activate(_registry: any): void;
+    /**
+     * Register this Group class globally under the given name.
+     *
+     * Equivalent to calling `Extensions.register(name, this)`.
+     *
+     * @param {string|null} [name] - Optional name for the group.
+     */
+    static register(name?: string | null): void;
+    /**
+     * Called by {@link Registry#activate} on every document conversion.
+     *
+     * Override this method to register extensions with the provided registry.
+     *
+     * @param {Registry} _registry - The registry to register extensions with.
+     */
+    activate(_registry: Registry): void;
 }
 /**
  * The primary entry point into the extension system.
@@ -520,28 +544,17 @@ export class Group {
  * methods for registering or defining a processor and looks up extensions
  * stored in the registry during parsing.
  *
- * **Registry reuse across conversions**
+ * A registry can be reused across multiple conversions. Extensions registered
+ * via a group block (passed to {@link Extensions.create} or
+ * {@link Extensions.register}) are re-executed on every activation. Extensions
+ * registered directly on the registry instance (e.g. `registry.preprocessor(fn)`)
+ * are preserved across activations.
  *
- * A registry *can* be reused across multiple conversions, but only when extensions
- * are registered via a group block (passed to {@link Extensions.create} or
- * {@link Extensions.register}). Group blocks are stored in `groups` and survive
- * the internal reset that happens on each activation.
- *
- * Extensions registered *directly* on the registry instance (e.g.
- * `registry.preprocessor(fn)` called outside a group block) are stored in
- * transient internal state that is cleared on every activation. They will be
- * silently lost from the second conversion onwards.
- *
- * Use the group-block form for reusable registries:
- * @example <caption>Safe — group block survives reset</caption>
+ * @example
  * const registry = Extensions.create('my-ext', function () {
  *   this.preprocessor(function () { ... })
  * })
  * // registry can be passed to multiple conversions safely
- *
- * @example <caption>Unsafe — direct registration is lost on reuse</caption>
- * const registry = Extensions.create()
- * registry.preprocessor(function () { ... }) // lost after 1st conversion!
  */
 export class Registry {
     constructor(groups?: {});


### PR DESCRIPTION
Previously, extensions registered directly on a Registry instance (e.g. `registry.preprocessor(fn)`) were silently lost after the first conversion because `_reset()` cleared all state unconditionally. Only group-block registrations survived reuse, since groups are re-executed on every activation.

I considered two structural alternatives: throwing on direct registration (forcing users into the group pattern), and extracting registration methods into a RegistrationDSL object mixed in only during activation. Both required widespread changes across test fixtures and public-facing code, with no benefit to users.

The simpler fix is behavioural: tag each `ProcessorExtension` with `_direct` (`true` when registered outside a group callback, `false` inside one), and have `_reset()` preserve tagged extensions instead of clearing everything. Group-registered extensions are still re-created on every activation; directly-registered ones survive. No API surface changes, no migration required, and the group/non-group distinction no longer acts as a trap.

Additionally, the documentation still explains the difference between direct registration and group-block registration, but I believe the expected behaviour is better captured by having directly-registered extensions survive — registering an extension on a registry and then seeing it vanish on the next conversion is simply surprising.

Closes #1709