### PR TITLE
fix(extensions): parse inline macro content into attributes per contentModel config

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,14 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 == Unreleased
 
+Bug Fixes::
+
+* Fix inline macro extensions ignoring the `contentModel`/`positionalAttrs` (or the DSL `contentModel()`/`positionalAttributes()`/`resolveAttributes()` setters) configuration, so the macro's bracket content was never parsed into named/positional attributes and always ended up as a raw string in `attributes.text` instead — e.g. `registry.inlineMacro(function () { this.named('emoji'); this.positionalAttributes('size'); this.process(...) })` produced `{ text: '2x' }` instead of `{ '1': '2x', size: '2x' }` for `emoji:smile[2x]`. `Substitutors#subMacros` (the inline macro substitution path in `substitutors.js`) read the extension config with keys that were never populated by the DSL/static config ({uri-repo}/issues/1857[#1857])
+
+Improvements::
+
+* Extension `Processor` config keys (`contentModel`, `positionalAttrs`, `defaultAttrs`) now use `camelCase` consistently across every registration style — the DSL setters, class-based `static config`, and the block/inline macro substitution code that reads them. The legacy Ruby-style `snake_case` keys (`content_model`, `positional_attrs`, `pos_attrs`, `default_attrs`) are still accepted for backward compatibility when a processor class declares its config directly (`static config = { content_model: 'attributes' }` or `MyProcessor.config = { content_model: 'attributes' }`). `Processor.config` also gained a static setter, so assigning a static config object after the class declaration (as shown in the `BlockMacroProcessor`/`InlineMacroProcessor` JSDoc examples) no longer throws a `TypeError`
+
 == v4.0.4 (2026-07-15)
 
 Improvements::

--- a/packages/core/CLAUDE.md
+++ b/packages/core/CLAUDE.md
@@ -47,7 +47,7 @@ When converting or extending code, follow the conventions established in the exi
 - **Ruby module methods → named exports** (e.g. `Asciidoctor.load` → `export function load`).
 - **Ruby mixins / `include`** → plain objects applied with `Object.assign(instance, mixin)` or helper functions like `applyLogging()`.
 - **Ruby class methods (`def self.foo`)** → `static foo()` on the JS class.
-- **Ruby symbols (`:key`)** → plain strings (`'key'`), including config option keys which keep `snake_case`.
+- **Ruby symbols (`:key`)** → plain strings (`'key'`), and internal AST-node constructor options (e.g. `new Block(parent, ctx, { content_model: 'empty' })`) keep `snake_case` to mirror the Ruby kwargs. **Exception:** `Extensions.Processor` config keys (`contentModel`, `positionalAttrs`, `defaultAttrs`) use `camelCase` — the legacy `snake_case` Ruby-style keys are still accepted when a user declares a static `config` object directly, normalized by `normalizeLegacyConfigAliases()` in `src/extensions.js`.
 - **Ruby predicates (`attr?`, `title?`)** → `hasAttr()`, `hasTitle()`, etc.
 - **Ruby `nil` / `.nil_or_empty?`** → `null` / `!val` or explicit `== null || === ''` checks.
 - **Ruby `.to_i`** → `parseInt(val, 10)` (returns `0` for `null`/non-numeric).

