### PR TITLE
fix(templates): apply JS templates regardless of extension and module format

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,10 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 == Unreleased
 
+Bug Fixes::
+
+* Fix JavaScript templates not being applied depending on their file extension and the project's module format ({uri-repo}/issues/1841[#1841]) — a `.js` template in a `"type": "module"` (ESM) project crashed with `template.render is not a function`, and `.mjs` templates were silently ignored (the extension was not even recognised). The template loader used a CommonJS `require()` for `.js`/`.cjs` files, which returned the ESM namespace object (not the render function) for ESM `.js` files and did not handle `.mjs` at all. `.js` and `.mjs` templates are now loaded with a dynamic `import()` (which Node resolves as either ESM or CommonJS) and the render function is taken from the module's default export, so all combinations of extension (`.js`, `.cjs`, `.mjs`) and module format (ESM or CommonJS) work. The same loading is applied to the optional `helpers` file (`helpers.js`/`helpers.cjs`/`helpers.mjs`), which can now also be an ES module
+
 == v4.0.1 (2026-07-01)
 
 Bug Fixes::

--- a/packages/core/src/converter/template.js
+++ b/packages/core/src/converter/template.js
@@ -8,8 +8,7 @@
 //   - Ruby File.directory?/File.file? → fsp.stat().isDirectory()/isFile() (async).
 //   - Ruby File.basename / File.expand_path → node:path basename / resolve.
 //   - PathResolver.system_path → pathResolver.systemPath().
-//   - template.render(node, opts) → template.render({node, opts, helpers}).
-//   - Helpers loaded from helpers.js/helpers.cjs; can export configure(enginesContext).
+//   - template.render(node, opts) → template.render({node, opts, helpers}).//   - Helpers loaded from helpers.js/helpers.cjs/helpers.mjs; can export configure(enginesContext).
 //   - Custom engines registered via TemplateConverter.TemplateEngine.register(ext, adapter).
 //   - Thread safety / Mutex → not needed (single-threaded JS).
 //   - load_eruby / eRuby support → not applicable in JS environment.
@@ -19,6 +18,7 @@
 import { ConverterBase } from '../converter.js'
 import { PathResolver } from '../path_resolver.js'
 import { createRequire } from 'node:module'
+import { pathToFileURL } from 'node:url'
 import { promises as fsp } from 'node:fs'
 import path from 'node:path'
 
