### PR TITLE
fix(core): type Logger progname as optional, close applyLogging() type gaps

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,12 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 Bug Fixes::
 
 * Fix `tasks/changelog.js notes` (used to generate GitHub release notes) leaving AsciiDoc attribute references such as `{uri-repo}/issues/1857[#1857]` unresolved in the generated Markdown. `extractReleaseNotes` used to extract the raw AsciiDoc section for a release and convert only that fragment to Markdown, losing the `:uri-repo:` attribute definition from the changelog header in the process. The whole changelog is now converted to Markdown once, and the release section is extracted from the resulting Markdown instead, so attribute references resolve correctly
+* Type `Logger#warn()`/`#debug()`/`#info()`/`#error()`/`#fatal()`/`#unknown()`/`#log()` (and the matching `MemoryLogger` methods) with an optional `progname`/`pn` parameter instead of a required one. The generated `.d.ts` previously declared both arguments as mandatory, so calling `doc.getLogger().warn(doc.messageWithContext(...))` with a single argument — the documented pattern for logging from an extension — was flagged by editors as "expected 2 arguments" even though it is valid at runtime; the error surfaced because `getLogger()` resolves to the `LoggerLike` union (`Logger | MemoryLogger | NullLogger | Console`) and TypeScript requires a call to satisfy every member's signature
+* Type `messageWithContext()`/`createLogMessage()` on `Document`, `ConverterBase`, `PathResolver`, and `Table.ParserContext` (and the static equivalents on `Parser`). These are installed at runtime by the `applyLogging()` mixin (`logging.js`) *after* the class body closes, so `tsc`'s JSDoc-based declaration emit never picked them up — `doc.messageWithContext(...)`, the pattern shown in the extensions guide, previously had no type at all on the public API surface
+
+Infrastructure::
+
+* Add compile-only type tests for the Logger/MemoryLogger/NullLogger API and the `LoggerLike` union (`test/types/logging.test-d.ts`, run by `npm run test:types`), covering every shorthand log method across single- and two-argument call forms, the `applyLogging()` consumers listed above, and negative `@ts-expect-error` checks (e.g. `fatal()`/`unknown()` are intentionally unavailable on the raw `LoggerLike` union because `Console` has neither, but resolve once narrowed away from `Console`)
 
 == v4.0.5 (2026-07-21)
 

--- a/packages/core/src/converter.js
+++ b/packages/core/src/converter.js
@@ -11,7 +11,7 @@
 //   - Converter.derive_backend_traits exposed as static function.
 //   - DEFAULT_EXTENSIONS / TrailingDigitsRx imported from constants/rx.
 
-import { applyLogging } from './logging.js'
+import { applyLogging, Logger, LoggerManager } from './logging.js'
 import { DEFAULT_EXTENSIONS } from './constants.js'
 import { TrailingDigitsRx } from './rx.js'
 
@@ -436,6 +436,41 @@ export class ConverterBase {
     this.backend = backend
     applyBackendTraits(this)
     applyLogging(this)
+  }
+
+  // ── Logging mixin ───────────────────────────────────────────────────────────
+  // Declared here (in addition to being installed by applyLogging(this) above)
+  // so that generated .d.ts declarations expose them — applyLogging() assigns
+  // own properties at construction time, which tsc's declaration emit can't see.
+
+  /**
+   * The logger for this converter.
+   * The Logging mixin (logging.js) overrides this getter on the instance.
+   * @returns {import('./logging.js').LoggerLike}
+   */
+  get logger() {
+    return LoggerManager.logger
+  }
+
+  /** @returns {import('./logging.js').LoggerLike} */
+  getLogger() {
+    return this.logger
+  }
+
+  /**
+   * Build an auto-formatting log message that carries structured source_location
+   * (rather than baking it into the text), for use with `this.logger.warn(...)`.
+   * @param {string} text
+   * @param {{source_location?: any, include_location?: any}} [context={}]
+   * @returns {{text: string, source_location?: any, include_location?: any, inspect(): string, toString(): string}}
+   */
+  messageWithContext(text, context = {}) {
+    return Logger.AutoFormattingMessage.attach({ text, ...context })
+  }
+
+  /** Alias for {@link messageWithContext} (used in extensions). */
+  createLogMessage(text, context = {}) {
+    return this.messageWithContext(text, context)
   }
 
   /**

--- a/packages/core/src/document.js
+++ b/packages/core/src/document.js
@@ -33,7 +33,7 @@ import {
 import { Converter, CustomFactory, deriveBackendTraits } from './converter.js'
 import { XmlSanitizeRx, AttributeEntryPassMacroRx } from './rx.js'
 import { LF } from './constants.js'
-import { applyLogging } from './logging.js'
+import { applyLogging, Logger } from './logging.js'
 import { SyntaxHighlighter, DefaultFactoryProxy } from './syntax_highlighter.js'
 import { Reader, PreprocessorReader, Cursor } from './reader.js'
 import { Parser } from './parser.js'
@@ -2139,6 +2139,28 @@ export class Document extends AbstractBlock {
     attrs[`doctype-${newDoctype}`] = ''
     this.doctype = attrs.doctype = newDoctype
     return newDoctype
+  }
+
+  // ── Logging mixin ───────────────────────────────────────────────────────────
+  // Declared here (in addition to being installed by applyLogging() below) so
+  // that generated .d.ts declarations expose them — applyLogging() mutates the
+  // prototype after the class body closes, which tsc's declaration emit can't see.
+
+  /**
+   * Build an auto-formatting log message that carries structured source_location
+   * (rather than baking it into the text), for use with `this.logger.warn(...)`.
+   * The Logging mixin (logging.js) overrides this method on the prototype.
+   * @param {string} text
+   * @param {{source_location?: any, include_location?: any}} [context={}]
+   * @returns {{text: string, source_location?: any, include_location?: any, inspect(): string, toString(): string}}
+   */
+  messageWithContext(text, context = {}) {
+    return Logger.AutoFormattingMessage.attach({ text, ...context })
+  }
+
+  /** Alias for {@link messageWithContext} (used in extensions). */
+  createLogMessage(text, context = {}) {
+    return this.messageWithContext(text, context)
   }
 }
 

