### PR TITLE
feat(cli): allow overriding the program name shown in --help

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,10 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 == Unreleased
 
+Improvements::
+
+* Add `Options#getProgramName()`, `#getUsageLine()`, and `#getHelpDescription()` to the extensible CLI (`@asciidoctor/core`'s `cli.js`), letting an extended CLI override just the program name shown by `--help` -- or the usage line/description individually -- the same way `Invoker#version()` can already be overridden; `#getHelpPreamble()` remains available to override the whole preamble as a last resort
+
 Bug Fixes::
 
 * Fix a footnote inside a list item or table cell being numbered (and listed in the footnotes block) ahead of an earlier footnote in a preceding paragraph, instead of in document order. List item and table cell text is substituted eagerly, ahead of normal body conversion, so any footnote there previously consumed the next footnote number immediately regardless of its actual position in the document; it's now assigned a placeholder that resolves to the real, document-order number once real conversion reaches that block. Reading a list item's or table cell's `text`/`getText()` before conversion (e.g. from an extension) no longer fixes the wrong number either -- an unresolved footnote there now previews as `1` rather than consuming the real counter (https://github.com/asciidoctor/asciidoctor.js/issues/1871[#1871])

--- a/packages/asciidoctor/lib/cli.js
+++ b/packages/asciidoctor/lib/cli.js
@@ -25,11 +25,10 @@ const FAILURE_LEVELS = {
 
 const DOT_RELATIVE_RX = new RegExp(`^\\.{1,2}[/${sep.replace('\\', '\\\\')}]`)
 
-const HELP_PREAMBLE = `asciidoctor [options...] files...
-Translate the AsciiDoc source file or file(s) into the backend output format (e.g., HTML 5, DocBook 5, etc.)
-By default, the output is written to a file with the basename of the source file and the appropriate extension
+const DEFAULT_PROGRAM_NAME = 'asciidoctor'
 
-Options:`
+const HELP_DESCRIPTION = `Translate the AsciiDoc source file or file(s) into the backend output format (e.g., HTML 5, DocBook 5, etc.)
+By default, the output is written to a file with the basename of the source file and the appropriate extension`
 
 const HELP_COLUMN = 36
 
@@ -318,11 +317,52 @@ export class Options {
    * @returns {string}
    */
   buildHelpText() {
-    const lines = [HELP_PREAMBLE]
+    const lines = [this.getHelpPreamble()]
     for (const [key, def] of Object.entries(this._definitions)) {
       lines.push(buildHelpLine(key, def))
     }
     return lines.join('\n')
+  }
+
+  /**
+   * Return the program name shown in the `--help` usage line.
+   * Override this for the common case of wrapping this CLI under a different command name.
+   *
+   * @returns {string}
+   */
+  getProgramName() {
+    return DEFAULT_PROGRAM_NAME
+  }
+
+  /**
+   * Return the usage line printed at the top of `--help` (e.g., `asciidoctor [options...] files...`).
+   * Override to change the argument summary; override {@link Options#getProgramName} to only change the name.
+   *
+   * @returns {string}
+   */
+  getUsageLine() {
+    return `${this.getProgramName()} [options...] files...`
+  }
+
+  /**
+   * Return the description printed below the usage line in `--help`.
+   *
+   * @returns {string}
+   */
+  getHelpDescription() {
+    return HELP_DESCRIPTION
+  }
+
+  /**
+   * Return the usage line, description, and "Options:" header printed above the options list in `--help`.
+   * Assembled from {@link Options#getUsageLine} and {@link Options#getHelpDescription}; override those
+   * instead where possible. Override this method directly only as a last resort, e.g. to drop the
+   * "Options:" header or restructure the preamble entirely.
+   *
+   * @returns {string}
+   */
+  getHelpPreamble() {
+    return `${this.getUsageLine()}\n${this.getHelpDescription()}\n\nOptions:`
   }
 }
 

--- a/packages/asciidoctor/test/cli.test.js
+++ b/packages/asciidoctor/test/cli.test.js
@@ -202,6 +202,46 @@ describe('CLI extensibility', () => {
       assert.match(help, /-w, --watch/)
       assert.match(help, /watch for changes/)
     })
+
+    test('getProgramName() can be overridden to change the usage line', () => {
+      class MyOptions extends Options {
+        getProgramName() {
+          return 'my-tool'
+        }
+      }
+      const help = new MyOptions().buildHelpText()
+      assert.match(help, /^my-tool \[options\.\.\.\] files\.\.\./)
+    })
+
+    test('getUsageLine() can be overridden to change the argument summary', () => {
+      class MyOptions extends Options {
+        getUsageLine() {
+          return `${this.getProgramName()} [options...] <input>`
+        }
+      }
+      const help = new MyOptions().buildHelpText()
+      assert.match(help, /^asciidoctor \[options\.\.\.\] <input>/)
+    })
+
+    test('getHelpDescription() can be overridden', () => {
+      class MyOptions extends Options {
+        getHelpDescription() {
+          return 'Convert AsciiDoc to my format.'
+        }
+      }
+      const help = new MyOptions().buildHelpText()
+      assert.match(help, /Convert AsciiDoc to my format\./)
+    })
+
+    test('getHelpPreamble() can be overridden as a last resort', () => {
+      class MyOptions extends Options {
+        getHelpPreamble() {
+          return 'Usage: my-tool <args>'
+        }
+      }
+      const help = new MyOptions().buildHelpText()
+      assert.match(help, /^Usage: my-tool <args>/)
+    })
   })
 
   describe('Invoker', () => {
@@ -228,6 +268,12 @@ describe('CLI extensibility', () => {
       assert.match(result.stderr, /a custom flag/)
       assert.match(result.stderr, /--theme/)
       assert.match(result.stderr, /PDF theme name/)
+    })
+
+    test('subclass --help uses overridden getProgramName()', () => {
+      const result = extendedCli(['--help'])
+      assert.equal(result.status, 0)
+      assert.match(result.stderr, /^extended-cli \[options\.\.\.\] files\.\.\./)
     })
 
     test('subclass convertFiles() receives custom option values', () => {

--- a/packages/asciidoctor/test/fixtures/extended-cli.js
+++ b/packages/asciidoctor/test/fixtures/extended-cli.js
@@ -7,6 +7,10 @@ class ExtendedOptions extends Options {
     this.addOption('custom-flag', { type: 'boolean', short: 'F', describe: 'a custom flag' })
     this.addOption('theme', { type: 'string', describe: 'PDF theme name', metavar: '<theme>' })
   }
+
+  getProgramName() {
+    return 'extended-cli'
+  }
 }
 
 class ExtendedInvoker extends Invoker {

--- a/packages/asciidoctor/types/cli.d.ts
+++ b/packages/asciidoctor/types/cli.d.ts
@@ -126,6 +126,12 @@ export class Options {
             describe: string;
             metavar: string;
         };
+        extension: {
+            type: string;
+            multiple: boolean;
+            describe: string;
+            metavar: string;
+        };
         version: {
             type: string;
             short: string;
@@ -186,6 +192,35 @@ export class Options {
      * @returns {string}
      */
     buildHelpText(): string;
+    /**
+     * Return the program name shown in the `--help` usage line.
+     * Override this for the common case of wrapping this CLI under a different command name.
+     *
+     * @returns {string}
+     */
+    getProgramName(): string;
+    /**
+     * Return the usage line printed at the top of `--help` (e.g., `asciidoctor [options...] files...`).
+     * Override to change the argument summary; override {@link Options#getProgramName} to only change the name.
+     *
+     * @returns {string}
+     */
+    getUsageLine(): string;
+    /**
+     * Return the description printed below the usage line in `--help`.
+     *
+     * @returns {string}
+     */
+    getHelpDescription(): string;
+    /**
+     * Return the usage line, description, and "Options:" header printed above the options list in `--help`.
+     * Assembled from {@link Options#getUsageLine} and {@link Options#getHelpDescription}; override those
+     * instead where possible. Override this method directly only as a last resort, e.g. to drop the
+     * "Options:" header or restructure the preamble entirely.
+     *
+     * @returns {string}
+     */
+    getHelpPreamble(): string;
 }
 /**
  * Executes the CLI after options have been parsed.
@@ -232,6 +267,8 @@ export class Invoker {
     convertFiles(files: string[], options: any, values: Record<string, unknown>): Promise<void>;
     /** @internal */
     _prepareProcessor(values: any): void;
+    /** @internal */
+    _prepareExtensions(values: any): void;
     /** @internal */
     _convertFromStdin(options: any): Promise<void>;
     /** @internal */


### PR DESCRIPTION
Options#getProgramName(), #getUsageLine(), and #getHelpDescription() let an extended CLI customize the --help preamble piecemeal (most commonly just the program name), the same way Invoker#version() can already be overridden. #getHelpPreamble() remains available to override the whole preamble as a last resort.