### PR TITLE
docs(typedoc): display the package version and publish a major.minor docs alias

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,6 +113,9 @@ jobs:
           TAG="${GITHUB_REF#refs/tags/v}"
           if [[ "$TAG" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-(alpha|beta|rc)\. ]]; then
             echo "folder=${BASH_REMATCH[1]}-dev" >> "$GITHUB_OUTPUT"
+          elif [[ "$TAG" =~ ^([0-9]+\.[0-9]+)\.[0-9]+$ ]]; then
+            echo "folder=$TAG" >> "$GITHUB_OUTPUT"
+            echo "alias=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
           else
             echo "folder=$TAG" >> "$GITHUB_OUTPUT"
           fi
@@ -121,3 +124,10 @@ jobs:
         with:
           folder: packages/core/build/docs
           target-folder: ${{ steps.dest.outputs.folder }}
+      # e.g. 4.0 always points to the docs of the latest 4.0.x release
+      - name: Publish version alias to gh-pages
+        if: steps.dest.outputs.alias
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: packages/core/build/docs
+          target-folder: ${{ steps.dest.outputs.alias }}

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,10 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 == Unreleased
 
+Infrastructure::
+
+* Display the package version number in the generated TypeDoc API documentation (`includeVersion` option), so both the `@asciidoctor/core` API docs and the `asciidoctor` CLI docs show which release they document (e.g. `@asciidoctor/core - v4.0.3`)
+
 == v4.0.3 (2026-07-13)
 
 Bug Fixes::

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 Infrastructure::
 
 * Display the package version number in the generated TypeDoc API documentation (`includeVersion` option), so both the `@asciidoctor/core` API docs and the `asciidoctor` CLI docs show which release they document (e.g. `@asciidoctor/core - v4.0.3`)
+* Publish a `major.minor` alias of the TypeDoc API documentation on each stable release — e.g. releasing v4.0.4 (re)deploys the docs to both `4.0.4/` and `4.0/` on GitHub Pages, so the `4.0` URL always points to the documentation of the latest 4.0.x release
 
 == v4.0.3 (2026-07-13)
 

--- a/packages/asciidoctor/tsconfig.docs.json
+++ b/packages/asciidoctor/tsconfig.docs.json
@@ -9,6 +9,7 @@
   "typedocOptions": {
     "entryPoints": ["types/cli.d.ts"],
     "out": "build/docs",
+    "includeVersion": true,
     "navigationLinks": {
       "API": "../"
     }

--- a/packages/core/tsconfig.docs.json
+++ b/packages/core/tsconfig.docs.json
@@ -9,6 +9,7 @@
   "typedocOptions": {
     "entryPoints": ["types/index.d.ts"],
     "out": "build/docs",
+    "includeVersion": true,
     "navigationLinks": {
       "CLI": "./cli/"
     }


### PR DESCRIPTION

#### Display the package version in the generated TypeDoc documentation

Enable TypeDoc's `includeVersion` option in both docs configs, so the generated documentation shows which release it documents:

- `@asciidoctor/core` API docs → **@asciidoctor/core - v4.0.3**
- `asciidoctor` CLI docs → **asciidoctor - v4.0.3**

The version is read automatically from each package's `package.json`, so nothing needs to be maintained manually on release.

#### Publish a `major.minor` docs alias on each stable release

The release workflow now deploys the TypeDoc documentation to a second `major.minor` folder on GitHub Pages. For example, releasing v4.0.4 (re)deploys the docs to both `4.0.4/` and `4.0/`, so the `4.0` URL always points to the documentation of the latest 4.0.x release.

Prereleases (alpha/beta/rc) are unaffected and keep going to `X.Y.Z-dev` only.