--- a/packages/core/src/logging.js
+++ b/packages/core/src/logging.js
@@ -221,26 +221,62 @@ export class Logger {
     return true
   }
 
-  /** Alias for {@link add} (Ruby Logger API). */
+  /**
+   * Alias for {@link add} (Ruby Logger API).
+   * @param {number|string} severity
+   * @param {string|{inspect?(): string}|null} [message=null]
+   * @param {string|Function|null} [progname=null]
+   * @returns {boolean}
+   */
   log(severity, message, progname) {
     return this.add(severity, message, progname)
   }
 
+  /**
+   * @param {string|{inspect?(): string}|null} [msg=null]
+   * @param {string|Function|null} [progname=null]
+   * @returns {boolean}
+   */
   debug(msg, progname) {
     return this.add(Severity.DEBUG, msg, progname)
   }
+  /**
+   * @param {string|{inspect?(): string}|null} [msg=null]
+   * @param {string|Function|null} [progname=null]
+   * @returns {boolean}
+   */
   info(msg, progname) {
     return this.add(Severity.INFO, msg, progname)
   }
+  /**
+   * @param {string|{inspect?(): string}|null} [msg=null]
+   * @param {string|Function|null} [progname=null]
+   * @returns {boolean}
+   */
   warn(msg, progname) {
     return this.add(Severity.WARN, msg, progname)
   }
+  /**
+   * @param {string|{inspect?(): string}|null} [msg=null]
+   * @param {string|Function|null} [progname=null]
+   * @returns {boolean}
+   */
   error(msg, progname) {
     return this.add(Severity.ERROR, msg, progname)
   }
+  /**
+   * @param {string|{inspect?(): string}|null} [msg=null]
+   * @param {string|Function|null} [progname=null]
+   * @returns {boolean}
+   */
   fatal(msg, progname) {
     return this.add(Severity.FATAL, msg, progname)
   }
+  /**
+   * @param {string|{inspect?(): string}|null} [msg=null]
+   * @param {string|Function|null} [progname=null]
+   * @returns {boolean}
+   */
   unknown(msg, progname) {
     return this.add(Severity.UNKNOWN, msg, progname)
   }
@@ -392,25 +428,61 @@ export class MemoryLogger {
     return true
   }
 
+  /**
+   * @param {string|{inspect?(): string}|null} [msg=null]
+   * @param {string|Function|null} [pn=null]
+   * @returns {boolean}
+   */
   debug(msg, pn) {
     return this.add(Severity.DEBUG, msg, pn)
   }
+  /**
+   * @param {string|{inspect?(): string}|null} [msg=null]
+   * @param {string|Function|null} [pn=null]
+   * @returns {boolean}
+   */
   info(msg, pn) {
     return this.add(Severity.INFO, msg, pn)
   }
+  /**
+   * @param {string|{inspect?(): string}|null} [msg=null]
+   * @param {string|Function|null} [pn=null]
+   * @returns {boolean}
+   */
   warn(msg, pn) {
     return this.add(Severity.WARN, msg, pn)
   }
