### PR TITLE
fix(include): recognize allow-uri-read declared with an empty value

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,6 +10,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 Bug Fixes::
 
+* Fix `allow-uri-read` not being recognised when declared with an empty value (e.g. `allow-uri-read=` or `attributes: { 'allow-uri-read': '' }`) — include resolution checked the attribute's truthiness via `getAttribute`, but `''` is falsy in JavaScript while Asciidoctor treats the mere presence of an attribute as enabled; the include reader (Node and browser modes) now checks presence via `hasAttribute`, matching Ruby's `attr?` semantics
 * Fix incorrect generated type declarations for `async` substitutor methods — `applySubs`, `subQuotes`, `subMacros`, `subPostReplacements`, `subSource`, `subCallouts`, `highlightSource`, `restorePassthroughs` and `parseAttributes` are all `async` but their JSDoc `@returns` declared the unwrapped type (e.g. `string`), so the emitted `.d.ts` advertised `string` instead of `Promise<string>`; callers following the types could concatenate the returned Promise and produce `[object Promise]`. The JSDoc now declares `Promise<…>` and the `.d.ts` was regenerated
 
 == v4.0.0 (2026-06-22)

--- a/packages/core/src/browser/reader.js
+++ b/packages/core/src/browser/reader.js
@@ -92,7 +92,7 @@ export function resolveBrowserIncludePath(reader, target, attrlist) {
     // ── Rule 2: target is an absolute URL (http:// / https:// / …) ───────────
   } else if (isUriish(pTarget)) {
     const descends = pathResolver.descendsFrom(pTarget, baseDir)
-    if (descends === false && !doc.getAttribute('allow-uri-read')) {
+    if (descends === false && !doc.hasAttribute('allow-uri-read')) {
       return reader.replaceNextLine(_linkReplacement(reader, target, attrlist))
     }
     incPath = relpath = pTarget
@@ -126,7 +126,7 @@ export function resolveBrowserIncludePath(reader, target, attrlist) {
   } else {
     // Nested include: context dir is an absolute URL.
     const ctxDescends = pathResolver.descendsFrom(ctxDir, baseDir)
-    if (ctxDescends !== false || doc.getAttribute('allow-uri-read')) {
+    if (ctxDescends !== false || doc.hasAttribute('allow-uri-read')) {
       incPath = `${ctxDir}/${pTarget}`
       relpath = ctxDescends !== false ? incPath.slice(ctxDescends) : pTarget
     } else {

--- a/packages/core/src/reader.js
+++ b/packages/core/src/reader.js
@@ -1448,7 +1448,7 @@ export class PreprocessorReader extends Reader {
     }
 
     if (isUriish(target) || typeof this._dir !== 'string') {
-      if (!doc.getAttribute('allow-uri-read')) {
+      if (!doc.hasAttribute('allow-uri-read')) {
         this._logWarn(
           `cannot include contents of URI: ${target} (allow-uri-read attribute not enabled)`,
           { sourceLocation: this.cursor }

--- a/packages/core/test/browser.reader.test.js
+++ b/packages/core/test/browser.reader.test.js
@@ -28,6 +28,7 @@ function makeDoc({
     },
     hasAttribute: (name) => {
       if (name === 'compat-mode') return compatMode
+      if (name === 'allow-uri-read') return allowUriRead
       return false
     },
   }

--- a/packages/core/test/include-http.test.js
+++ b/packages/core/test/include-http.test.js
@@ -56,6 +56,16 @@ describe('Include http URI', () => {
     assert.ok(html.includes('Foo'), `Expected "Foo" in:\n${html}`)
   })
 
+  test('should include file with an absolute http URI when allow-uri-read has an empty value', async () => {
+    // Asciidoctor treats the mere presence of an attribute (even with an empty
+    // value) as "enabled"; '' is falsy in JS so presence must be checked, not truthiness.
+    const html = await convert(`include::${baseUri}/foo.adoc[]`, {
+      safe: 'safe',
+      attributes: { 'allow-uri-read': '' },
+    })
+    assert.ok(html.includes('Foo'), `Expected "Foo" in:\n${html}`)
+  })
+
   test('should include file with an absolute http URI when base_dir is an absolute http URI', async () => {
     const html = await convert(`include::${baseUri}/foo.adoc[]`, {
       safe: 'safe',


### PR DESCRIPTION
The include reader gated URI reads on getAttribute('allow-uri-read') truthiness, but '' is falsy in JavaScript while Asciidoctor treats the mere presence of an attribute as enabled. Check presence via hasAttribute (matching Ruby's attr?) in both Node and browser readers.