### PR TITLE
feat(converter): support data URI image targets

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,8 +8,13 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 == Unreleased
 
+Improvements::
+
+* The HTML5 converter can now inline an SVG image whose target is a `data:` URI (e.g. `image::data:image/svg+xml;base64,…[opts=inline]`). `readSvgContents` decodes both Base64 and percent-encoded `data:` payloads instead of only reading from a file or remote URI, so a diagram or image embedded as a data-URI can be rendered as inline `<svg>` without writing a file or enabling `allow-uri-read`. The SVG format is inferred from the `image/svg+xml` media type, so an explicit `format=svg` attribute is no longer required on a `data:` URI target
+
 Bug Fixes::
 
+* `imageUri` now returns a `data:` URI image target as-is instead of attempting to read it as a file or fetch it via the Fetch API; previously, with both `data-uri` and `allow-uri-read` set, a `data:` URI target (e.g. `data:image/png;base64,…`) triggered a spurious "could not retrieve image data from URI" warning
 * Fix the built-in `asciidoctor-version` attribute reporting the hard-coded upstream Ruby version (`3.0.0.dev`) instead of the actual library version — it now resolves to the `@asciidoctor/core` package version (e.g. `4.0.1`), so references such as `{asciidoctor-version}` reflect the real release
 * Report `Asciidoctor.js` (instead of `Asciidoctor`) in the HTML5 `<meta name="generator">` and manpage `Generator:` metadata, so the generated output identifies the JavaScript library and its version (e.g. `Asciidoctor.js 4.0.1`)
 * Fix natural cross-references (e.g. `<<Some section title>>`) not resolving inside list items, description list items and table cells — they rendered as `<a href="#Some section title">[Some section title]</a>` instead of linking to the section's generated ID. Unlike paragraph text (substituted lazily during conversion, after the reftext→id map is built), list/cell/dlist text is pre-computed eagerly in `_resolveAllTexts`, which ran *before* the map existed; the synchronous `resolveId` fallback then matched against the raw `reftext` attribute rather than the computed `xreftext` (a section's title), so the lookup failed. Text pre-computation now runs in two passes — titles and reftexts first, then the reftext→id map is built, then list/cell/dlist content text — restoring Ruby's invariant that all references are known before any content substitution resolves a natural cross-reference

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -35,6 +35,10 @@ Improvements::
 
 * Improve typing of `MemoryLogger#getMessages()` — it previously returned `any[]`; the `LogMessage` wrapper class is now exported and `getMessages()` is declared to return `LogMessage[]`, so consumers get typed `getSeverity()` (`string`), `getText()` (`string`) and `getSourceLocation()` (`Cursor | undefined`) accessors. The wrapper's internal `_text`/`_sourceLocation` fields were renamed to public `text`/`sourceLocation` properties (consistent with `severity`), providing dual property/getter access
 
+Infrastructure::
+
+* Fix the browser-test `Buffer` polyfill so `Buffer.from(str).toString('base64')` actually returns Base64 instead of the original string; previously the data-URI SVG tests built a malformed `data:…;base64,<svg …>` target that made the browser's `atob` throw `InvalidCharacterError`
+
 == v4.0.0 (2026-06-22)
 
 Bug Fixes::

--- a/packages/core/src/abstract_node.js
+++ b/packages/core/src/abstract_node.js
@@ -461,9 +461,10 @@ export class AbstractNode {
    * Construct a URI reference or data URI to the target image.
    *
    * If the target image is already a URI it is left untouched (unless data-uri
-   * conversion is requested). The image is resolved relative to the directory
-   * named by assetDirKey. When data-uri is enabled and the safe level permits,
-   * the image is embedded as a Base64 data URI.
+   * conversion is requested). If the target image is a data URI, then it is
+   * already an embedded image, so it is returned as-is. The image is resolved
+   * relative to the directory named by assetDirKey. When data-uri is enabled and
+   * the safe level permits, the image is embedded as a Base64 data URI.
    *
    * NOTE: When the document has both 'data-uri' and 'allow-uri-read' enabled
    * and the resolved image URL is a remote URI, this method returns a Promise