+  /**
+   * @param {string|{inspect?(): string}|null} [msg=null]
+   * @param {string|Function|null} [pn=null]
+   * @returns {boolean}
+   */
   error(msg, pn) {
     return this.add(Severity.ERROR, msg, pn)
   }
+  /**
+   * @param {string|{inspect?(): string}|null} [msg=null]
+   * @param {string|Function|null} [pn=null]
+   * @returns {boolean}
+   */
   fatal(msg, pn) {
     return this.add(Severity.FATAL, msg, pn)
   }
+  /**
+   * @param {string|{inspect?(): string}|null} [msg=null]
+   * @param {string|Function|null} [pn=null]
+   * @returns {boolean}
+   */
   unknown(msg, pn) {
     return this.add(Severity.UNKNOWN, msg, pn)
   }
 
+  /**
+   * @param {number|string} severity
+   * @param {string|{inspect?(): string}|null} [message=null]
+   * @param {string|Function|null} [progname=null]
+   * @returns {boolean}
+   */
   log(severity, message, progname) {
     return this.add(severity, message, progname)
   }

--- a/packages/core/src/parser.js
+++ b/packages/core/src/parser.js
@@ -9,7 +9,7 @@
 //   - ListContinuationMarker module → Symbol used for identity checks.
 //   - Logging mixin applied via applyLogging().
 
-import { applyLogging } from './logging.js'
+import { applyLogging, Logger, LoggerManager } from './logging.js'
 import { Block } from './block.js'
 import { Section } from './section.js'
 import { List, ListItem } from './list.js'
@@ -3671,6 +3671,42 @@ export class Parser {
     return name
       .replace(new RegExp(InvalidAttributeNameCharsRx.source, 'gu'), '')
       .toLowerCase()
+  }
+
+  // ── Logging mixin (static) ──────────────────────────────────────────────────
+  // Declared here (in addition to being installed by applyLogging(Parser) below)
+  // so that generated .d.ts declarations expose them — applyLogging() assigns
+  // static properties after the class body closes, which tsc's declaration
+  // emit can't see.
+
+  /**
+   * The logger used by the static Parser methods.
+   * The Logging mixin (logging.js) overrides this getter on the class.
+   * @returns {import('./logging.js').LoggerLike}
+   */
+  static get logger() {
+    return LoggerManager.logger
+  }
+
+  /** @returns {import('./logging.js').LoggerLike} */
+  static getLogger() {
+    return this.logger
+  }
+
+  /**
+   * Build an auto-formatting log message that carries structured source_location
+   * (rather than baking it into the text), for use with `Parser.logger.warn(...)`.
+   * @param {string} text
+   * @param {{source_location?: any, include_location?: any}} [context={}]
+   * @returns {{text: string, source_location?: any, include_location?: any, inspect(): string, toString(): string}}
+   */
+  static messageWithContext(text, context = {}) {
+    return Logger.AutoFormattingMessage.attach({ text, ...context })
+  }
+
+  /** Alias for {@link messageWithContext} (used in extensions). */
+  static createLogMessage(text, context = {}) {
+    return this.messageWithContext(text, context)
   }
 }
 

--- a/packages/core/src/path_resolver.js
+++ b/packages/core/src/path_resolver.js
@@ -7,7 +7,7 @@
 //   - The Opal / JRuby conditional root? overloads are omitted (Node.js only).
 //   - Logging mixin is applied via applyLogging() after class definition.
 
-import { applyLogging } from './logging.js'
+import { applyLogging, Logger, LoggerManager } from './logging.js'
 import { UriSniffRx } from './rx.js'
 
 const DOT = '.'
@@ -400,6 +400,41 @@ export class PathResolver {
       if (m) return [str.slice(m[0].length), m[0]]
     }
     return str
+  }
+
+  // ── Logging mixin ───────────────────────────────────────────────────────────
+  // Declared here (in addition to being installed by applyLogging() below) so
+  // that generated .d.ts declarations expose them — applyLogging() mutates the
+  // prototype after the class body closes, which tsc's declaration emit can't see.
+
+  /**
+   * The logger for this path resolver.
+   * The Logging mixin (logging.js) overrides this getter on the prototype.
+   * @returns {import('./logging.js').LoggerLike}
+   */
+  get logger() {
+    return LoggerManager.logger
+  }
+
+  /** @returns {import('./logging.js').LoggerLike} */
+  getLogger() {
+    return this.logger
+  }
+
+  /**
+   * Build an auto-formatting log message that carries structured source_location
+   * (rather than baking it into the text), for use with `this.logger.warn(...)`.
+   * @param {string} text
+   * @param {{source_location?: any, include_location?: any}} [context={}]
+   * @returns {{text: string, source_location?: any, include_location?: any, inspect(): string, toString(): string}}
+   */
+  messageWithContext(text, context = {}) {
+    return Logger.AutoFormattingMessage.attach({ text, ...context })
+  }
+
+  /** Alias for {@link messageWithContext} (used in extensions). */
+  createLogMessage(text, context = {}) {
+    return this.messageWithContext(text, context)
   }
 }
 

