### PR TITLE
fix(tasks): resolve AsciiDoc attribute references in generated release notes

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,10 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 == Unreleased
 
+Bug Fixes::
+
+* Fix `tasks/changelog.js notes` (used to generate GitHub release notes) leaving AsciiDoc attribute references such as `{uri-repo}/issues/1857[#1857]` unresolved in the generated Markdown. `extractReleaseNotes` used to extract the raw AsciiDoc section for a release and convert only that fragment to Markdown, losing the `:uri-repo:` attribute definition from the changelog header in the process. The whole changelog is now converted to Markdown once, and the release section is extracted from the resulting Markdown instead, so attribute references resolve correctly
+
 == v4.0.5 (2026-07-21)
 
 Bug Fixes::

--- a/tasks/changelog.js
+++ b/tasks/changelog.js
@@ -28,10 +28,11 @@ export function convertAsciidocToMarkdown(content) {
   return downdoc(preprocessed)
 }
 
-// Splits a release section into a summary (intro paragraph before the first
-// labeled section) and the structured changelog (the labeled sections themselves).
+// Splits a release section (already converted to Markdown) into a summary
+// (intro paragraph before the first labeled section) and the structured
+// changelog (the labeled sections themselves, now Markdown h3 headers).
 export function splitChangelog(sectionContent) {
-  const firstSectionIdx = sectionContent.search(/^[A-Z][^\n]+::\s*$/m)
+  const firstSectionIdx = sectionContent.search(/^### /m)
   if (firstSectionIdx === -1) {
     return { summary: sectionContent, changelog: '' }
   }
@@ -83,24 +84,30 @@ export function rollUnreleased(content, version, releaseDate) {
 }
 
 // Extracts the "== v<version> (date)" section and formats it as Markdown release notes.
+//
+// The whole changelog is converted to Markdown up front (rather than
+// extracting the AsciiDoc section first and converting it in isolation) so
+// that document-level context — attribute references such as
+// "{uri-repo}/issues/1857[#1857]" in particular — resolves correctly.
 export function extractReleaseNotes(content, version, { author, previousTag }) {
   const escapedVersion = version.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const markdown = convertAsciidocToMarkdown(content)
   const headerRegex = new RegExp(
-    `== v${escapedVersion} \\(([^)]+)\\)\\n([\\s\\S]*?)(?=\\n== |$)`
+    `## v${escapedVersion} \\(([^)]+)\\)\\n([\\s\\S]*?)(?=\\n## |$)`
   )
-  const match = content.match(headerRegex)
+  const match = markdown.match(headerRegex)
   if (!match) {
     throw new Error(`Section "== v${version}" not found in CHANGELOG.adoc`)
   }
   const [, releaseDate, sectionContent] = match
   const { summary, changelog } = splitChangelog(sectionContent.trim())
   return formatReleaseNotes({
-    summary: convertAsciidocToMarkdown(summary),
+    summary,
     date: releaseDate,
     author,
     previousTag,
     currentTag: `v${version}`,
-    changelog: convertAsciidocToMarkdown(changelog),
+    changelog,
   })
 }
 

--- a/test/changelog.test.js
+++ b/test/changelog.test.js
@@ -9,6 +9,7 @@ import {
 } from '../tasks/changelog.js'
 
 const CHANGELOG_FIXTURE = `= Asciidoctor.js Changelog
+:uri-repo: https://github.com/asciidoctor/asciidoctor.js
 
 This document provides a high-level view of the changes introduced in Asciidoctor.js by release.
 
@@ -35,7 +36,7 @@ await convert('Hello _world_')
 
 Bug Fixes::
 
-* Fix conditional exports (#1722)
+* Fix conditional exports ({uri-repo}/issues/1722[#1722])
 `
 
 const RELEASE_NOTES_OPTS = {
@@ -119,20 +120,29 @@ describe('convertAsciidocToMarkdown', () => {
     const input = '* Use `npm ci` to install'
     assert.equal(convertAsciidocToMarkdown(input), input)
   })
+
+  test('resolves a document attribute reference defined earlier in the same content', () => {
+    assert.equal(
+      convertAsciidocToMarkdown(
+        ':uri-repo: https://github.com/asciidoctor/asciidoctor.js\n\nSee {uri-repo}/issues/1857[#1857]'
+      ),
+      'See [#1857](https://github.com/asciidoctor/asciidoctor.js/issues/1857)'
+    )
+  })
 })
 
 describe('splitChangelog', () => {
   test('returns the intro paragraph as summary and the sections as changelog', () => {
     const input =
-      'A great release.\n\nBreaking Changes::\n\n* Item A\n\nImprovements::\n\n* Item B'
+      'A great release.\n\n### Breaking Changes\n\n* Item A\n\n### Improvements\n\n* Item B'
     const { summary, changelog } = splitChangelog(input)
     assert.equal(summary, 'A great release.')
-    assert.ok(changelog.startsWith('Breaking Changes::'))
+    assert.ok(changelog.startsWith('### Breaking Changes'))
     assert.ok(!changelog.includes('A great release.'))
   })
 
   test('returns empty summary when content starts with a labeled section', () => {
-    const input = 'Breaking Changes::\n\n* Item A'
+    const input = '### Breaking Changes\n\n* Item A'
     const { summary, changelog } = splitChangelog(input)
     assert.equal(summary, '')
     assert.equal(changelog, input)
@@ -251,6 +261,16 @@ describe('extractReleaseNotes', () => {
     const releaseNotes = extractReleaseNotes(CHANGELOG_FIXTURE, '3.0.4', meta)
     assert.ok(releaseNotes.includes('Released on: 2024-02-12'))
     assert.ok(releaseNotes.includes('### Bug Fixes'))
+  })
+
+  test('resolves a document attribute reference from the changelog header', () => {
+    const releaseNotes = extractReleaseNotes(CHANGELOG_FIXTURE, '3.0.4', meta)
+    assert.ok(
+      releaseNotes.includes(
+        '[#1722](https://github.com/asciidoctor/asciidoctor.js/issues/1722)'
+      )
+    )
+    assert.ok(!releaseNotes.includes('{uri-repo}'))
   })
 
   test('throws when the version section is missing', () => {


### PR DESCRIPTION
`extractReleaseNotes` (used by `node tasks/changelog.js notes <version>` to build GitHub release notes) extracted the raw AsciiDoc section for a release and converted only that fragment to Markdown, losing the `:uri-repo:` attribute defined in the changelog header. As a result, references like `{uri-repo}/issues/1857[#1857]` were left unresolved in the generated Markdown instead of becoming a proper link.

The whole changelog is now converted to Markdown once, and the release section is extracted from the resulting Markdown (matching `## v<version> (date)` headers) instead of converting an isolated AsciiDoc fragment. This resolves attribute references correctly and is more robust to any other document-level context, not just this one attribute.
