### PR TITLE
fix(core): skip node:async_hooks import outside Node.js

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -9,6 +9,9 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 == Unreleased
 
 == v4.0.8 (2026-08-06)
+Bug Fixes::
+
+* Fix `logging.js` logging a spurious CORS error to the console in some browsers (e.g. Firefox) on first use. The per-execution logger context lazily probes for `node:async_hooks` and falls back to `null` when unavailable, but the dynamic `import('node:async_hooks')` itself was still attempted in the browser, where it is treated as a cross-origin fetch and rejected -- caught safely, but still logged by the browser regardless. The import is now skipped entirely when `process` is undefined (i.e. outside Node.js)
 
 Improvements::
 

--- a/packages/core/src/logging.js
+++ b/packages/core/src/logging.js
@@ -56,13 +56,22 @@ let _loggerStorePromise = null
  */
 async function _ensureLoggerStore() {
   if (_loggerStorePromise === null) {
-    _loggerStorePromise = import('node:async_hooks')
-      .then(({ AsyncLocalStorage }) => {
-        const store = new AsyncLocalStorage()
-        _loggerStore = store
-        return store
-      })
-      .catch(() => null)
+    // Only attempt the import in Node.js. Browsers have no `node:` module
+    // scheme, so a dynamic import of one is treated as a cross-origin fetch
+    // and rejected -- the .catch(() => null) below makes that safe, but some
+    // browsers (e.g. Firefox) additionally log the rejected request to the
+    // console as a CORS error, regardless of it being caught. Skipping the
+    // import entirely in non-Node environments avoids that console noise.
+    _loggerStorePromise =
+      typeof process !== 'undefined'
+        ? import('node:async_hooks')
+            .then(({ AsyncLocalStorage }) => {
+              const store = new AsyncLocalStorage()
+              _loggerStore = store
+              return store
+            })
+            .catch(() => null)
+        : Promise.resolve(null)
   }
   return _loggerStorePromise
 }


### PR DESCRIPTION
Dynamic `import('node:async_hooks')` was still attempted in browsers to lazily initialise the per-execution logger context, even though the result is discarded via `.catch(() => null)`. Browsers treat the `node:` scheme as a cross-origin fetch, and some (e.g. Firefox) log the rejected request to the console as a CORS error regardless of it being caught. The import is now skipped entirely when `process` is undefined (i.e. outside Node.js).