--- a/packages/core/src/table.js
+++ b/packages/core/src/table.js
@@ -11,7 +11,7 @@
 import { AbstractBlock } from './abstract_block.js'
 import { AbstractNode } from './abstract_node.js'
 import { Inline } from './inline.js'
-import { applyLogging } from './logging.js'
+import { applyLogging, Logger, LoggerManager } from './logging.js'
 import { LF, ATTR_REF_HEAD, BASIC_SUBS, NORMAL_SUBS } from './constants.js'
 import { BlankLineRx, LeadingInlineAnchorRx } from './rx.js'
 import { PreprocessorReader } from './reader.js'
@@ -966,6 +966,41 @@ Table.ParserContext = class ParserContext {
 
   _advance() {
     this._linenum++
+  }
+
+  // ── Logging mixin ───────────────────────────────────────────────────────────
+  // Declared here (in addition to being installed by applyLogging() below) so
+  // that generated .d.ts declarations expose them — applyLogging() mutates the
+  // prototype after the class body closes, which tsc's declaration emit can't see.
+
+  /**
+   * The logger for this parser context.
+   * The Logging mixin (logging.js) overrides this getter on the prototype.
+   * @returns {import('./logging.js').LoggerLike}
+   */
+  get logger() {
+    return this.table?.document?.logger ?? LoggerManager.logger
+  }
+
+  /** @returns {import('./logging.js').LoggerLike} */
+  getLogger() {
+    return this.logger
+  }
+
+  /**
+   * Build an auto-formatting log message that carries structured source_location
+   * (rather than baking it into the text), for use with `this.logger.warn(...)`.
+   * @param {string} text
+   * @param {{source_location?: any, include_location?: any}} [context={}]
+   * @returns {{text: string, source_location?: any, include_location?: any, inspect(): string, toString(): string}}
+   */
+  messageWithContext(text, context = {}) {
+    return Logger.AutoFormattingMessage.attach({ text, ...context })
+  }
+
+  /** Alias for {@link messageWithContext} (used in extensions). */
+  createLogMessage(text, context = {}) {
+    return this.messageWithContext(text, context)
   }
 }
 

