### PR TITLE
fix(core): pass:[] inline macro escapes content instead of passing it through

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,10 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 == Unreleased
 
+Bug Fixes::
+
+* Fix the inline `pass:[...]` macro escaping its content instead of passing it through unmodified when no explicit substitution list is given, e.g. `pass:[<u>underlined</u>]` rendered as `&lt;u&gt;underlined&lt;/u&gt;` instead of `<u>underlined</u>`. The passthrough's `subs` was left `undefined`, which fell through to `applySubs()`'s `NORMAL_SUBS` default parameter instead of the intended "no substitutions" behavior (https://github.com/asciidoctor/asciidoctor.js/issues/1870[#1870])
+
 == v4.0.9 (2026-08-16)
 
 Bug Fixes::

--- a/packages/core/src/substitutors.js
+++ b/packages/core/src/substitutors.js
@@ -1645,6 +1645,7 @@ export const Substitutors = {
             } else {
               passthrus[(passthruKey = passthrus.length)] = {
                 text: this.normalizeText(p8, null, true),
+                subs: [],
               }
             }
             return `${PASS_START}${passthruKey}${PASS_END}`

--- a/packages/core/test/substitutions.passthroughs.test.js
+++ b/packages/core/test/substitutions.passthroughs.test.js
@@ -194,6 +194,33 @@ describe('Substitutions', () => {
       assert.equal(await para.restorePassthroughs(result), '')
     })
 
+    // https://github.com/asciidoctor/asciidoctor.js/issues/1870
+    test('should not apply any subs to content of inline pass macro without explicit subs', async () => {
+      const para = await blockFromString('pass:[<u>underlined</u>]')
+      const result = para.extractPassthroughs(para.source)
+      const passthroughs = para.passthroughs
+      assert.equal(passthroughs.length, 1)
+      assert.deepEqual(passthroughs[0].subs, [])
+      assert.equal(await para.restorePassthroughs(result), '<u>underlined</u>')
+    })
+
+    test('should not escape content of inline pass macro without explicit subs when converting to HTML', async () => {
+      const result = await convertInlineString('pass:[<u>underlined</u>]')
+      assert.equal(result, '<u>underlined</u>')
+    })
+
+    test('should apply specialcharacters subs to content of inline pass macro using c shorthand', async () => {
+      const para = await blockFromString('pass:c[<u>underlined</u>]')
+      const result = para.extractPassthroughs(para.source)
+      const passthroughs = para.passthroughs
+      assert.equal(passthroughs.length, 1)
+      assert.deepEqual(passthroughs[0].subs, ['specialcharacters'])
+      assert.equal(
+        await para.restorePassthroughs(result),
+        '&lt;u&gt;underlined&lt;/u&gt;'
+      )
+    })
+
     // NOTE placeholder is surrounded by text to prevent reader from stripping trailing boundary char (unique to test scenario)
     test('restore inline passthroughs without subs', async () => {
       const para = await blockFromString(


### PR DESCRIPTION
In 4.0.9 the inline `pass:[...]` macro escaped its content instead of passing it through unmodified, e.g. `pass:[<u>underlined</u>]` rendered `&lt;u&gt;underlined&lt;/u&gt;` instead of `<u>underlined</u>`. This was a regression against 3.0.4 and against Ruby Asciidoctor.

The bug was introduced during the Ruby-to-JavaScript port: when the macro has no explicit substitution list, the collected passthrough's `subs` was left `undefined` instead of an empty array. `applySubs(text, subs = NORMAL_SUBS)` then fell through to its `NORMAL_SUBS` default parameter (since `undefined` triggers JS default params), applying `specialcharacters` and other substitutions the macro is meant to skip.

Fixed by explicitly setting `subs: []` for the no-explicit-subs case, matching the behavior of the `+++`/`$$` passthrough delimiters, which already did this correctly.

Fixes #1870