@@ -474,6 +475,8 @@ export class AbstractNode {
    * @returns {Promise<string>} a Promise resolving to a String reference or data URI.
    */
   async imageUri(targetImage, assetDirKey = 'imagesdir') {
+    // A data URI is already an embedded image, so use it as-is rather than reading or re-encoding it.
+    if (targetImage.startsWith('data:')) return targetImage
     const doc = this.document
     if (doc.safe < SafeMode.SECURE && doc.hasAttribute('data-uri')) {
       let imagesBase

--- a/packages/core/src/converter/html5.js
+++ b/packages/core/src/converter/html5.js
@@ -833,7 +833,9 @@ ${await node.content()}
     const slash = this._voidSlash
     let img, src
     if (
-      (node.hasAttribute('format', 'svg') || target.includes('.svg')) &&
+      (node.hasAttribute('format', 'svg') ||
+        target.includes('.svg') ||
+        target.startsWith('data:image/svg+xml')) &&
       node.document.safe < SafeMode.SECURE
     ) {
       if (node.hasOption('inline')) {
@@ -1674,7 +1676,9 @@ Your browser does not support the video tag.
       if (node.hasAttribute('title'))
         attrs += ` title="${node.getAttribute('title')}"`
       if (
-        (node.hasAttribute('format', 'svg') || target.includes('.svg')) &&
+        (node.hasAttribute('format', 'svg') ||
+          target.includes('.svg') ||
+          target.startsWith('data:image/svg+xml')) &&
         node.document.safe < SafeMode.SECURE
       ) {
         if (node.hasOption('inline')) {
@@ -1767,12 +1771,17 @@ Your browser does not support the video tag.
 
   // NOTE expose readSvgContents for Bespoke converter
   async readSvgContents(node, target) {
-    let svg = await node.readContents(target, {
-      start: node.document.getAttribute('imagesdir'),
-      normalize: true,
-      label: 'SVG',
-      warnIfEmpty: true,
-    })
+    // A data-URI carries the SVG in the target itself (e.g. an embedded diagram
+    // produced with `:data-uri:`), so decode it directly rather than trying to
+    // read it as a file or remote URI.
+    let svg = target.startsWith('data:')
+      ? this._decodeDataUri(target)
+      : await node.readContents(target, {
+          start: node.document.getAttribute('imagesdir'),
+          normalize: true,
+          label: 'SVG',
+          warnIfEmpty: true,
+        })
     if (!svg) return null
     if (!svg.startsWith('<svg')) svg = svg.replace(SvgPreambleRx, '')
     // Fix incomplete SVG start tag (missing closing >) by inserting > before the first child element.
@@ -1803,6 +1812,27 @@ Your browser does not support the video tag.
   }
 
   // ── Private helpers ─────────────────────────────────────────────────────────
+
+  /**
+   * Decode an inline `data:` URI to its text contents (e.g. an SVG document) so
+   * an image whose target is a data-URI can be embedded inline. Supports both
+   * Base64 (`;base64,`) and percent-encoded payloads. Returns null when the
+   * payload is missing.
+   *
+   * @internal
+   * @private
+   */
+  _decodeDataUri(target) {
+    const comma = target.indexOf(',')
+    if (comma === -1) return null
+    const meta = target.slice('data:'.length, comma)
+    const data = target.slice(comma + 1)
+    if (/;base64\b/i.test(meta)) {
+      const bytes = Uint8Array.from(atob(data), (c) => c.charCodeAt(0))
+      return new TextDecoder('utf-8').decode(bytes)
+    }
+    return decodeURIComponent(data)
+  }
 
   /**
    * @internal

--- a/packages/core/test/blocks.images.test.js
+++ b/packages/core/test/blocks.images.test.js
@@ -191,6 +191,19 @@ image::circle.svg[Tiger,100]
       assert.match(output, /<svg\s[^>]*width="100">/)
     })
 
+    test('passes a data URI image target through to the img src unchanged', async () => {
+      await usingMemoryLogger(async (logger) => {
+        const dataUri =
+          'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+        const output = await convertStringToEmbedded(`image::${dataUri}[Dot]`, {
+          safe: 'safe',
+          attributes: { 'data-uri': '', 'allow-uri-read': '' },
+        })
+        assertCss(output, `img[src="${dataUri}"]`, 1)
+        assert.equal(logger.messages.length, 0)
+      })
+    })
+
     test('do not throw exception if SVG to inline is empty', async () => {
       await usingMemoryLogger(async (logger) => {
         const input = 'image::empty.svg[nada,opts=inline]'

--- a/packages/core/test/converter.test.js
+++ b/packages/core/test/converter.test.js
@@ -553,4 +553,40 @@ describe('Custom converters', () => {
     assert.ok(result != null, 'SVG does not exist or cannot be read')
     assert.ok(result.startsWith('<svg'))
   })
+
+  test('readSvgContents decodes a base64 data-URI target', async () => {
+    const doc = await load('image::diagram[format=svg,opts=inline]', {
+      safe: 'safe',
+    })
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg"><circle r="1"/></svg>'
+    const target = `data:image/svg+xml;base64,${Buffer.from(svg, 'utf8').toString('base64')}`
+    const result = await doc.converter.readSvgContents(doc.blocks[0], target)
+    assert.equal(result, svg)
+  })
+
+  test('readSvgContents decodes a percent-encoded data-URI target', async () => {
+    const doc = await load('image::diagram[format=svg,opts=inline]', {
+      safe: 'safe',
+    })
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg"><circle r="1"/></svg>'
+    const target = `data:image/svg+xml,${encodeURIComponent(svg)}`
+    const result = await doc.converter.readSvgContents(doc.blocks[0], target)
+    assert.equal(result, svg)
+  })
+
+  test('an inline SVG image with a data-URI target is embedded, inferring the SVG format from the media type', async () => {
+    const svg = '<svg xmlns="http://www.w3.org/2000/svg"><circle r="1"/></svg>'
+    const target = `data:image/svg+xml;base64,${Buffer.from(svg, 'utf8').toString('base64')}`
+    const doc = await load(`image::${target}[opts=inline]`, {
+      safe: 'safe',
+    })
+    assert.ok(
+      !doc.blocks[0].hasAttribute('format'),
+      'expected no explicit format attribute'
+    )
+    const html = await doc.convert()
+    assert.ok(html.includes('<svg'), 'expected inline <svg> in the output')
+    assert.ok(html.includes('<circle r="1"/>'), 'expected SVG contents inline')
+    assert.ok(!html.includes('<img'), 'expected no <img> fallback')
+  })
 })

--- a/packages/core/test/shims/setup.js
+++ b/packages/core/test/shims/setup.js
@@ -10,7 +10,16 @@ if (typeof globalThis.Buffer === 'undefined') {
     static from(data, encoding) {
       if (typeof data === 'string') {
         const encoded = new TextEncoder().encode(data)
-        return Object.assign(encoded, { toString: () => data })
+        return Object.assign(encoded, {
+          toString: (enc = 'utf8') => {
+            if (enc === 'base64') {
+              let binary = ''
+              for (const byte of encoded) binary += String.fromCharCode(byte)
+              return btoa(binary)
+            }
+            return data
+          },
+        })
       }
       return new Uint8Array(data)
     }

--- a/packages/core/types/abstract_node.d.ts
+++ b/packages/core/types/abstract_node.d.ts
@@ -234,9 +234,10 @@ export abstract class AbstractNode {
      * Construct a URI reference or data URI to the target image.
      *
      * If the target image is already a URI it is left untouched (unless data-uri
-     * conversion is requested). The image is resolved relative to the directory
-     * named by assetDirKey. When data-uri is enabled and the safe level permits,
-     * the image is embedded as a Base64 data URI.
+     * conversion is requested). If the target image is a data URI, then it is
+     * already an embedded image, so it is returned as-is. The image is resolved
+     * relative to the directory named by assetDirKey. When data-uri is enabled and
+     * the safe level permits, the image is embedded as a Base64 data URI.
      *
      * NOTE: When the document has both 'data-uri' and 'allow-uri-read' enabled
      * and the resolved image URL is a remote URI, this method returns a Promise


### PR DESCRIPTION
Decode the target of an image with the inline option directly when it is a data: URI rather than reading it as a file or remote URI, so an SVG carried in the target itself (e.g. an embedded diagram) is rendered as inline <svg>. Support both Base64 and percent-encoded payloads, and infer the SVG format from the image/svg+xml media type so format=svg is no longer required.

Return a data: URI image target as-is from AbstractNode#imageUri so a raster image target is passed through to the img src without attempting to fetch it via the Fetch API, which logged a spurious "could not retrieve image data from URI" warning when data-uri and allow-uri-read were both set.

Mirrors the upstream Asciidoctor (Ruby) change for asciidoctor/asciidoctor#3791.