--- a/packages/core/src/extensions.js
+++ b/packages/core/src/extensions.js
@@ -546,15 +546,14 @@ export class Processor {
   }
 
   constructor(config = {}) {
-    this.config = normalizeLegacyConfigAliases({
-      ...this.constructor.config,
-      ...config,
-    })
+    this.config = {
+      ...normalizeLegacyConfigAliases({ ...this.constructor.config }),
+      ...normalizeLegacyConfigAliases({ ...config }),
+    }
   }
 
   updateConfig(config) {
-    Object.assign(this.config, config)
-    normalizeLegacyConfigAliases(this.config)
+    Object.assign(this.config, normalizeLegacyConfigAliases({ ...config }))
   }
 
   process(..._args) {

--- a/packages/core/src/extensions.js
+++ b/packages/core/src/extensions.js
@@ -10,7 +10,11 @@
 //   - Ruby class << self → static methods.
 //   - Ruby Helpers.resolve_class → typeof fn === 'function' check.
 //   - Ruby @@class_var (InlineMacroProcessor.rx_cache) → static property.
-//   - Config option keys keep snake_case to match the Ruby/parser convention.
+//   - Config option keys (contentModel, positionalAttrs, defaultAttrs) use
+//     camelCase, matching normal JS style. The legacy snake_case Ruby-style
+//     keys (content_model, positional_attrs, pos_attrs, default_attrs) are
+//     still accepted when a user declares a static config object directly,
+//     for backward compatibility — see normalizeLegacyConfigAliases().
 //   - String class-name resolution (e.g. preprocessor 'MyClass') is not supported;
 //     pass the class constructor or an instance directly.
 //   - Parser.parseBlocks / block.subAttributes / block.assignCaption are forward
@@ -227,41 +231,41 @@ export const SyntaxProcessorDsl = {
   },
 
   contentModel(value) {
-    this.option('content_model', value)
+    this.option('contentModel', value)
   },
 
   /** Alias for {@link contentModel}. */
   parseContentAs(value) {
-    this.option('content_model', value)
+    this.option('contentModel', value)
   },
 
   positionalAttributes(...value) {
-    this.option('positional_attrs', value.flat().map(String))
+    this.option('positionalAttrs', value.flat().map(String))
   },
 
   /** Alias for {@link positionalAttributes}. */
   namePositionalAttributes(...value) {
-    this.option('positional_attrs', value.flat().map(String))
+    this.option('positionalAttrs', value.flat().map(String))
   },
 
   positionalAttrs(...value) {
-    this.option('positional_attrs', value.flat().map(String))
+    this.option('positionalAttrs', value.flat().map(String))
   },
 
   defaultAttributes(value) {
-    this.option('default_attrs', value)
+    this.option('defaultAttrs', value)
   },
 
   /** @deprecated Alias for {@link defaultAttributes}. */
   defaultAttrs(value) {
-    this.option('default_attrs', value)
+    this.option('defaultAttrs', value)
   },
 
   /**
    * Resolve and register positional attribute names and default values.
    *
    * Accepts any of:
-   *   resolveAttributes()             → positional_attrs: [], default_attrs: {}
+   *   resolveAttributes()             → positionalAttrs: [], defaultAttrs: {}
    *   resolveAttributes('foo', 'bar') → positional maps (Array-style)
    *   resolveAttributes({...})        → positional maps (Object-style)
    *
@@ -282,8 +286,8 @@ export const SyntaxProcessorDsl = {
     }
 
     if (args === true) {
-      this.option('positional_attrs', [])
-      this.option('default_attrs', {})
+      this.option('positionalAttrs', [])
+      this.option('defaultAttrs', {})
     } else if (Array.isArray(args)) {
       const names = []
       const defaults = {}
@@ -312,10 +316,10 @@ export const SyntaxProcessorDsl = {
         }
       }
       this.option(
-        'positional_attrs',
+        'positionalAttrs',
         names.filter((n) => n != null)
       )
-      this.option('default_attrs', defaults)
+      this.option('defaultAttrs', defaults)
     } else if (typeof args === 'object' && args !== null) {
       const names = []
       const defaults = {}
@@ -331,10 +335,10 @@ export const SyntaxProcessorDsl = {
         if (val) defaults[name] = val
       }
       this.option(
-        'positional_attrs',
+        'positionalAttrs',
         names.filter((n) => n != null)
       )
-      this.option('default_attrs', defaults)
+      this.option('defaultAttrs', defaults)
     } else {
       throw new Error(`unsupported attributes specification for macro: ${args}`)
     }
@@ -423,17 +427,17 @@ export const MacroProcessorDsl = {
   ...SyntaxProcessorDsl,
 
   /**
-   * Override: passing a falsy value sets content_model to :text instead of
+   * Override: passing a falsy value sets contentModel to 'text' instead of
    * configuring positional attributes.
    *
    * @param {...*} args - Positional attribute specifications.
    */
   resolveAttributes(...args) {
     if (args.length === 1 && !args[0]) {
-      this.option('content_model', 'text')
+      this.option('contentModel', 'text')
     } else {
       SyntaxProcessorDsl.resolveAttributes.call(this, ...args)
-      this.option('content_model', 'attributes')
+      this.option('contentModel', 'attributes')
     }
   },
 
@@ -467,6 +471,30 @@ export const InlineMacroProcessorDsl = {
 // ── Processor ────────────────────────────────────────────────────────────────
 
 /**
+ * Legacy Ruby-style snake_case config keys, mapped to the camelCase keys
+ * actually read by the parser/substitutor. Only consulted when a processor
+ * is declared with a raw static config object (e.g. `static config = {
+ * content_model: 'attributes' }`) that bypasses the DSL setters, which
+ * already write camelCase directly.
+ */
+const LEGACY_CONFIG_ALIASES = {
+  content_model: 'contentModel',
+  positional_attrs: 'positionalAttrs',
+  pos_attrs: 'positionalAttrs',
+  default_attrs: 'defaultAttrs',
+}
+
+/** @internal Fill in camelCase config keys from their legacy snake_case alias. */
+function normalizeLegacyConfigAliases(config) {
+  for (const [legacyKey, key] of Object.entries(LEGACY_CONFIG_ALIASES)) {
+    if (config[key] === undefined && config[legacyKey] !== undefined) {
+      config[key] = config[legacyKey]
+    }
+  }
+  return config
+}
+
+/**
  * Abstract base class for document and syntax processors.
  *
  * Provides a class-level config map (via static config / static option) and a
@@ -483,6 +511,16 @@ export class Processor {
   static get config() {
     if (!Object.hasOwn(this, '_config')) this._config = {}
     return this._config
+  }
+
+  /**
+   * Replace the static configuration map for this processor class, e.g.
+   * `ShoutBlock.config = { name: 'shout', contentModel: 'simple' }`.
+   *
+   * @param {object} value
+   */
+  static set config(value) {
+    this._config = value
   }
 
   /**
@@ -508,11 +546,15 @@ export class Processor {
   }
 
   constructor(config = {}) {
-    this.config = { ...this.constructor.config, ...config }
+    this.config = normalizeLegacyConfigAliases({
+      ...this.constructor.config,
+      ...config,
+    })
   }
 
   updateConfig(config) {
     Object.assign(this.config, config)
+    normalizeLegacyConfigAliases(this.config)
   }
 
   process(..._args) {
@@ -951,12 +993,12 @@ DocinfoProcessor.DSL = DocinfoProcessorDsl
  *
  * @example <caption>Custom delimited block that wraps content in a div</caption>
  * class ShoutBlock extends BlockProcessor {
+ *   static config = { name: 'shout', contexts: ['paragraph'], contentModel: 'simple' }
  *   process(parent, reader, attrs) {
  *     const block = this.createBlock(parent, 'paragraph', reader.readLines().join('\n').toUpperCase(), attrs)
  *     return block
  *   }
  * }
- * ShoutBlock.config = { name: 'shout', contexts: ['paragraph'], content_model: 'simple' }
  * Extensions.register(function () { this.block(ShoutBlock) })
  * // AsciiDoc usage: [shout]\nHello world
  */
@@ -975,7 +1017,7 @@ export class BlockProcessor extends Processor {
       this.config.contexts = new Set(ctx)
     }
 
-    this.config.content_model ??= 'compound'
+    this.config.contentModel ??= 'compound'
   }
 
   /**
@@ -999,7 +1041,7 @@ export class MacroProcessor extends Processor {
   constructor(name = null, config = {}) {
     super(config)
     this.name = name || this.config.name || null
-    this.config.content_model ??= 'attributes'
+    this.config.contentModel ??= 'attributes'
   }
 
   /**

--- a/packages/core/src/parser.js
+++ b/packages/core/src/parser.js
@@ -883,20 +883,26 @@ export class Parser {
                     target = expanded
                   }
                   const extConfig = extension.config
-                  if (extConfig.content_model === 'attributes') {
+                  const contentModel =
+                    extConfig.contentModel ?? extConfig.content_model
+                  if (contentModel === 'attributes') {
                     if (content)
                       await document.parseAttributes(
                         content,
-                        extConfig.positional_attrs ?? extConfig.pos_attrs ?? [],
+                        extConfig.positionalAttrs ??
+                          extConfig.positional_attrs ??
+                          extConfig.posAttrs ??
+                          extConfig.pos_attrs ??
+                          [],
                         { sub_input: true, into: attributes }
                       )
                   } else {
                     attributes.text = content ?? ''
                   }
-                  if (extConfig.default_attrs) {
-                    for (const [k, v] of Object.entries(
-                      extConfig.default_attrs
-                    )) {
+                  const defaultAttrs =
+                    extConfig.defaultAttrs ?? extConfig.default_attrs
+                  if (defaultAttrs) {
+                    for (const [k, v] of Object.entries(defaultAttrs)) {
                       attributes[k] ??= v
                     }
                   }
@@ -1396,14 +1402,20 @@ export class Parser {
             cloakedContext
           )
           const extConfig = extension.config
-          const contentModel = extConfig.content_model
+          const contentModel = extConfig.contentModel ?? extConfig.content_model
           if (contentModel !== 'skip') {
-            const posAttrs = extConfig.positional_attrs ?? extConfig.pos_attrs
+            const posAttrs =
+              extConfig.positionalAttrs ??
+              extConfig.positional_attrs ??
+              extConfig.posAttrs ??
+              extConfig.pos_attrs
             if (posAttrs && posAttrs.length > 0) {
               AttributeList.rekey(attributes, [null, ...posAttrs])
             }
-            if (extConfig.default_attrs) {
-              for (const [k, v] of Object.entries(extConfig.default_attrs)) {
+            const defaultAttrs =
+              extConfig.defaultAttrs ?? extConfig.default_attrs
+            if (defaultAttrs) {
+              for (const [k, v] of Object.entries(defaultAttrs)) {
                 attributes[k] ??= v
               }
             }

--- a/packages/core/src/substitutors.js
+++ b/packages/core/src/substitutors.js
@@ -498,19 +498,25 @@ export const Substitutors = {
             }
 
             const extConfig = extension.config
-            const defaultAttrs = extConfig.defaultAttrs
+            const defaultAttrs =
+              extConfig.defaultAttrs || extConfig.default_attrs
             const attributes = defaultAttrs ? { ...defaultAttrs } : {}
+            const contentModel =
+              extConfig.contentModel || extConfig.content_model
 
             if (content !== null && content !== undefined) {
               if (!content) {
-                if (extConfig.contentModel !== 'attributes')
-                  attributes.text = content
+                if (contentModel !== 'attributes') attributes.text = content
               } else {
                 content = this.normalizeText(content, true, true)
-                if (extConfig.contentModel === 'attributes') {
+                if (contentModel === 'attributes') {
                   await this.parseAttributes(
                     content,
-                    extConfig.positionalAttrs || extConfig.posAttrs || [],
+                    extConfig.positionalAttrs ||
+                      extConfig.positional_attrs ||
+                      extConfig.posAttrs ||
+                      extConfig.pos_attrs ||
+                      [],
                     { into: attributes }
                   )
                 } else {

--- a/packages/core/test/extensions.api.test.js
+++ b/packages/core/test/extensions.api.test.js
@@ -13,6 +13,8 @@ import {
   load,
   convert,
   InlineMacroProcessor,
+  BlockMacroProcessor,
+  BlockProcessor,
 } from '../src/index.js'
 
 describe('Extensions (API)', () => {
@@ -206,6 +208,126 @@ describe('Extensions (API)', () => {
     })
     await convert('emoji:smile[2x]', { doctype: 'inline' })
     assert.deepEqual(capturedAttrs, { 1: '2x', size: '2x' })
+  })
+
+  test('should parse inline macro content into positional/named attributes (legacy pos_attrs alias)', async () => {
+    let capturedAttrs
+    class EmojiInlineMacro extends InlineMacroProcessor {
+      static config = {
+        name: 'emoji',
+        content_model: 'attributes',
+        pos_attrs: ['size'],
+      }
+
+      process(parent, target, attrs) {
+        capturedAttrs = attrs
+        return this.createInline(parent, 'quoted', target, {})
+      }
+    }
+    Extensions.register(function () {
+      this.inlineMacro(EmojiInlineMacro)
+    })
+    await convert('emoji:smile[2x]', { doctype: 'inline' })
+    assert.deepEqual(capturedAttrs, { 1: '2x', size: '2x' })
+  })
+
+  test('should merge inline macro defaultAttrs with parsed attributes, content taking precedence', async () => {
+    let capturedAttrs
+    Extensions.register(function () {
+      this.inlineMacro('emoji', function () {
+        this.positionalAttributes('size')
+        this.defaultAttributes({ size: '1x', color: 'blue' })
+        this.process((parent, target, attrs) => {
+          capturedAttrs = attrs
+          return this.createInline(parent, 'quoted', target, {})
+        })
+      })
+    })
+    await convert('emoji:smile[2x]', { doctype: 'inline' })
+    assert.deepEqual(capturedAttrs, { size: '2x', color: 'blue', 1: '2x' })
+  })
+
+  test('should parse block macro content into positional/named attributes, merging in defaultAttrs', async () => {
+    let capturedAttrs
+    const registry = Extensions.create()
+    registry.blockMacro(function () {
+      this.named('badge')
+      this.positionalAttributes('size')
+      this.defaultAttributes({ color: 'blue' })
+      this.process(function (parent, target, attrs) {
+        capturedAttrs = { ...attrs }
+        return this.createBlock(parent, 'paragraph', target, {})
+      })
+    })
+    await convert('badge::icon[2x]', { extension_registry: registry })
+    assert.deepEqual(capturedAttrs, { 1: '2x', size: '2x', color: 'blue' })
+  })
+
+  test('should parse block macro content into positional/named attributes (class-based legacy snake_case config)', async () => {
+    let capturedAttrs
+    class BadgeBlockMacro extends BlockMacroProcessor {
+      static config = {
+        name: 'badge',
+        content_model: 'attributes',
+        positional_attrs: ['size'],
+        default_attrs: { color: 'blue' },
+      }
+
+      process(parent, target, attrs) {
+        capturedAttrs = { ...attrs }
+        return this.createBlock(parent, 'paragraph', target, {})
+      }
+    }
+    const registry = Extensions.create()
+    registry.blockMacro(BadgeBlockMacro)
+    await convert('badge::icon[2x]', { extension_registry: registry })
+    assert.deepEqual(capturedAttrs, { 1: '2x', size: '2x', color: 'blue' })
+  })
+
+  test('should rekey a block extension positional attribute per positionalAttributes()', async () => {
+    let capturedAttrs
+    const registry = Extensions.create()
+    registry.block(function () {
+      this.named('badge')
+      this.onContext('paragraph')
+      this.positionalAttributes('size')
+      this.process(function (parent, reader, attrs) {
+        capturedAttrs = { ...attrs }
+        return this.createBlock(
+          parent,
+          'paragraph',
+          reader.getLines().join('\n'),
+          attrs
+        )
+      })
+    })
+    await convert('[badge,2x]\nHello', { extension_registry: registry })
+    assert.equal(capturedAttrs.size, '2x')
+  })
+
+  test('should rekey a block extension positional attribute (class-based legacy snake_case config)', async () => {
+    let capturedAttrs
+    class BadgeBlock extends BlockProcessor {
+      static config = {
+        name: 'badge',
+        contexts: ['paragraph'],
+        positional_attrs: ['size'],
+      }
+
+      process(parent, reader, attrs) {
+        capturedAttrs = { ...attrs }
+        return this.createBlock(
+          parent,
+          'paragraph',
+          reader.getLines().join('\n'),
+          attrs
+        )
+      }
+    }
+    const registry = Extensions.create()
+    registry.block(BadgeBlock)
+    await convert('[badge,2x]\nHello', { extension_registry: registry })
+    assert.equal(capturedAttrs.size, '2x')
   })
 
   test('should register a block macro that creates a link', async () => {

--- a/packages/core/test/extensions.api.test.js
+++ b/packages/core/test/extensions.api.test.js
@@ -8,7 +8,12 @@
 import { describe, test, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 
-import { Extensions, load, convert } from '../src/index.js'
+import {
+  Extensions,
+  load,
+  convert,
+  InlineMacroProcessor,
+} from '../src/index.js'
 
 describe('Extensions (API)', () => {
   afterEach(() => {
@@ -165,6 +170,42 @@ describe('Extensions (API)', () => {
     })
     const html = await convert('label:[Checkbox]', { doctype: 'inline' })
     assert.equal(html, '<label>Checkbox</label>')
+  })
+
+  test('should parse inline macro content into positional/named attributes (DSL closure style)', async () => {
+    let capturedAttrs
+    Extensions.register(function () {
+      this.inlineMacro('emoji', function () {
+        this.positionalAttributes('size')
+        this.process((parent, target, attrs) => {
+          capturedAttrs = attrs
+          return this.createInline(parent, 'quoted', target, {})
+        })
+      })
+    })
+    await convert('emoji:smile[2x]', { doctype: 'inline' })
+    assert.deepEqual(capturedAttrs, { 1: '2x', size: '2x' })
+  })
+
+  test('should parse inline macro content into positional/named attributes (class-based style)', async () => {
+    let capturedAttrs
+    class EmojiInlineMacro extends InlineMacroProcessor {
+      static config = {
+        name: 'emoji',
+        content_model: 'attributes',
+        positional_attrs: ['size'],
+      }
+
+      process(parent, target, attrs) {
+        capturedAttrs = attrs
+        return this.createInline(parent, 'quoted', target, {})
+      }
+    }
+    Extensions.register(function () {
+      this.inlineMacro(EmojiInlineMacro)
+    })
+    await convert('emoji:smile[2x]', { doctype: 'inline' })
+    assert.deepEqual(capturedAttrs, { 1: '2x', size: '2x' })
   })
 
   test('should register a block macro that creates a link', async () => {

--- a/packages/core/test/extensions.registry.test.js
+++ b/packages/core/test/extensions.registry.test.js
@@ -123,7 +123,7 @@ describe('DSL aliases', () => {
     assert.ok(html.includes('bnd-ok'))
   })
 
-  test('MacroProcessorDsl.resolveAttributes with falsy arg sets content_model to text', async () => {
+  test('MacroProcessorDsl.resolveAttributes with falsy arg sets contentModel to text', async () => {
     const registry = Extensions.create()
     registry.inlineMacro(function () {
       this.named('noattr')

--- a/packages/core/test/extensions.test.js
+++ b/packages/core/test/extensions.test.js
@@ -8,6 +8,7 @@ import { describe, test, beforeEach } from 'node:test'
 import assert from 'node:assert/strict'
 
 import {
+  Processor,
   Preprocessor,
   TreeProcessor,
   Postprocessor,
@@ -693,6 +694,100 @@ describe('BlockProcessor', () => {
     const bp = new BlockProcessor('myblock', { contexts: ['sidebar'] })
     assert.ok(bp.config.contexts.has('sidebar'))
     assert.ok(!bp.config.contexts.has('open'))
+  })
+})
+
+// ── MacroProcessor defaults ─────────────────────────────────────────────────
+
+describe('MacroProcessor', () => {
+  test('default contentModel is attributes', () => {
+    const mp = new BlockMacroProcessor('mymacro')
+    assert.equal(mp.config.contentModel, 'attributes')
+  })
+
+  test('default contentModel is attributes (InlineMacroProcessor)', () => {
+    const mp = new InlineMacroProcessor('mymacro')
+    assert.equal(mp.config.contentModel, 'attributes')
+  })
+})
+
+// ── Legacy snake_case config alias normalization ────────────────────────────
+//
+// Extension config keys (contentModel, positionalAttrs, defaultAttrs) are
+// camelCase. The legacy Ruby-style snake_case keys are still accepted when a
+// processor declares its config directly (static config field, post-
+// declaration `X.config = {...}` assignment, or a plain object passed to the
+// constructor / updateConfig()) so pre-4.0.5 extensions keep working.
+// See https://github.com/asciidoctor/asciidoctor.js/issues/1857
+
+describe('Processor config normalization', () => {
+  test('static config setter allows post-declaration assignment', () => {
+    class Foo extends Processor {}
+    Foo.config = { name: 'foo', contentModel: 'simple' }
+    assert.deepEqual(Foo.config, { name: 'foo', contentModel: 'simple' })
+    const foo = new Foo()
+    assert.equal(foo.config.contentModel, 'simple')
+  })
+
+  test('constructor normalizes legacy content_model into contentModel', () => {
+    const bp = new BlockProcessor('x', { content_model: 'simple' })
+    assert.equal(bp.config.contentModel, 'simple')
+  })
+
+  test('constructor normalizes legacy positional_attrs into positionalAttrs', () => {
+    const bmp = new BlockMacroProcessor('x', {
+      positional_attrs: ['a', 'b'],
+    })
+    assert.deepEqual(bmp.config.positionalAttrs, ['a', 'b'])
+  })
+
+  test('constructor normalizes legacy pos_attrs into positionalAttrs', () => {
+    const bmp = new BlockMacroProcessor('x', { pos_attrs: ['a', 'b'] })
+    assert.deepEqual(bmp.config.positionalAttrs, ['a', 'b'])
+  })
+
+  test('positional_attrs takes precedence over pos_attrs when both are set', () => {
+    const bmp = new BlockMacroProcessor('x', {
+      positional_attrs: ['a'],
+      pos_attrs: ['b'],
+    })
+    assert.deepEqual(bmp.config.positionalAttrs, ['a'])
+  })
+
+  test('constructor normalizes legacy default_attrs into defaultAttrs', () => {
+    const bmp = new BlockMacroProcessor('x', {
+      default_attrs: { color: 'red' },
+    })
+    assert.deepEqual(bmp.config.defaultAttrs, { color: 'red' })
+  })
+
+  test('an explicit camelCase key is not overwritten by a legacy alias', () => {
+    const bp = new BlockProcessor('x', {
+      contentModel: 'simple',
+      content_model: 'compound',
+    })
+    assert.equal(bp.config.contentModel, 'simple')
+  })
+
+  test('static config declared with legacy keys is normalized on construction', () => {
+    class LegacyBlock extends BlockProcessor {}
+    LegacyBlock.config = {
+      name: 'legacy',
+      content_model: 'simple',
+      positional_attrs: ['size'],
+      default_attrs: { size: '1x' },
+    }
+    const instance = new LegacyBlock()
+    assert.equal(instance.config.contentModel, 'simple')
+    assert.deepEqual(instance.config.positionalAttrs, ['size'])
+    assert.deepEqual(instance.config.defaultAttrs, { size: '1x' })
+  })
+
+  test('updateConfig() normalizes legacy aliases', () => {
+    const bp = new BlockProcessor('x')
+    bp.updateConfig({ content_model: 'simple', positional_attrs: ['a'] })
+    assert.equal(bp.config.contentModel, 'simple')
+    assert.deepEqual(bp.config.positionalAttrs, ['a'])
   })
 })
 

--- a/packages/core/test/extensions.test.js
+++ b/packages/core/test/extensions.test.js
@@ -525,27 +525,27 @@ describe('Extensions.DSL', () => {
       assert.equal(proc.name, 'myblock')
     })
 
-    test('contentModel() / parseContentAs() set content_model option', () => {
+    test('contentModel() / parseContentAs() set contentModel option', () => {
       const proc = new BlockProcessor()
       Object.assign(proc, SyntaxProcessorDsl)
       proc.contentModel('simple')
-      assert.equal(proc.config.content_model, 'simple')
+      assert.equal(proc.config.contentModel, 'simple')
       proc.parseContentAs('compound')
-      assert.equal(proc.config.content_model, 'compound')
+      assert.equal(proc.config.contentModel, 'compound')
     })
 
-    test('positionalAttributes() sets positional_attrs option', () => {
+    test('positionalAttributes() sets positionalAttrs option', () => {
       const proc = new BlockProcessor()
       Object.assign(proc, SyntaxProcessorDsl)
       proc.positionalAttributes('name', 'value')
-      assert.deepEqual(proc.config.positional_attrs, ['name', 'value'])
+      assert.deepEqual(proc.config.positionalAttrs, ['name', 'value'])
     })
 
-    test('defaultAttributes() sets default_attrs option', () => {
+    test('defaultAttributes() sets defaultAttrs option', () => {
       const proc = new BlockProcessor()
       Object.assign(proc, SyntaxProcessorDsl)
       proc.defaultAttributes({ format: 'html' })
-      assert.deepEqual(proc.config.default_attrs, { format: 'html' })
+      assert.deepEqual(proc.config.defaultAttrs, { format: 'html' })
     })
 
     describe('resolveAttributes()', () => {
@@ -555,60 +555,60 @@ describe('Extensions.DSL', () => {
         return p
       }
 
-      test('with no args sets empty positional_attrs and default_attrs', () => {
+      test('with no args sets empty positionalAttrs and defaultAttrs', () => {
         const p = makeProc()
         p.resolveAttributes()
-        assert.deepEqual(p.config.positional_attrs, [])
-        assert.deepEqual(p.config.default_attrs, {})
+        assert.deepEqual(p.config.positionalAttrs, [])
+        assert.deepEqual(p.config.defaultAttrs, {})
       })
 
-      test('with true sets empty positional_attrs and default_attrs', () => {
+      test('with true sets empty positionalAttrs and defaultAttrs', () => {
         const p = makeProc()
         p.resolveAttributes(true)
-        assert.deepEqual(p.config.positional_attrs, [])
-        assert.deepEqual(p.config.default_attrs, {})
+        assert.deepEqual(p.config.positionalAttrs, [])
+        assert.deepEqual(p.config.defaultAttrs, {})
       })
 
       test('parses simple positional attribute names from array', () => {
         const p = makeProc()
         p.resolveAttributes('units', 'precision')
-        assert.deepEqual(p.config.positional_attrs, ['units', 'precision'])
-        assert.deepEqual(p.config.default_attrs, {})
+        assert.deepEqual(p.config.positionalAttrs, ['units', 'precision'])
+        assert.deepEqual(p.config.defaultAttrs, {})
       })
 
       test('parses indexed positional names (e.g. "1:units")', () => {
         const p = makeProc()
         p.resolveAttributes('1:units', 'precision=1')
-        assert.deepEqual(p.config.positional_attrs, ['units'])
-        assert.deepEqual(p.config.default_attrs, { precision: '1' })
+        assert.deepEqual(p.config.positionalAttrs, ['units'])
+        assert.deepEqual(p.config.defaultAttrs, { precision: '1' })
       })
 
       test('parses @-indexed names (append to current length)', () => {
         const p = makeProc()
         p.resolveAttributes('@:first', '@:second')
-        assert.deepEqual(p.config.positional_attrs, ['first', 'second'])
+        assert.deepEqual(p.config.positionalAttrs, ['first', 'second'])
       })
 
       test('parses indexed name with default value', () => {
         const p = makeProc()
         p.resolveAttributes('1:name=default')
-        assert.deepEqual(p.config.positional_attrs, ['name'])
-        assert.deepEqual(p.config.default_attrs, { name: 'default' })
+        assert.deepEqual(p.config.positionalAttrs, ['name'])
+        assert.deepEqual(p.config.defaultAttrs, { name: 'default' })
       })
 
       test('parses Object-style { "1:name": null } specs', () => {
         const p = makeProc()
         p.resolveAttributes({ '1:name': null })
-        assert.deepEqual(p.config.positional_attrs, ['name'])
-        assert.deepEqual(p.config.default_attrs, {})
+        assert.deepEqual(p.config.positionalAttrs, ['name'])
+        assert.deepEqual(p.config.defaultAttrs, {})
       })
 
       test('parses Object-style with default values', () => {
         const p = makeProc()
         p.resolveAttributes({ format: 'html', '1:target': null })
         // Object key order may vary; check both outcomes
-        assert.ok(p.config.positional_attrs.includes('target'))
-        assert.equal(p.config.default_attrs.format, 'html')
+        assert.ok(p.config.positionalAttrs.includes('target'))
+        assert.equal(p.config.defaultAttrs.format, 'html')
       })
     })
   })
@@ -636,19 +636,19 @@ describe('Extensions.DSL', () => {
   // ── MacroProcessorDsl ───────────────────────────────────────────────────────
 
   describe('MacroProcessorDsl', () => {
-    test('resolveAttributes(false) sets content_model to text', () => {
+    test('resolveAttributes(false) sets contentModel to text', () => {
       const proc = new BlockMacroProcessor()
       Object.assign(proc, MacroProcessorDsl)
       proc.resolveAttributes(false)
-      assert.equal(proc.config.content_model, 'text')
+      assert.equal(proc.config.contentModel, 'text')
     })
 
-    test('resolveAttributes() with args sets positional_attrs and content_model to attributes', () => {
+    test('resolveAttributes() with args sets positionalAttrs and contentModel to attributes', () => {
       const proc = new BlockMacroProcessor()
       Object.assign(proc, MacroProcessorDsl)
       proc.resolveAttributes('1:target')
-      assert.deepEqual(proc.config.positional_attrs, ['target'])
-      assert.equal(proc.config.content_model, 'attributes')
+      assert.deepEqual(proc.config.positionalAttrs, ['target'])
+      assert.equal(proc.config.contentModel, 'attributes')
     })
   })
 
@@ -677,9 +677,9 @@ describe('Extensions.DSL', () => {
 // ── BlockProcessor defaults ───────────────────────────────────────────────────
 
 describe('BlockProcessor', () => {
-  test('default content_model is compound', () => {
+  test('default contentModel is compound', () => {
     const bp = new BlockProcessor('myblock')
-    assert.equal(bp.config.content_model, 'compound')
+    assert.equal(bp.config.contentModel, 'compound')
   })
 
   test('default contexts is Set containing open and paragraph', () => {

--- a/packages/core/types/extensions.d.ts
+++ b/packages/core/types/extensions.d.ts
@@ -24,7 +24,7 @@ export namespace SyntaxProcessorDsl {
      * Resolve and register positional attribute names and default values.
      *
      * Accepts any of:
-     *   resolveAttributes()             → positional_attrs: [], default_attrs: {}
+     *   resolveAttributes()             → positionalAttrs: [], defaultAttrs: {}
      *   resolveAttributes('foo', 'bar') → positional maps (Array-style)
      *   resolveAttributes({...})        → positional maps (Object-style)
      *
@@ -69,7 +69,7 @@ export namespace BlockProcessorDsl {
 }
 export namespace MacroProcessorDsl {
     /**
-     * Override: passing a falsy value sets content_model to :text instead of
+     * Override: passing a falsy value sets contentModel to 'text' instead of
      * configuring positional attributes.
      *
      * @param {...*} args - Positional attribute specifications.
@@ -93,6 +93,13 @@ export namespace InlineMacroProcessorDsl {
  * set of convenience factory methods for creating AST nodes.
  */
 export class Processor {
+    /**
+     * Replace the static configuration map for this processor class, e.g.
+     * `ShoutBlock.config = { name: 'shout', contentModel: 'simple' }`.
+     *
+     * @param {object} value
+     */
+    static set config(value: object);
     /**
      * Get the static configuration map for this processor class.
      * Uses hasOwnProperty to avoid inheriting a parent class's config object
@@ -375,12 +382,12 @@ export namespace DocinfoProcessor {
  *
  * @example <caption>Custom delimited block that wraps content in a div</caption>
  * class ShoutBlock extends BlockProcessor {
+ *   static config = { name: 'shout', contexts: ['paragraph'], contentModel: 'simple' }
  *   process(parent, reader, attrs) {
  *     const block = this.createBlock(parent, 'paragraph', reader.readLines().join('\n').toUpperCase(), attrs)
  *     return block
  *   }
  * }
- * ShoutBlock.config = { name: 'shout', contexts: ['paragraph'], content_model: 'simple' }
  * Extensions.register(function () { this.block(ShoutBlock) })
  * // AsciiDoc usage: [shout]\nHello world
  */


### PR DESCRIPTION
#### Summary

Fixes #1857. Inline macro extensions registered via the DSL closure style (`registry.inlineMacro(function () { this.contentModel(...); this.positionalAttributes(...) })`) silently ignored their `contentModel`/`positionalAttrs` configuration — the macro's bracket content was never parsed into named/positional attributes and always ended up as a raw string in `attributes.text`.

Root cause: `Substitutors#subMacros` (the inline macro substitution path in `packages/core/src/substitutors.js`) read the extension config with keys the DSL/static config never actually populated, so the `contentModel === 'attributes'` branch was never taken.

While fixing this I also standardized extension `Processor` config keys on `camelCase` (`contentModel`, `positionalAttrs`, `defaultAttrs`) across every registration style — DSL setters, class-based `static config`, and the block/inline macro substitution readers in `parser.js` and `substitutors.js`. Legacy `snake_case` keys (`content_model`, `positional_attrs`, `pos_attrs`, `default_attrs`) are still accepted for backward compatibility when a processor declares its config directly (e.g. `MyProcessor.config = { content_model: 'attributes' }`).

As a related fix, `Processor.config` gained a static setter, so post-declaration assignment (`MyProcessor.config = {...}`, as already shown in the `BlockMacroProcessor`/`InlineMacroProcessor` JSDoc examples) no longer throws a `TypeError` — it previously only had a getter.