### PR TITLE
fix(table): render AsciiDoc cell content in nested tables

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,10 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 == Unreleased
 
+Bug Fixes::
+
+* Fix AsciiDoc table cells (`a`) losing their content when they belong to a table that is itself nested inside another AsciiDoc cell — the deeper cells rendered as an empty `<div class="content"></div>` (text became invisible). `Document#convert` computes each AsciiDoc cell's inner content in `_convertAsciiDocCells`, but that pass only ran on the root document (guarded by `!parentDocument`) and, when it converted an AsciiDoc cell's inner document, never recursed into the tables *inside* that inner document. So a nested table's own AsciiDoc cells were rendered before their `_innerContent` was ever set. The pass now recurses into a cell's inner document before rendering it, so AsciiDoc cells at any nesting depth have their content computed first
+
 == v4.0.2 (2026-07-06)
 
 Improvements::

--- a/packages/core/src/document.js
+++ b/packages/core/src/document.js
@@ -1594,6 +1594,10 @@ export class Document extends AbstractBlock {
                 cell._innerDocument &&
                 cell._innerContent == null
               ) {
+                // Recurse into the inner document first so that AsciiDoc cells
+                // of any nested table have their content computed before the
+                // inner document (and the nested table) is rendered.
+                await this._convertAsciiDocCells(cell._innerDocument)
                 cell._innerContent = await cell._innerDocument.convert()
               }
             }

--- a/packages/core/test/tables.psv-asciidoc-cells.test.js
+++ b/packages/core/test/tables.psv-asciidoc-cells.test.js
@@ -627,6 +627,26 @@ The word 'askew' is emphasized.`
       )
     })
 
+    test('AsciiDoc cell inside a nested table should render its content', async () => {
+      const input = `[cols="2a"]
+|===
+a|
+[cols="1,1a"]
+!===
+!label
+!nested asciidoc content
+!===
+|===`
+      const output = await convertStringToEmbedded(input)
+      assertCss(output, 'table table', 1)
+      // The nested AsciiDoc cell must render its paragraph, not an empty div.
+      assertXpath(
+        output,
+        '//table//table//td/div[@class="content"]/div[@class="paragraph"]/p[text()="nested asciidoc content"]',
+        1
+      )
+    })
+
     test('can set format of nested table to psv', async () => {
       const input = `[cols="2*"]
 |===


### PR DESCRIPTION
Text became invisible in AsciiDoc (`a`) cells of a table nested inside another AsciiDoc cell: the deeper cells rendered as an empty `<div class="content"></div>`.

`Document#convert` computes each AsciiDoc cell's inner content in `_convertAsciiDocCells`, but that pass only ran on the root document (guarded by `!parentDocument`) and, when it converted an AsciiDoc cell's inner document, never recursed into the tables inside that inner document. So a nested table's own AsciiDoc cells were rendered before their `_innerContent` was ever set.

The pass now recurses into a cell's inner document before rendering it, so AsciiDoc cells at any nesting depth have their content computed first.

Closes #1850