### PR TITLE
fix(core): report the document path in asset-not-found warnings

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,6 +8,10 @@ For a detailed view of what has changed, refer to the {uri-repo}/commits/main[co
 
 == Unreleased
 
+Bug Fixes::
+
+* Fix the warning issued when an asset cannot be found or read (e.g. `image::does-not-exist.svg[opts=inline]`) always reporting the document as `<stdin>`. The `docfile` attribute was looked up on the node instead of on the document, and since `docfile` is only ever set as a document attribute the lookup never resolved (https://github.com/asciidoctor/asciidoctor/issues/4873[asciidoctor#4873])
+
 == v4.0.11 (2026-08-18)
 
 Improvements::

--- a/packages/core/src/abstract_node.js
+++ b/packages/core/src/abstract_node.js
@@ -684,7 +684,7 @@ export class AbstractNode {
       if (text != null)
         return opts.normalize ? prepareSourceString(text).join(LF) : text
       if (opts.warnOnFailure) {
-        const docfile = this.getAttribute('docfile') || '<stdin>'
+        const docfile = this.document.getAttribute('docfile') || '<stdin>'
         const label = opts.label || 'file'
         this.logger.warn(
           `${docfile}: ${label} does not exist or cannot be read: ${path}`
@@ -699,7 +699,7 @@ export class AbstractNode {
       return _fsp.readFile(path, 'utf8')
     }
     if (opts.warnOnFailure) {
-      const docfile = this.getAttribute('docfile') || '<stdin>'
+      const docfile = this.document.getAttribute('docfile') || '<stdin>'
       const label = opts.label || 'file'
       this.logger.warn(
         `${docfile}: ${label} does not exist or cannot be read: ${path}`

--- a/packages/core/test/blocks.images.test.js
+++ b/packages/core/test/blocks.images.test.js
@@ -233,9 +233,32 @@ image::circle.svg[Tiger,100]
 [%inline]
 image::no-such-image.svg[Alt Text]
 `
+        const output = await convertStringToEmbedded(input, {
+          safe: 'safe',
+          attributes: { docfile: 'document.adoc' },
+        })
+        assertXpath(output, '//span[@class="alt"][text()="Alt Text"]', 1)
+        assertMessage(
+          logger,
+          'warn',
+          'document.adoc: SVG does not exist or cannot be read'
+        )
+      })
+    })
+
+    test('uses <stdin> in warning if SVG cannot be read and document has no docfile', async () => {
+      await usingMemoryLogger(async (logger) => {
+        const input = `\
+[%inline]
+image::no-such-image.svg[Alt Text]
+`
         const output = await convertStringToEmbedded(input, { safe: 'server' })
         assertXpath(output, '//span[@class="alt"][text()="Alt Text"]', 1)
-        assertMessage(logger, 'warn', 'SVG does not exist or cannot be read')
+        assertMessage(
+          logger,
+          'warn',
+          '<stdin>: SVG does not exist or cannot be read'
+        )
       })
     })
 


### PR DESCRIPTION
Port of asciidoctor/asciidoctor#4874, which fixes asciidoctor/asciidoctor#4873. The bug is present in this implementation too.

The warning issued when an asset cannot be found or read always reported the document as `<stdin>`:

```adoc
image::does-not-exist.svg[opts=inline]
```

```
<stdin>: SVG does not exist or cannot be read: /path/to/does-not-exist.svg
```

instead of:

```
doc.adoc: SVG does not exist or cannot be read: /path/to/does-not-exist.svg
```

In `readAsset()`, the `docfile` attribute was looked up on the node (`this.getAttribute('docfile')`) rather than on the document. As in Ruby, `getAttribute()` without a `fallbackName` only consults the node's own attributes, and `docfile` is only ever set as a document attribute — so the lookup never resolved and the message fell back to `<stdin>`.