### PR TITLE
fix(core): expose node-builder helpers on every extension DSL, not just BlockProcessor

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,17 +10,15 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 Bug Fixes::
 
+* Fix the extension DSL `this` types (`BlockProcessorDslInterface`, `BlockMacroProcessorDslInterface`, `InlineMacroProcessorDslInterface`, and the document-processor DSLs for preprocessors, tree processors, postprocessors, include processors, and docinfo processors) missing the node-builder helpers -- `createSection`, `createBlock`, `createList`, `createListItem`, `createImageBlock`, `createInline`, `parseContent`, `parseAttributes`, and the `createBlock`/`createInline` shorthands (`createParagraph`, `createOpenBlock`, `createExampleBlock`, `createPassBlock`, `createListingBlock`, `createLiteralBlock`, `createAnchor`, `createInlinePass`) -- even though all of them are available at runtime on the bound processor instance, since every processor type shares the same `Processor` base class (matching Ruby's `Asciidoctor::Extensions::Processor`)
 * Fix JSDoc `Document` type references across `abstract_node.js`, `extensions.js`, `parser.js`, `syntax_highlighter.js`, and `table.js` (and the corresponding generated `.d.ts` files) resolving to the ambient DOM `Document` type instead of Asciidoctor's own `Document` class from `document.js`. None of those source files imported `Document`, so TypeScript resolved the unqualified name to `lib.dom.d.ts` — `getDocument()`, extension processor callbacks (`Preprocessor#process()`, `TreeProcessor#process()`, etc.), `Parser` methods, `SyntaxHighlighterBase` methods, and `Table.Cell#getInnerDocument()` were all typed against the browser DOM document rather than the Asciidoctor document, silently defeating type checking on any code calling Asciidoctor `Document` methods on the result
+* Fix `logging.js` logging a spurious CORS error to the console in some browsers (e.g. Firefox) on first use. The per-execution logger context lazily probes for `node:async_hooks` and falls back to `null` when unavailable, but the dynamic `import('node:async_hooks')` itself was still attempted in the browser, where it is treated as a cross-origin fetch and rejected -- caught safely, but still logged by the browser regardless. The import is now skipped entirely when `process` is undefined (i.e. outside Node.js)
 
 Infrastructure::
 
 * Add compile-only type tests (`test/types/document_type.test-d.ts`) guarding against the `Document` DOM-leak regression above, covering `AbstractNode#getDocument()`, `Preprocessor`/`TreeProcessor`/`Postprocessor`/`IncludeProcessor`/`DocinfoProcessor`'s `process()`/`handles()`, `Registry#activate()`, and `SyntaxHighlighterBase`'s `docinfo()`/`writeStylesheet()`/`writeStylesheetToDisk()`
 
 == v4.0.8 (2026-08-06)
-
-Bug Fixes::
-
-* Fix `logging.js` logging a spurious CORS error to the console in some browsers (e.g. Firefox) on first use. The per-execution logger context lazily probes for `node:async_hooks` and falls back to `null` when unavailable, but the dynamic `import('node:async_hooks')` itself was still attempted in the browser, where it is treated as a cross-origin fetch and rejected -- caught safely, but still logged by the browser regardless. The import is now skipped entirely when `process` is undefined (i.e. outside Node.js)
 
 Improvements::
 

--- a/packages/core/src/extensions.js
+++ b/packages/core/src/extensions.js
@@ -47,10 +47,33 @@ import { MacroNameRx, CC_ANY } from './rx.js'
  * The `process` property behaves as a setter when called with a single Function
  * argument (stores the process block), or as a passthrough caller otherwise.
  *
+ * Every processor type (Preprocessor, TreeProcessor, Postprocessor, IncludeProcessor,
+ * DocinfoProcessor, BlockProcessor, BlockMacroProcessor, InlineMacroProcessor) extends
+ * the {@link Processor} base class, so the node-builder helpers below (and their
+ * `createBlock`/`createInline` shorthands) are available on `this` inside the
+ * registration function and the bound `process` callback for all of them, not just
+ * block processors.
+ *
  * @typedef {object} ProcessorDslInterface
  * @property {(key: string, value: unknown) => void} option - Set a config option.
  * @property {(fn: (...args: unknown[]) => unknown) => void} process - Register the process function.
  * @property {() => boolean} processBlockGiven - Returns true if a process function has been registered.
+ * @property {(parent: AbstractBlock, title: string, attrs: object, opts?: object) => Section} createSection
+ * @property {(parent: AbstractBlock, context: string, source?: string | string[] | null, attrs?: object, opts?: object) => Block} createBlock
+ * @property {(parent: AbstractBlock, context: string, attrs?: object | null) => List} createList
+ * @property {(parent: List, text?: string | null) => ListItem} createListItem
+ * @property {(parent: AbstractBlock, attrs: object, opts?: object) => Block} createImageBlock
+ * @property {(parent: AbstractBlock, context: string, text: string, opts?: object) => Inline} createInline
+ * @property {(parent: AbstractBlock, content: string[] | Reader, attributes?: object | null) => Promise<AbstractBlock>} parseContent
+ * @property {(block: AbstractBlock, attrlist: string, opts?: object) => Promise<Record<string, unknown>>} parseAttributes
+ * @property {(parent: AbstractBlock, source?: string | string[] | null, attrs?: object, opts?: object) => Block} createParagraph
+ * @property {(parent: AbstractBlock, source?: string | string[] | null, attrs?: object, opts?: object) => Block} createOpenBlock
+ * @property {(parent: AbstractBlock, source?: string | string[] | null, attrs?: object, opts?: object) => Block} createExampleBlock
+ * @property {(parent: AbstractBlock, source?: string | string[] | null, attrs?: object, opts?: object) => Block} createPassBlock
+ * @property {(parent: AbstractBlock, source?: string | string[] | null, attrs?: object, opts?: object) => Block} createListingBlock
+ * @property {(parent: AbstractBlock, source?: string | string[] | null, attrs?: object, opts?: object) => Block} createLiteralBlock
+ * @property {(parent: AbstractBlock, text: string, opts?: object) => Inline} createAnchor
+ * @property {(parent: AbstractBlock, text: string, opts?: object) => Inline} createInlinePass
  */
 
 /**
@@ -123,14 +146,14 @@ import { MacroNameRx, CC_ANY } from './rx.js'
  * DSL interface for block processors.
  *
  * The `process` callback is bound to the processor instance, so `this` inside it
- * (and inside the registration function) exposes the `createBlock` helpers.
+ * (and inside the registration function) exposes the `createBlock` helpers
+ * inherited from {@link ProcessorDslInterface}.
  *
  * @typedef {Omit<SyntaxProcessorDslInterface, 'process'> & {
  *   contexts(...value: (string | string[])[]): void;
  *   onContexts(...value: (string | string[])[]): void;
  *   onContext(...value: (string | string[])[]): void;
  *   bindTo(...value: (string | string[])[]): void;
- *   createBlock(parent: AbstractBlock, context: string, source?: string | string[] | null, attrs?: object, opts?: object): Block;
  *   process(fn: (this: BlockProcessorDslInterface, parent: AbstractBlock, reader: Reader, attributes: Record<string, unknown>) => AbstractBlock | void): void;
  * }} BlockProcessorDslInterface
  */
@@ -145,10 +168,10 @@ import { MacroNameRx, CC_ANY } from './rx.js'
  * DSL interface for block macro processors.
  *
  * The `process` callback is bound to the processor instance, so `this` inside it
- * (and inside the registration function) exposes the `createBlock` helpers.
+ * (and inside the registration function) exposes the `createBlock` helpers
+ * inherited from {@link ProcessorDslInterface}.
  *
  * @typedef {Omit<MacroProcessorDslInterface, 'process'> & {
- *   createBlock(parent: AbstractBlock, context: string, source?: string | string[] | null, attrs?: object, opts?: object): Block;
  *   process(fn: (this: BlockMacroProcessorDslInterface, parent: AbstractBlock, target: string, attributes: Record<string, unknown>) => AbstractBlock | void): void;
  * }} BlockMacroProcessorDslInterface
  */
@@ -157,14 +180,14 @@ import { MacroNameRx, CC_ANY } from './rx.js'
  * DSL interface for inline macro processors.
  *
  * The `process` callback is bound to the processor instance, so `this` inside it
- * (and inside the registration function) exposes the `createInline` helper.
+ * (and inside the registration function) exposes the `createInline` helper
+ * inherited from {@link ProcessorDslInterface}.
  *
  * @typedef {Omit<MacroProcessorDslInterface, 'process'> & {
  *   format(value: string): void;
  *   matchFormat(value: string): void;
  *   usingFormat(value: string): void;
  *   match(value: RegExp): void;
- *   createInline(parent: AbstractBlock, context: string, text: string, opts?: object): Inline;
  *   process(fn: (this: InlineMacroProcessorDslInterface, parent: AbstractBlock, target: string, attributes: Record<string, unknown>) => Inline | void): void;
  * }} InlineMacroProcessorDslInterface
  */

--- a/packages/core/test/types/extensions.test-d.ts
+++ b/packages/core/test/types/extensions.test-d.ts
@@ -76,9 +76,14 @@ registry.preprocessor(function () {
 })
 
 // ── treeProcessor(fn): (document) → Document | void ───────────────────────────
+// The node-builder helpers (createBlock, createSection, createParagraph, …) live
+// on the shared Processor base class in Ruby, so every processor DSL exposes them
+// on `this` -- not just BlockProcessor. Confirm a tree processor can build nodes too.
 registry.treeProcessor(function () {
   this.process((document) => {
     void document.getBlocks()
+    this.createParagraph(document, 'injected by tree processor')
+    this.createSection(document, 'Appendix', {})
   })
 })
 

--- a/packages/core/types/extensions.d.ts
+++ b/packages/core/types/extensions.d.ts
@@ -1684,6 +1684,13 @@ export type PreprocessorReader = import("./reader.js").PreprocessorReader;
  *
  * The `process` property behaves as a setter when called with a single Function
  * argument (stores the process block), or as a passthrough caller otherwise.
+ *
+ * Every processor type (Preprocessor, TreeProcessor, Postprocessor, IncludeProcessor,
+ * DocinfoProcessor, BlockProcessor, BlockMacroProcessor, InlineMacroProcessor) extends
+ * the {@link Processor} base class, so the node-builder helpers below (and their
+ * `createBlock`/`createInline` shorthands) are available on `this` inside the
+ * registration function and the bound `process` callback for all of them, not just
+ * block processors.
  */
 export type ProcessorDslInterface = {
     /**
@@ -1698,6 +1705,22 @@ export type ProcessorDslInterface = {
      * - Returns true if a process function has been registered.
      */
     processBlockGiven: () => boolean;
+    createSection: (parent: AbstractBlock, title: string, attrs: object, opts?: object) => Section;
+    createBlock: (parent: AbstractBlock, context: string, source?: string | string[] | null, attrs?: object, opts?: object) => Block;
+    createList: (parent: AbstractBlock, context: string, attrs?: object | null) => List;
+    createListItem: (parent: List, text?: string | null) => ListItem;
+    createImageBlock: (parent: AbstractBlock, attrs: object, opts?: object) => Block;
+    createInline: (parent: AbstractBlock, context: string, text: string, opts?: object) => Inline;
+    parseContent: (parent: AbstractBlock, content: string[] | Reader, attributes?: object | null) => Promise<AbstractBlock>;
+    parseAttributes: (block: AbstractBlock, attrlist: string, opts?: object) => Promise<Record<string, unknown>>;
+    createParagraph: (parent: AbstractBlock, source?: string | string[] | null, attrs?: object, opts?: object) => Block;
+    createOpenBlock: (parent: AbstractBlock, source?: string | string[] | null, attrs?: object, opts?: object) => Block;
+    createExampleBlock: (parent: AbstractBlock, source?: string | string[] | null, attrs?: object, opts?: object) => Block;
+    createPassBlock: (parent: AbstractBlock, source?: string | string[] | null, attrs?: object, opts?: object) => Block;
+    createListingBlock: (parent: AbstractBlock, source?: string | string[] | null, attrs?: object, opts?: object) => Block;
+    createLiteralBlock: (parent: AbstractBlock, source?: string | string[] | null, attrs?: object, opts?: object) => Block;
+    createAnchor: (parent: AbstractBlock, text: string, opts?: object) => Inline;
+    createInlinePass: (parent: AbstractBlock, text: string, opts?: object) => Inline;
 };
 /**
  * DSL interface for document processors (Preprocessor, TreeProcessor, Postprocessor, DocinfoProcessor).
@@ -1758,14 +1781,14 @@ export type DocinfoProcessorDslInterface = Omit<DocumentProcessorDslInterface, "
  * DSL interface for block processors.
  *
  * The `process` callback is bound to the processor instance, so `this` inside it
- * (and inside the registration function) exposes the `createBlock` helpers.
+ * (and inside the registration function) exposes the `createBlock` helpers
+ * inherited from {@link ProcessorDslInterface}.
  */
 export type BlockProcessorDslInterface = Omit<SyntaxProcessorDslInterface, "process"> & {
     contexts(...value: (string | string[])[]): void;
     onContexts(...value: (string | string[])[]): void;
     onContext(...value: (string | string[])[]): void;
     bindTo(...value: (string | string[])[]): void;
-    createBlock(parent: AbstractBlock, context: string, source?: string | string[] | null, attrs?: object, opts?: object): Block;
     process(fn: (this: BlockProcessorDslInterface, parent: AbstractBlock, reader: Reader, attributes: Record<string, unknown>) => AbstractBlock | void): void;
 };
 /**
@@ -1776,24 +1799,24 @@ export type MacroProcessorDslInterface = SyntaxProcessorDslInterface;
  * DSL interface for block macro processors.
  *
  * The `process` callback is bound to the processor instance, so `this` inside it
- * (and inside the registration function) exposes the `createBlock` helpers.
+ * (and inside the registration function) exposes the `createBlock` helpers
+ * inherited from {@link ProcessorDslInterface}.
  */
 export type BlockMacroProcessorDslInterface = Omit<MacroProcessorDslInterface, "process"> & {
-    createBlock(parent: AbstractBlock, context: string, source?: string | string[] | null, attrs?: object, opts?: object): Block;
     process(fn: (this: BlockMacroProcessorDslInterface, parent: AbstractBlock, target: string, attributes: Record<string, unknown>) => AbstractBlock | void): void;
 };
 /**
  * DSL interface for inline macro processors.
  *
  * The `process` callback is bound to the processor instance, so `this` inside it
- * (and inside the registration function) exposes the `createInline` helper.
+ * (and inside the registration function) exposes the `createInline` helper
+ * inherited from {@link ProcessorDslInterface}.
  */
 export type InlineMacroProcessorDslInterface = Omit<MacroProcessorDslInterface, "process"> & {
     format(value: string): void;
     matchFormat(value: string): void;
     usingFormat(value: string): void;
     match(value: RegExp): void;
-    createInline(parent: AbstractBlock, context: string, text: string, opts?: object): Inline;
     process(fn: (this: InlineMacroProcessorDslInterface, parent: AbstractBlock, target: string, attributes: Record<string, unknown>) => Inline | void): void;
 };
 import { Section } from './section.js';


### PR DESCRIPTION
Ruby's `Asciidoctor::Extensions::Processor` base class defines `create_block`, `create_image_block`, `create_inline`, `create_section`, `create_list`, `create_list_item`, `parse_content`, `parse_attributes`, and their shorthand aliases (`create_paragraph`, `create_open_block`, etc.), inherited by every processor subtype -- not just `BlockProcessor`. The JS runtime already mirrors this via the shared `Processor` base class, but the extension DSL `this` types only declared these helpers on `BlockProcessorDslInterface` (plus a lone `createBlock`/`createInline` on the block-macro/inline-macro interfaces).

This moves the node-builder helpers onto the shared `ProcessorDslInterface` base typedef so they propagate to every DSL interface -- preprocessor, tree processor, postprocessor, include processor, docinfo processor, block processor, block macro, and inline macro -- matching both the Ruby class hierarchy and the actual JS runtime behavior. Regenerated `types/extensions.d.ts` accordingly and added a compile-only type test proving a tree-processor callback can call `this.createParagraph`/`this.createSection`.
