### PR TITLE
fix(core): footnote inside list item or table cell not advancing counter

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,7 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 Bug Fixes::
 
 * Fix the inline `pass:[...]` macro escaping its content instead of passing it through unmodified when no explicit substitution list is given, e.g. `pass:[<u>underlined</u>]` rendered as `&lt;u&gt;underlined&lt;/u&gt;` instead of `<u>underlined</u>`. The passthrough's `subs` was left `undefined`, which fell through to `applySubs()`'s `NORMAL_SUBS` default parameter instead of the intended "no substitutions" behavior (https://github.com/asciidoctor/asciidoctor.js/issues/1870[#1870])
+* Fix a footnote inside a list item or table cell not advancing the footnote counter, causing a subsequent footnote elsewhere in the document to reuse the same number and `id` (invalid HTML, and the later footnote reference would link to the earlier definition). List item and table cell text is substituted eagerly, ahead of normal body conversion, and the footnote counter was unconditionally reset afterwards; it now carries forward into conversion so later footnotes continue numbering from where these left off (https://github.com/asciidoctor/asciidoctor.js/issues/1871[#1871])
 
 == v4.0.9 (2026-08-16)
 

--- a/packages/core/src/document.js
+++ b/packages/core/src/document.js
@@ -614,12 +614,25 @@ export class Document extends AbstractBlock {
     // Pass 2: list item / table cell / dlist text, now that natural cross-references
     // can be resolved against the reftext→id map.
     await this._resolveAllTexts(this, true)
+    // List item / table cell / dlist footnotes registered just now are rendered inline
+    // during real body conversion (via their cached precomputed text), so — unlike title
+    // footnotes, which render out-of-band before conversion and are reset below to
+    // reproduce Ruby's "out of sequence" quirk — their counter progress must carry over
+    // into conversion so a footnote later in the body doesn't reuse an index already
+    // assigned to one of them.
+    const footnoteNumberAfterPass2 = this.attributes['footnote-number']
     this._restoreAttributeSnapshot(attributesSnapshot)
-    // Reset the footnote counter so that body-content footnotes (processed during conversion)
-    // start numbering from 1, reproducing Ruby's "out of sequence" quirk: title footnotes are
-    // numbered during parsing via apply_title_subs, then the counter restarts for body content.
-    delete this.attributes['footnote-number']
-    delete this._counters['footnote-number']
+    if (footnoteNumberAfterPass2 != null) {
+      this.attributes['footnote-number'] = footnoteNumberAfterPass2
+      this._counters['footnote-number'] = footnoteNumberAfterPass2
+    } else {
+      // Reset the footnote counter so that body-content footnotes (processed during
+      // conversion) start numbering from 1, reproducing Ruby's "out of sequence" quirk:
+      // title footnotes are numbered during parsing via apply_title_subs, then the
+      // counter restarts for body content.
+      delete this.attributes['footnote-number']
+      delete this._counters['footnote-number']
+    }
 
     this._parsed = true
     return this

--- a/packages/core/test/substitutions.macros.test.js
+++ b/packages/core/test/substitutions.macros.test.js
@@ -1205,6 +1205,52 @@ describe('Substitutions', () => {
       )
     })
 
+    // https://github.com/asciidoctor/asciidoctor.js/issues/1871
+    test('should not reuse a footnote index or id for a footnote following one inside a list item', async () => {
+      const input = [
+        '* item.footnote:[note text]',
+        '',
+        'paragraph.footnote:[second note]',
+      ].join('\n')
+      const { parse } = await import('node-html-parser')
+      const result = await convertStringToEmbedded(input)
+      const root = parse(`<body>${result}</body>`)
+      const footnoteRefs = root.querySelectorAll('a.footnote')
+      const footnoteDefs = root.querySelectorAll('div.footnote')
+      assert.deepEqual(
+        footnoteRefs.map((el) => el.text),
+        ['1', '2']
+      )
+      assert.deepEqual(
+        footnoteDefs.map((el) => el.id),
+        ['_footnotedef_1', '_footnotedef_2']
+      )
+    })
+
+    // https://github.com/asciidoctor/asciidoctor.js/issues/1871
+    test('should not reuse a footnote index or id for a footnote following one inside a table cell', async () => {
+      const input = [
+        '|===',
+        '|cell.footnote:[table note]',
+        '|===',
+        '',
+        'paragraph.footnote:[second note]',
+      ].join('\n')
+      const { parse } = await import('node-html-parser')
+      const result = await convertStringToEmbedded(input)
+      const root = parse(`<body>${result}</body>`)
+      const footnoteRefs = root.querySelectorAll('a.footnote')
+      const footnoteDefs = root.querySelectorAll('div.footnote')
+      assert.deepEqual(
+        footnoteRefs.map((el) => el.text),
+        ['1', '2']
+      )
+      assert.deepEqual(
+        footnoteDefs.map((el) => el.id),
+        ['_footnotedef_1', '_footnotedef_2']
+      )
+    })
+
     test('a single-line index term macro with a primary term should be registered as an index reference', async () => {
       const sentence =
         'The tiger (Panthera tigris) is the largest cat species.\n'


### PR DESCRIPTION
In 4.0.9 a footnote placed inside a list item or table cell did not advance the footnote counter for the rest of the document: the next footnote reused number 1, and both footnote definitions got the same `id`, making the second reference link to the first definition instead of its own. This was a regression against 3.0.4 and against Ruby Asciidoctor.

**Root cause**: list item and table cell text is substituted eagerly, during `Document#parse()`, ahead of normal body conversion. This is needed so their synchronous getters work correctly at conversion time. A footnote macro inside gets registered and numbered during that eager pass, but the `footnote-number` counter was then unconditionally reset afterwards (originally to reproduce Ruby's "title footnotes are numbered out of sequence" quirk). That reset also wiped out numbering progress made by list items/table cells, so the next footnote encountered during real body conversion restarted from 1, colliding with the one already assigned.

**Fix**: the counter now carries forward into conversion specifically when list items/table cells registered footnotes during the eager pass, while still resetting to reproduce the title-footnote quirk when they didn't (since title text has no counter progress worth preserving).

Fixes #1871