--- a/packages/core/test/types/logging.test-d.ts
+++ b/packages/core/test/types/logging.test-d.ts
@@ -1,0 +1,164 @@
+// Type-level tests for Logger/MemoryLogger/NullLogger and the LoggerLike
+// union returned by every `getLogger()`/`#logger` in the codebase.
+//
+// These are compile-only checks: `npm run test:types` runs `tsc --noEmit`
+// against this file using the generated declarations in ../../types.
+// A regression in the JSDoc typings makes this file fail to compile.
+//
+// Context: `getLogger()` resolves to `LoggerLike` (`Logger | MemoryLogger |
+// NullLogger | Console`). Calling a method on a union type requires the call
+// to satisfy every member's signature, so a single unannotated `progname`
+// parameter on `Logger`/`MemoryLogger` was enough to make the whole union
+// require 2 arguments, even though the documented single-argument usage
+// (`doc.getLogger().warn(doc.messageWithContext(...))`) is valid at runtime.
+
+import {
+  type ConverterBase as ConverterBaseType,
+  ConverterBase,
+  type Document,
+  load,
+  Logger,
+  LoggerManager,
+  type LogMessage,
+  MemoryLogger,
+  NullLogger,
+  Registry,
+} from '../../types/index.js'
+import { PathResolver } from '../../types/path_resolver.js'
+import type { Cursor } from '../../types/reader.js'
+import { type LoggerLike, Severity, withLogger } from '../../types/logging.js'
+
+const doc: Document = await load('= Title')
+
+// ── single-argument form: the documented extension/converter pattern ──────────
+doc.getLogger().warn(
+  doc.messageWithContext('skipping emoji inline macro, smile not found', {
+    source_location: doc.getSourceLocation(),
+  })
+)
+doc.getLogger().error('plain string message')
+doc.getLogger().info(doc.createLogMessage('info message'))
+doc.getLogger().debug('debug message')
+
+// ── the `logger` getter alias behaves the same as getLogger() ─────────────────
+doc.logger.warn('via the logger getter')
+
+// ── two-argument form: msg + progname, or msg + a message-supplier function ───
+doc.getLogger().warn('deprecated API', 'my-extension')
+doc.getLogger().warn(null, () => 'lazily computed message')
+
+// ── reader.getLogger() inside a preprocessor uses the same LoggerLike union ───
+const registry = new Registry()
+registry.preprocessor(function () {
+  this.process((document, reader) => {
+    reader.getLogger().warn(reader.createLogMessage('include not found'))
+    void document
+    return reader
+  })
+})
+
+// ── messageWithContext()/createLogMessage() on every applyLogging() consumer ──
+// (Document above; also ConverterBase, PathResolver, and Table.ParserContext,
+// which install the same 4 members at runtime but need them redeclared in the
+// class body — see logging.js's "Logging mixin" comment in each file.)
+class MyConverter extends ConverterBase {
+  convert_paragraph(node: unknown) {
+    this.getLogger().warn(
+      this.messageWithContext('unsupported paragraph style')
+    )
+    void node
+    return ''
+  }
+}
+const converter: ConverterBaseType = new MyConverter('html5')
+void converter
+
+const pathResolver = new PathResolver()
+pathResolver
+  .getLogger()
+  .warn(pathResolver.createLogMessage('unsafe path resolved'))
+
+// ── console is a valid LoggerLike (fallback when no document is attached) ─────
+const consoleAsLogger: LoggerLike = console
+consoleAsLogger.warn('console message')
+
+// ── Logger: single required message + optional progname ───────────────────────
+const logger = new Logger()
+logger.warn('hello')
+logger.warn('hello', 'progname')
+const warned: boolean = logger.warn('hello')
+void warned
+logger.log(Severity.WARN, 'via log()/add() alias')
+logger.log('WARN', 'severity as a string label')
+const maxSeverity: number = logger.getMaxSeverity()
+void maxSeverity
+
+// ── MemoryLogger: same shorthand surface, plus message inspection ─────────────
+const memoryLogger = new MemoryLogger()
+memoryLogger.warn('captured message')
+const messages: LogMessage[] = memoryLogger.getMessages()
+const [firstMessage] = messages
+if (firstMessage) {
+  const severity: string = firstMessage.getSeverity()
+  const text: string = firstMessage.getText()
+  const sourceLocation: Cursor | undefined = firstMessage.getSourceLocation()
+  void severity
+  void text
+  void sourceLocation
+}
+
+// ── NullLogger: every shorthand takes zero arguments ───────────────────────────
+const nullLogger = new NullLogger()
+nullLogger.warn()
+nullLogger.error()
+nullLogger.debug()
+nullLogger.info()
+nullLogger.fatal()
+nullLogger.unknown()
+
+// ── LoggerManager: get/set the process-wide default logger ────────────────────
+LoggerManager.setLogger(memoryLogger)
+const current: Logger = LoggerManager.getLogger()
+void current
+
+// ── withLogger(logger, fn): scope a logger to an async execution ──────────────
+await withLogger(memoryLogger, async () => {
+  doc.getLogger().warn('scoped warning')
+})
+
+// ── fatal()/unknown(): NOT on the raw LoggerLike union, because Console has ───
+// neither (Node's console object really lacks them — calling them through a
+// console-backed logger would throw at runtime, so rejecting them here is
+// correct, not a typing gap). Narrowing LoggerLike away from Console (e.g.
+// with an `in` check, or `instanceof Logger`/`instanceof MemoryLogger`)
+// restores fatal()/unknown().
+const maybeLogger: LoggerLike = doc.getLogger()
+
+// @ts-expect-error fatal() is missing on the Console member of LoggerLike
+maybeLogger.fatal('nope')
+// @ts-expect-error unknown() is missing on the Console member of LoggerLike
+maybeLogger.unknown('nope')
+
+if ('fatal' in maybeLogger) {
+  // narrowed to Logger | MemoryLogger | NullLogger
+  maybeLogger.fatal('fatal message')
+  maybeLogger.unknown('unknown-severity message')
+}
+
+if (maybeLogger instanceof Logger) {
+  // Logger | NullLogger (NullLogger extends Logger)
+  maybeLogger.fatal('fatal via instanceof Logger')
+  maybeLogger.unknown('unknown via instanceof Logger')
+}
+
+if (maybeLogger instanceof MemoryLogger) {
+  maybeLogger.fatal('fatal via instanceof MemoryLogger')
+  maybeLogger.unknown('unknown via instanceof MemoryLogger')
+}
+
+// ── Negative checks: misuse must NOT compile ───────────────────────────────────
+// @ts-expect-error severity is required on Logger#add()
+logger.add()
+
+// @ts-expect-error NullLogger's shorthand methods take no arguments
+nullLogger.warn('message')

