### PR TITLE
fix(types): declare Promise return types for async substitutor methods

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,10 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 == Unreleased
 
+Bug Fixes::
+
+* Fix incorrect generated type declarations for `async` substitutor methods — `applySubs`, `subQuotes`, `subMacros`, `subPostReplacements`, `subSource`, `subCallouts`, `highlightSource`, `restorePassthroughs` and `parseAttributes` are all `async` but their JSDoc `@returns` declared the unwrapped type (e.g. `string`), so the emitted `.d.ts` advertised `string` instead of `Promise<string>`; callers following the types could concatenate the returned Promise and produce `[object Promise]`. The JSDoc now declares `Promise<…>` and the `.d.ts` was regenerated
+
 == v4.0.0 (2026-06-22)
 
 Bug Fixes::

--- a/packages/core/src/substitutors.js
+++ b/packages/core/src/substitutors.js
@@ -176,7 +176,7 @@ export const Substitutors = {
    *
    * @param {string|string[]} text - The text to process; must not be null.
    * @param {string[]} [subs=NORMAL_SUBS] - The substitutions to perform.
-   * @returns {string|string[]} Text with substitutions applied.
+   * @returns {Promise<string|string[]>} Text with substitutions applied.
    */
   async applySubs(text, subs = NORMAL_SUBS) {
     const isEmpty = Array.isArray(text) ? text.length === 0 : text.length === 0
@@ -290,7 +290,7 @@ export const Substitutors = {
    * Substitute quoted text (emphasis, strong, monospaced, etc.)
    *
    * @param {string} text
-   * @returns {string}
+   * @returns {Promise<string>}
    */
   async subQuotes(text) {
     const compat = this.document.compatMode
@@ -462,7 +462,7 @@ export const Substitutors = {
    * Substitute inline macros (links, images, etc.)
    *
    * @param {string} text
-   * @returns {string}
+   * @returns {Promise<string>}
    */
   async subMacros(text) {
     const foundSquareBracket = text.includes('[')
@@ -1357,7 +1357,7 @@ export const Substitutors = {
    * Substitute post replacements (hard line breaks).
    *
    * @param {string} text
-   * @returns {string}
+   * @returns {Promise<string>}
    */
   async subPostReplacements(text) {
     if (
@@ -1395,7 +1395,7 @@ export const Substitutors = {
    *
    * @param {string} source
    * @param {boolean} processCallouts
-   * @returns {string}
+   * @returns {Promise<string>}
    */
   async subSource(source, processCallouts) {
     return processCallouts
@@ -1407,7 +1407,7 @@ export const Substitutors = {
    * Substitute callout source references.
    *
    * @param {string} text
-   * @returns {string}
+   * @returns {Promise<string>}
    */
   async subCallouts(text) {
     const calloutRx = this.hasAttribute('line-comment')
@@ -1436,7 +1436,7 @@ export const Substitutors = {
    *
    * @param {string} source
    * @param {boolean} processCallouts
-   * @returns {string}
+   * @returns {Promise<string>}
    */
   async highlightSource(source, processCallouts) {
     const syntaxHl = this.document.syntaxHighlighter
@@ -1782,7 +1782,7 @@ export const Substitutors = {
    * Restore passthrough text by reinserting into placeholder positions.
    *
    * @param {string} text
-   * @returns {string}
+   * @returns {Promise<string>}
    */
   async restorePassthroughs(text) {
     if (!text.includes(PASS_START)) return text
@@ -1974,7 +1974,7 @@ export const Substitutors = {
    * @param {string} attrlist
    * @param {string[]} [posattrs=[]]
    * @param {Object} [opts={}]
-   * @returns {Object}
+   * @returns {Promise<Object>}
    */
   async parseAttributes(attrlist, posattrs = [], opts = {}) {
     if (!attrlist || attrlist.length === 0) return {}

--- a/packages/core/types/substitutors.d.ts
+++ b/packages/core/types/substitutors.d.ts
@@ -4,9 +4,9 @@ export namespace Substitutors {
      *
      * @param {string|string[]} text - The text to process; must not be null.
      * @param {string[]} [subs=NORMAL_SUBS] - The substitutions to perform.
-     * @returns {string|string[]} Text with substitutions applied.
+     * @returns {Promise<string|string[]>} Text with substitutions applied.
      */
-    function applySubs(text: string | string[], subs?: string[]): string | string[];
+    function applySubs(text: string | string[], subs?: string[]): Promise<string | string[]>;
     /** Apply normal substitutions (alias for applySubs with default args). */
     function applyNormalSubs(text: any): Promise<string | string[]>;
     /** Apply substitutions for header metadata and attribute assignments.
@@ -32,9 +32,9 @@ export namespace Substitutors {
      * Substitute quoted text (emphasis, strong, monospaced, etc.)
      *
      * @param {string} text
-     * @returns {string}
+     * @returns {Promise<string>}
      */
-    function subQuotes(text: string): string;
+    function subQuotes(text: string): Promise<string>;
     /**
      * Substitute attribute references in the specified text.
      *
@@ -54,39 +54,39 @@ export namespace Substitutors {
      * Substitute inline macros (links, images, etc.)
      *
      * @param {string} text
-     * @returns {string}
+     * @returns {Promise<string>}
      */
-    function subMacros(text: string): string;
+    function subMacros(text: string): Promise<string>;
     /**
      * Substitute post replacements (hard line breaks).
      *
      * @param {string} text
-     * @returns {string}
+     * @returns {Promise<string>}
      */
-    function subPostReplacements(text: string): string;
+    function subPostReplacements(text: string): Promise<string>;
     /**
      * Apply verbatim substitutions on source.
      *
      * @param {string} source
      * @param {boolean} processCallouts
-     * @returns {string}
+     * @returns {Promise<string>}
      */
-    function subSource(source: string, processCallouts: boolean): string;
+    function subSource(source: string, processCallouts: boolean): Promise<string>;
     /**
      * Substitute callout source references.
      *
      * @param {string} text
-     * @returns {string}
+     * @returns {Promise<string>}
      */
-    function subCallouts(text: string): string;
+    function subCallouts(text: string): Promise<string>;
     /**
      * Highlight (colorize) the source code using a syntax highlighter.
      *
      * @param {string} source
      * @param {boolean} processCallouts
-     * @returns {string}
+     * @returns {Promise<string>}
      */
-    function highlightSource(source: string, processCallouts: boolean): string;
+    function highlightSource(source: string, processCallouts: boolean): Promise<string>;
     /**
      * Resolve line numbers to highlight from a test string.
      *
@@ -107,9 +107,9 @@ export namespace Substitutors {
      * Restore passthrough text by reinserting into placeholder positions.
      *
      * @param {string} text
-     * @returns {string}
+     * @returns {Promise<string>}
      */
-    function restorePassthroughs(text: string): string;
+    function restorePassthroughs(text: string): Promise<string>;
     /**
      * Resolve the list of comma-delimited subs against the possible options.
      *
@@ -143,9 +143,9 @@ export namespace Substitutors {
      * @param {string} attrlist
      * @param {string[]} [posattrs=[]]
      * @param {Object} [opts={}]
-     * @returns {Object}
+     * @returns {Promise<Object>}
      */
-    function parseAttributes(attrlist: string, posattrs?: string[], opts?: any): any;
+    function parseAttributes(attrlist: string, posattrs?: string[], opts?: any): Promise<any>;
     function extractAttributesFromText(text: any, defaultText?: any): Promise<any[]>;
     function extractCallouts(source: any): any[];
     function restoreCallouts(source: any, calloutMarks: any, sourceOffset?: any): Promise<string>;


### PR DESCRIPTION
Nine async methods in substitutors.js (applySubs, subQuotes, subMacros, subPostReplacements, subSource, subCallouts, highlightSource, restorePassthroughs, parseAttributes) carried a JSDoc `@returns` that declared the unwrapped type (e.g. string). An explicit `@returns` overrides tsc's async inference, so the generated .d.ts advertised string instead of Promise<string>. Callers trusting the types could concatenate the returned Promise and emit [object Promise].

Declare `@returns {Promise<...>}` on each and regenerate the declarations.