@@ -288,7 +288,11 @@ export class TemplateConverter extends ConverterBase {
       if (!(await _isFile(file))) continue
 
       // Collect helpers separately; process after all templates.
-      if (basename === 'helpers.js' || basename === 'helpers.cjs') {
+      if (
+        basename === 'helpers.js' ||
+        basename === 'helpers.cjs' ||
+        basename === 'helpers.mjs'
+      ) {
         helpersFile = file
         continue
       }
@@ -356,8 +360,8 @@ export class TemplateConverter extends ConverterBase {
         const pugOpts = { ...(this.engineOptions.pug ?? {}), filename: file }
         const renderFn = pug.compileFile(file, pugOpts)
         template = { render: renderFn, file }
-      } else if (ext === 'js' || ext === 'cjs') {
-        const renderFn = _require(file)
+      } else if (ext === 'js' || ext === 'cjs' || ext === 'mjs') {
+        const renderFn = await _loadModule(file, ext)
         template = { render: renderFn, file }
       } else {
         // Fall back to custom TemplateEngine registry.
@@ -372,16 +376,20 @@ export class TemplateConverter extends ConverterBase {
       result[name] = template
     }
 
-    // Load helpers if found (or if a helpers.js exists at the top of the dir).
-    const fallbackHelpers = path.join(templateDir, 'helpers.js')
-    const fallbackHelpersCjs = path.join(templateDir, 'helpers.cjs')
-    if (!helpersFile && (await _isFile(fallbackHelpers)))
-      helpersFile = fallbackHelpers
-    if (!helpersFile && (await _isFile(fallbackHelpersCjs)))
-      helpersFile = fallbackHelpersCjs
+    // Load helpers if found (or if a helpers file exists at the top of the dir).
+    if (!helpersFile) {
+      for (const ext of ['js', 'cjs', 'mjs']) {
+        const fallback = path.join(templateDir, `helpers.${ext}`)
+        if (await _isFile(fallback)) {
+          helpersFile = fallback
+          break
+        }
+      }
+    }
 
     if (helpersFile) {
-      const ctx = _require(helpersFile)
+      const helpersExt = helpersFile.slice(helpersFile.lastIndexOf('.') + 1)
+      const ctx = await _loadModule(helpersFile, helpersExt)
       if (typeof ctx.configure === 'function') ctx.configure(enginesCtx)
       result['helpers.js'] = { file: helpersFile, ctx }
     }
@@ -408,6 +416,32 @@ export class TemplateConverter extends ConverterBase {
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Load a JavaScript module (template render function or helpers object) by
+ * file extension.
+ *
+ * - `.cjs` files are always CommonJS: require() returns `module.exports`.
+ * - `.js` and `.mjs` files are loaded with a dynamic `import()`, which Node
+ *   resolves as either ES modules or CommonJS. The export is taken from the
+ *   module's default export (`export default …` in ESM, `module.exports = …`
+ *   in CommonJS via interop); when there is no default export the module
+ *   namespace is returned instead, so ESM helpers exposing named exports
+ *   (`export function configure() {}`) work too.
+ * @param {string} file - absolute path to the module file
+ * @param {string} ext - file extension without the leading dot ('js' | 'cjs' | 'mjs')
+ * @returns {Promise<*>} the module's default export, or its namespace
+ * @internal
+ * @private
+ */
+async function _loadModule(file, ext) {
+  if (ext === 'cjs') {
+    const mod = _require(file)
+    return mod?.default ? mod.default : mod
+  }
+  const mod = await import(pathToFileURL(file).href)
+  return mod.default ?? mod
+}
 
 /**
  * @internal

--- a/packages/core/test/converter.template.test.js
+++ b/packages/core/test/converter.template.test.js
@@ -100,6 +100,77 @@ describe('Using a template converter', () => {
     )
   })
 
+  // https://github.com/asciidoctor/asciidoctor.js/issues/1841
+  // A JavaScript template must be applied regardless of its file extension
+  // (.js, .cjs, .mjs) and of the module format of the project (ESM or CJS).
+  describe('should apply a JavaScript template regardless of extension/format', () => {
+    for (const { name, dir, cssClass } of [
+      {
+        name: 'a .cjs file (always CommonJS)',
+        dir: 'js',
+        cssClass: 'paragraph-js',
+      },
+      {
+        name: 'a .js file in a "type": "commonjs" project (CommonJS)',
+        dir: 'js-cjs',
+        cssClass: 'paragraph-js-cjs',
+      },
+      {
+        name: 'a .js file in a "type": "module" project (ESM)',
+        dir: 'js-esm',
+        cssClass: 'paragraph-js-esm',
+      },
+      {
+        name: 'a .mjs file (always ESM)',
+        dir: 'mjs',
+        cssClass: 'paragraph-mjs',
+      },
+    ]) {
+      test(name, async () => {
+        const result = await convert('content', {
+          safe: 'safe',
+          backend: 'html5',
+          template_dir: join(TEMPLATES_DIR, dir),
+        })
+        assert.ok(
+          result.includes(`<p class="${cssClass}">content</p>`),
+          `Unexpected output:\n${result}`
+        )
+      })
+    }
+  })
+
+  // A helpers file must be loaded regardless of its extension and module
+  // format, just like the render templates it supports.
+  describe('should load a helpers file regardless of extension/format', () => {
+    for (const { name, dir, cssClass, greeting } of [
+      {
+        name: 'ESM helpers.js with named exports',
+        dir: 'js-esm-helpers',
+        cssClass: 'paragraph-esm-helpers',
+        greeting: 'esm-helper',
+      },
+      {
+        name: 'ESM helpers.mjs with a default export object',
+        dir: 'mjs-helpers',
+        cssClass: 'paragraph-mjs-helpers',
+        greeting: 'mjs-helper',
+      },
+    ]) {
+      test(name, async () => {
+        const result = await convert('content', {
+          safe: 'safe',
+          backend: 'html5',
+          template_dir: join(TEMPLATES_DIR, dir),
+        })
+        assert.ok(
+          result.includes(`<p class="${cssClass}">${greeting}:content</p>`),
+          `Unexpected output:\n${result}`
+        )
+      })
+    }
+  })
+
   test('should handle a given node', async () => {
     const doc = await load('content', {
       safe: 'safe',

--- a/packages/core/test/fixtures/templates/js-cjs/package.json
+++ b/packages/core/test/fixtures/templates/js-cjs/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/packages/core/test/fixtures/templates/js-cjs/paragraph.js
+++ b/packages/core/test/fixtures/templates/js-cjs/paragraph.js
@@ -1,0 +1,4 @@
+// CommonJS template: `.js` file in a `"type": "commonjs"` project.
+module.exports = function ({ node }) {
+  return `<p class="paragraph-js-cjs">${node.getContent()}</p>`
+}

--- a/packages/core/test/fixtures/templates/js-esm-helpers/helpers.js
+++ b/packages/core/test/fixtures/templates/js-esm-helpers/helpers.js
@@ -1,0 +1,5 @@
+// ESM helpers exposed as named exports (no default export): the loader must
+// fall back to the module namespace so `helpers.greeting()` resolves.
+export function greeting() {
+  return 'esm-helper'
+}

--- a/packages/core/test/fixtures/templates/js-esm-helpers/package.json
+++ b/packages/core/test/fixtures/templates/js-esm-helpers/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/core/test/fixtures/templates/js-esm-helpers/paragraph.js
+++ b/packages/core/test/fixtures/templates/js-esm-helpers/paragraph.js
@@ -1,0 +1,3 @@
+export default function ({ node, helpers }) {
+  return `<p class="paragraph-esm-helpers">${helpers.greeting()}:${node.getContent()}</p>`
+}

--- a/packages/core/test/fixtures/templates/js-esm/package.json
+++ b/packages/core/test/fixtures/templates/js-esm/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/packages/core/test/fixtures/templates/js-esm/paragraph.js
+++ b/packages/core/test/fixtures/templates/js-esm/paragraph.js
@@ -1,0 +1,4 @@
+// ESM template: `.js` file in a `"type": "module"` project, default export.
+export default function ({ node }) {
+  return `<p class="paragraph-js-esm">${node.getContent()}</p>`
+}

--- a/packages/core/test/fixtures/templates/mjs-helpers/helpers.mjs
+++ b/packages/core/test/fixtures/templates/mjs-helpers/helpers.mjs
@@ -1,0 +1,6 @@
+// ESM helpers exposed as a default export object.
+export default {
+  greeting() {
+    return 'mjs-helper'
+  },
+}

--- a/packages/core/test/fixtures/templates/mjs-helpers/paragraph.mjs
+++ b/packages/core/test/fixtures/templates/mjs-helpers/paragraph.mjs
@@ -1,0 +1,3 @@
+export default function ({ node, helpers }) {
+  return `<p class="paragraph-mjs-helpers">${helpers.greeting()}:${node.getContent()}</p>`
+}

--- a/packages/core/test/fixtures/templates/mjs/paragraph.mjs
+++ b/packages/core/test/fixtures/templates/mjs/paragraph.mjs
@@ -1,0 +1,4 @@
+// ESM template: `.mjs` file is always an ES module, default export.
+export default function ({ node }) {
+  return `<p class="paragraph-mjs">${node.getContent()}</p>`
+}


### PR DESCRIPTION
A `.js` template in a `"type": "module"` (ESM) project crashed with `template.render is not a function`, and `.mjs` templates were silently ignored (the extension was not even recognised). The loader used a CommonJS `require()` for `.js`/`.cjs`, which returns the ESM namespace object (not the render function) for ESM `.js` files, and did not handle `.mjs` at all.

`.js` and `.mjs` templates (and the optional helpers file) are now loaded with a dynamic `import()`, which Node resolves as either ESM or CommonJS, taking the export from the module's default export. All combinations of extension (`.js`, `.cjs`, `.mjs`) and module format (ESM or CommonJS) now apply the template correctly.

Fixes #1841