--- a/packages/core/types/converter.d.ts
+++ b/packages/core/types/converter.d.ts
@@ -122,6 +122,39 @@ export class ConverterBase {
     constructor(backend: any, opts?: {});
     backend: any;
     /**
+     * The logger for this converter.
+     * The Logging mixin (logging.js) overrides this getter on the instance.
+     * @returns {import('./logging.js').LoggerLike}
+     */
+    get logger(): import("./logging.js").LoggerLike;
+    /** @returns {import('./logging.js').LoggerLike} */
+    getLogger(): import("./logging.js").LoggerLike;
+    /**
+     * Build an auto-formatting log message that carries structured source_location
+     * (rather than baking it into the text), for use with `this.logger.warn(...)`.
+     * @param {string} text
+     * @param {{source_location?: any, include_location?: any}} [context={}]
+     * @returns {{text: string, source_location?: any, include_location?: any, inspect(): string, toString(): string}}
+     */
+    messageWithContext(text: string, context?: {
+        source_location?: any;
+        include_location?: any;
+    }): {
+        text: string;
+        source_location?: any;
+        include_location?: any;
+        inspect(): string;
+        toString(): string;
+    };
+    /** Alias for {@link messageWithContext} (used in extensions). */
+    createLogMessage(text: any, context?: {}): {
+        text: string;
+        source_location?: any;
+        include_location?: any;
+        inspect(): string;
+        toString(): string;
+    };
+    /**
      * Convert a node by dispatching to a `convert_<transform>` method.
      *
      * @param {AbstractNode} node - the AbstractNode to convert

--- a/packages/core/types/document.d.ts
+++ b/packages/core/types/document.d.ts
@@ -498,6 +498,32 @@ export class Document extends AbstractBlock<string> {
      * @param {string} [delegateBackend] - An optional delegate backend to use when resolving the converter.
      */
     private _createConverter;
+    /**
+     * Build an auto-formatting log message that carries structured source_location
+     * (rather than baking it into the text), for use with `this.logger.warn(...)`.
+     * The Logging mixin (logging.js) overrides this method on the prototype.
+     * @param {string} text
+     * @param {{source_location?: any, include_location?: any}} [context={}]
+     * @returns {{text: string, source_location?: any, include_location?: any, inspect(): string, toString(): string}}
+     */
+    messageWithContext(text: string, context?: {
+        source_location?: any;
+        include_location?: any;
+    }): {
+        text: string;
+        source_location?: any;
+        include_location?: any;
+        inspect(): string;
+        toString(): string;
+    };
+    /** Alias for {@link messageWithContext} (used in extensions). */
+    createLogMessage(text: any, context?: {}): {
+        text: string;
+        source_location?: any;
+        include_location?: any;
+        inspect(): string;
+        toString(): string;
+    };
 }
 export namespace Document {
     export { Footnote };

--- a/packages/core/types/logging.d.ts
+++ b/packages/core/types/logging.d.ts
@@ -87,14 +87,64 @@ export class Logger {
     add(severity: number | string, message?: string | {
         inspect?(): string;
     } | null, progname?: string | Function | null): boolean;
-    /** Alias for {@link add} (Ruby Logger API). */
-    log(severity: any, message: any, progname: any): boolean;
-    debug(msg: any, progname: any): boolean;
-    info(msg: any, progname: any): boolean;
-    warn(msg: any, progname: any): boolean;
-    error(msg: any, progname: any): boolean;
-    fatal(msg: any, progname: any): boolean;
-    unknown(msg: any, progname: any): boolean;
+    /**
+     * Alias for {@link add} (Ruby Logger API).
+     * @param {number|string} severity
+     * @param {string|{inspect?(): string}|null} [message=null]
+     * @param {string|Function|null} [progname=null]
+     * @returns {boolean}
+     */
+    log(severity: number | string, message?: string | {
+        inspect?(): string;
+    } | null, progname?: string | Function | null): boolean;
+    /**
+     * @param {string|{inspect?(): string}|null} [msg=null]
+     * @param {string|Function|null} [progname=null]
+     * @returns {boolean}
+     */
+    debug(msg?: string | {
+        inspect?(): string;
+    } | null, progname?: string | Function | null): boolean;
+    /**
+     * @param {string|{inspect?(): string}|null} [msg=null]
+     * @param {string|Function|null} [progname=null]
+     * @returns {boolean}
+     */
+    info(msg?: string | {
+        inspect?(): string;
+    } | null, progname?: string | Function | null): boolean;
+    /**
+     * @param {string|{inspect?(): string}|null} [msg=null]
+     * @param {string|Function|null} [progname=null]
+     * @returns {boolean}
+     */
+    warn(msg?: string | {
+        inspect?(): string;
+    } | null, progname?: string | Function | null): boolean;
+    /**
+     * @param {string|{inspect?(): string}|null} [msg=null]
+     * @param {string|Function|null} [progname=null]
+     * @returns {boolean}
+     */
+    error(msg?: string | {
+        inspect?(): string;
+    } | null, progname?: string | Function | null): boolean;
+    /**
+     * @param {string|{inspect?(): string}|null} [msg=null]
+     * @param {string|Function|null} [progname=null]
+     * @returns {boolean}
+     */
+    fatal(msg?: string | {
+        inspect?(): string;
+    } | null, progname?: string | Function | null): boolean;
+    /**
+     * @param {string|{inspect?(): string}|null} [msg=null]
+     * @param {string|Function|null} [progname=null]
+     * @returns {boolean}
+     */
+    unknown(msg?: string | {
+        inspect?(): string;
+    } | null, progname?: string | Function | null): boolean;
 }
 export namespace Logger {
     export { BasicFormatter };
@@ -162,13 +212,63 @@ export class MemoryLogger {
     getMessages(): LogMessage[];
     getMaxSeverity(): number;
     add(severity: any, message?: any, progname?: any): boolean;
-    debug(msg: any, pn: any): boolean;
-    info(msg: any, pn: any): boolean;
-    warn(msg: any, pn: any): boolean;
-    error(msg: any, pn: any): boolean;
-    fatal(msg: any, pn: any): boolean;
-    unknown(msg: any, pn: any): boolean;
-    log(severity: any, message: any, progname: any): boolean;
+    /**
+     * @param {string|{inspect?(): string}|null} [msg=null]
+     * @param {string|Function|null} [pn=null]
+     * @returns {boolean}
+     */
+    debug(msg?: string | {
+        inspect?(): string;
+    } | null, pn?: string | Function | null): boolean;
+    /**
+     * @param {string|{inspect?(): string}|null} [msg=null]
+     * @param {string|Function|null} [pn=null]
+     * @returns {boolean}
+     */
+    info(msg?: string | {
+        inspect?(): string;
+    } | null, pn?: string | Function | null): boolean;
+    /**
+     * @param {string|{inspect?(): string}|null} [msg=null]
+     * @param {string|Function|null} [pn=null]
+     * @returns {boolean}
+     */
+    warn(msg?: string | {
+        inspect?(): string;
+    } | null, pn?: string | Function | null): boolean;
+    /**
+     * @param {string|{inspect?(): string}|null} [msg=null]
+     * @param {string|Function|null} [pn=null]
+     * @returns {boolean}
+     */
+    error(msg?: string | {
+        inspect?(): string;
+    } | null, pn?: string | Function | null): boolean;
+    /**
+     * @param {string|{inspect?(): string}|null} [msg=null]
+     * @param {string|Function|null} [pn=null]
+     * @returns {boolean}
+     */
+    fatal(msg?: string | {
+        inspect?(): string;
+    } | null, pn?: string | Function | null): boolean;
+    /**
+     * @param {string|{inspect?(): string}|null} [msg=null]
+     * @param {string|Function|null} [pn=null]
+     * @returns {boolean}
+     */
+    unknown(msg?: string | {
+        inspect?(): string;
+    } | null, pn?: string | Function | null): boolean;
+    /**
+     * @param {number|string} severity
+     * @param {string|{inspect?(): string}|null} [message=null]
+     * @param {string|Function|null} [progname=null]
+     * @returns {boolean}
+     */
+    log(severity: number | string, message?: string | {
+        inspect?(): string;
+    } | null, progname?: string | Function | null): boolean;
     isDebug(): boolean;
     isInfo(): boolean;
     /**

--- a/packages/core/types/parser.d.ts
+++ b/packages/core/types/parser.d.ts
@@ -105,6 +105,39 @@ export class Parser {
      */
     static parseStyleAttribute(attributes: any, reader?: Reader | null): string | null;
     static _yieldBufferedAttribute(attrs: any, name: any, value: any, reader: any): void;
+    /**
+     * The logger used by the static Parser methods.
+     * The Logging mixin (logging.js) overrides this getter on the class.
+     * @returns {import('./logging.js').LoggerLike}
+     */
+    static get logger(): import("./logging.js").LoggerLike;
+    /** @returns {import('./logging.js').LoggerLike} */
+    static getLogger(): import("./logging.js").LoggerLike;
+    /**
+     * Build an auto-formatting log message that carries structured source_location
+     * (rather than baking it into the text), for use with `Parser.logger.warn(...)`.
+     * @param {string} text
+     * @param {{source_location?: any, include_location?: any}} [context={}]
+     * @returns {{text: string, source_location?: any, include_location?: any, inspect(): string, toString(): string}}
+     */
+    static messageWithContext(text: string, context?: {
+        source_location?: any;
+        include_location?: any;
+    }): {
+        text: string;
+        source_location?: any;
+        include_location?: any;
+        inspect(): string;
+        toString(): string;
+    };
+    /** Alias for {@link messageWithContext} (used in extensions). */
+    static createLogMessage(text: any, context?: {}): {
+        text: string;
+        source_location?: any;
+        include_location?: any;
+        inspect(): string;
+        toString(): string;
+    };
 }
 import { Reader } from './reader.js';
 import { Section } from './section.js';

--- a/packages/core/types/path_resolver.d.ts
+++ b/packages/core/types/path_resolver.d.ts
@@ -95,4 +95,37 @@ export class PathResolver {
      * @returns {string} Path with parent references resolved and self references removed.
      */
     webPath(target: string, start?: string | null): string;
+    /**
+     * The logger for this path resolver.
+     * The Logging mixin (logging.js) overrides this getter on the prototype.
+     * @returns {import('./logging.js').LoggerLike}
+     */
+    get logger(): import("./logging.js").LoggerLike;
+    /** @returns {import('./logging.js').LoggerLike} */
+    getLogger(): import("./logging.js").LoggerLike;
+    /**
+     * Build an auto-formatting log message that carries structured source_location
+     * (rather than baking it into the text), for use with `this.logger.warn(...)`.
+     * @param {string} text
+     * @param {{source_location?: any, include_location?: any}} [context={}]
+     * @returns {{text: string, source_location?: any, include_location?: any, inspect(): string, toString(): string}}
+     */
+    messageWithContext(text: string, context?: {
+        source_location?: any;
+        include_location?: any;
+    }): {
+        text: string;
+        source_location?: any;
+        include_location?: any;
+        inspect(): string;
+        toString(): string;
+    };
+    /** Alias for {@link messageWithContext} (used in extensions). */
+    createLogMessage(text: any, context?: {}): {
+        text: string;
+        source_location?: any;
+        include_location?: any;
+        inspect(): string;
+        toString(): string;
+    };
 }

--- a/packages/core/types/table.d.ts
+++ b/packages/core/types/table.d.ts
@@ -227,5 +227,38 @@ declare class ParserContext {
     _activateRowspan(rowspan: any, colspan: any): void;
     _endOfRow(): 0 | 1 | -1;
     _advance(): void;
+    /**
+     * The logger for this parser context.
+     * The Logging mixin (logging.js) overrides this getter on the prototype.
+     * @returns {import('./logging.js').LoggerLike}
+     */
+    get logger(): import("./logging.js").LoggerLike;
+    /** @returns {import('./logging.js').LoggerLike} */
+    getLogger(): import("./logging.js").LoggerLike;
+    /**
+     * Build an auto-formatting log message that carries structured source_location
+     * (rather than baking it into the text), for use with `this.logger.warn(...)`.
+     * @param {string} text
+     * @param {{source_location?: any, include_location?: any}} [context={}]
+     * @returns {{text: string, source_location?: any, include_location?: any, inspect(): string, toString(): string}}
+     */
+    messageWithContext(text: string, context?: {
+        source_location?: any;
+        include_location?: any;
+    }): {
+        text: string;
+        source_location?: any;
+        include_location?: any;
+        inspect(): string;
+        toString(): string;
+    };
+    /** Alias for {@link messageWithContext} (used in extensions). */
+    createLogMessage(text: any, context?: {}): {
+        text: string;
+        source_location?: any;
+        include_location?: any;
+        inspect(): string;
+        toString(): string;
+    };
 }
 export {};


### PR DESCRIPTION
`Logger#warn()`/`#debug()`/`#info()`/`#error()`/`#fatal()`/`#unknown()`/`#log()` (and the matching `MemoryLogger` methods) declared `progname` as a required parameter in the generated `.d.ts`, so the documented single-argument pattern (`doc.getLogger().warn(doc.messageWithContext(...))`) failed to type-check: `getLogger()` resolves to the `LoggerLike` union, and TypeScript requires a call to satisfy every member's signature.

While adding compile-only type tests for this, `messageWithContext()`/`createLogMessage()` turned out to be missing entirely from the public types of every `applyLogging()` consumer (`Document`, `ConverterBase`, `PathResolver`, `Table.ParserContext`, and the static `Parser` case) — they're installed on the prototype/instance/class *after* the class body closes, which `tsc`'s JSDoc-based declaration emit can't see. Redeclared them explicitly in each class body, mirroring the existing `AbstractNode#getLogger` pattern.

Added `test/types/logging.test-d.ts` covering both fixes plus the `LoggerLike`/`Console` narrowing behavior for `fatal()`/`unknown()`.
